### PR TITLE
Basic support for RequireJS less! plugin

### DIFF
--- a/lib/relations/JavaScriptAmdRequire.js
+++ b/lib/relations/JavaScriptAmdRequire.js
@@ -33,7 +33,7 @@ extendWithGettersAndSetters(JavaScriptAmdRequire.prototype, {
         if (/^kotpl!/.test(this.node[1])) {
             // A custom plugin for KnockoutJS templates
             href += '.ko';
-        } else if (!/^text!/.test(this.node[1]) && !/\.(?:js|json|css)$/.test(href)) { // Hmm, this cannot be the correct criterion
+        } else if (!/^text!/.test(this.node[1]) && !/\.(?:js|json|css|less)$/.test(href)) { // Hmm, this cannot be the correct criterion
             href += ".js";
         }
         return href;


### PR DESCRIPTION
Exclude .less files from being considered JavaScript files when used through the less!file.less RequireJS plugin.
