### PR TITLE
Support for IE8+ inline css images

### DIFF
--- a/lib/transforms/inlineCssImagesWithLegacyFallback.js
+++ b/lib/transforms/inlineCssImagesWithLegacyFallback.js
@@ -14,6 +14,7 @@ module.exports = function (queryObj, sizeThreshold) {
             assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset}).forEach(function (htmlStyle) {
                 var cssAsset = htmlStyle.to,
                     cssImages = assetGraph.findRelations({type: 'CssImage', from: cssAsset, to: {isImage: true, isInline: false}}),
+                    ieVersion = 8,
                     hasCssImagesToInline = false;
                 cssImages.forEach(function (cssImage) {
                     if (cssImage.cssRule.style.getPropertyValue('-one-image-inline') ||
@@ -23,6 +24,9 @@ module.exports = function (queryObj, sizeThreshold) {
                          assetGraph.findRelations({from: cssAsset, to: cssImage.to}).length === 1)) {
 
                         hasCssImagesToInline = true;
+                        if (cssImage.to.rawSrc.length > 32 * 1024) {
+                            ieVersion = 9; // IE 8 doesn't support data-uri's over 32kb
+                        }
                     }
                 });
                 if (hasCssImagesToInline > 0) {
@@ -35,7 +39,7 @@ module.exports = function (queryObj, sizeThreshold) {
 
                     new relations.HtmlConditionalComment({
                         to: internetExplorerConditionalCommentBody,
-                        condition: 'IE'
+                        condition: 'lt IE ' + ieVersion
                     }).attach(htmlAsset, 'before', htmlStyle);
 
                     var htmlStyleInInternetExplorerConditionalComment = new relations.HtmlStyle({to: cssAsset});
@@ -43,7 +47,7 @@ module.exports = function (queryObj, sizeThreshold) {
 
                     new relations.HtmlConditionalComment({
                         to: nonInternetExplorerConditionalCommentBody,
-                        condition: '!IE'
+                        condition: 'gte IE ' + ieVersion
                     }).attach(htmlAsset, 'before', htmlStyle);
 
                     var htmlStyleInNonInternetExplorerConditionalComment = new relations.HtmlStyle({to: cssAsset});

--- a/test/inlineCssImagesWithLegacyFallback-test.js
+++ b/test/inlineCssImagesWithLegacyFallback-test.js
@@ -36,22 +36,29 @@ vows.describe('transforms.inlineCssImagesWithLegacyFallback').addBatch({
                 assert.isNotNull(captures);
                 assert.equal(captures.length, 6);
             },
-            'the Html asset should contain 5 non-IE conditional comment markers': function (assetGraph) {
+            'the Html asset should contain 3 non-IE conditional comment markers': function (assetGraph) {
                 var captures = assetGraph.findAssets({type: 'Html'})[0].text.match(/<!--\[if !IE\]>-->/g);
                 assert.isNotNull(captures);
-                assert.equal(captures.length, 5);
+                assert.equal(captures.length, 3);
             },
             'the media=handheld attribute should occur twice now that smallImages.css has been rolled out in two versions': function (assetGraph) {
                 var captures = assetGraph.findAssets({type: 'Html'})[0].text.match(/media=['"]handheld/g);
                 assert.isNotNull(captures);
                 assert.equal(captures.length, 2);
             },
-            'the Html asset should contain 2 IE conditional comment markers with link tags in them': function (assetGraph) {
+            'the Html asset should contain 1 IE 8 conditional comment marker with a link tag in it': function (assetGraph) {
                 var text = assetGraph.findAssets({type: 'Html'})[0].text;
-                assert.matches(text, /<!--\[if IE\]><link[^>]*><!\[\endif]-->/);
-                var captures = text.match(/<!--\[if IE\]><link[^>]*><!\[\endif]-->/g);
+                assert.matches(text, /<!--\[if gte IE 8\]><link[^>]*><!\[\endif]-->/);
+                var captures = text.match(/<!--\[if lt IE 8\]><link[^>]*><!\[\endif]-->/g);
                 assert.isNotNull(captures);
-                assert.equal(captures.length, 2);
+                assert.equal(captures.length, 1);
+            },
+            'the Html asset should contain 1 IE 9 conditional comment marker with a link tag in it': function (assetGraph) {
+                var text = assetGraph.findAssets({type: 'Html'})[0].text;
+                assert.matches(text, /<!--\[if gte IE 9\]><link[^>]*><!\[\endif]-->/);
+                var captures = text.match(/<!--\[if lt IE 9\]><link[^>]*><!\[\endif]-->/g);
+                assert.isNotNull(captures);
+                assert.equal(captures.length, 1);
             }
         }
     }


### PR DESCRIPTION
inlineCssImageWithLegacyFallback.js: Now includes IE8+ in browsers that get the stylesheet with inlined images.
IE9+ if an image is over 32kb (See: http://en.wikipedia.org/wiki/Data_URI_scheme#Web_browser_support)
