### PR TITLE
Rename '-one-' vendor prefix to '-ag-'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ Features
 * Using the separate `assetgraph-sprite transform
   <https://github.com/One-com/assetgraph-sprite>`_: Optimize CSS
   background images by creating sprite images. The spriting is guided
-  by a set of custom CSS properties with a ``-one-sprite`` prefix.
+  by a set of custom CSS properties with a ``-ag-sprite`` prefix.
 
 
 Installation
@@ -461,7 +461,7 @@ won't be inlined.
 ``CssImage`` relation won't be inlined.
 
 3) A ``CssImage`` relation residing in a CSS rule with a
-``-one-image-inline: true`` declaration will always be inlined. This
+``-ag-image-inline: true`` declaration will always be inlined. This
 takes precedence over the first two criteria.
 
 If any image is inlined an Internet Explorer-only version of the

--- a/lib/assets/Css.js
+++ b/lib/assets/Css.js
@@ -15,6 +15,8 @@ function Css(config) {
     Text.call(this, config);
 }
 
+Css.vendorPrefix = '-ag-'; // Should be in a more visible place
+
 util.inherits(Css, Text);
 
 function extractEncodingFromText(text) {
@@ -218,8 +220,6 @@ extendWithGettersAndSetters(Css.prototype, {
 
 // Grrr...
 Css.prototype.__defineSetter__('text', Text.prototype.__lookupSetter__('text'));
-
-Css.vendorPrefix = '-one'; // Should be in a more visible place
 
 // If lambda returns false, subrules won't be traversed
 Css.eachRuleInParseTree = function (ruleOrStylesheet, lambda, scope) {

--- a/lib/transforms/inlineCssImagesWithLegacyFallback.js
+++ b/lib/transforms/inlineCssImagesWithLegacyFallback.js
@@ -3,7 +3,7 @@ var _ = require('underscore'),
     assets = require('../assets');
 
 // Inlines images in Css as data: urls if
-//   the CSS rule containing the background/background-image property also has a "-one-image-inline: inline" property
+//   the CSS rule containing the background/background-image property also has a "-ag-image-inline: inline" property
 //   OR the size of the image is less than or equal to 'sizeThreshold' AND the Css asset only has that one relation to the image
 //
 // Note: If provided, the queryObj argument must specify the set of Html assets to start from so that a fallback IE stylesheet can be created.
@@ -17,7 +17,7 @@ module.exports = function (queryObj, sizeThreshold) {
                     ieVersion = 8,
                     hasCssImagesToInline = false;
                 cssImages.forEach(function (cssImage) {
-                    if (cssImage.cssRule.style.getPropertyValue('-one-image-inline') ||
+                    if (cssImage.cssRule.style.getPropertyValue('-ag-image-inline') ||
                         (!/^_/.test(cssImage.propertyName) && // Underscore hack (IE6), don't inline
                          sizeThreshold >= 0 &&
                          cssImage.to.rawSrc.length <= sizeThreshold &&
@@ -59,8 +59,8 @@ module.exports = function (queryObj, sizeThreshold) {
                     }
 
                     assetGraph.findRelations({from: cssAsset, type: 'CssImage'}).forEach(function (cssImage) {
-                        if (cssImage.cssRule.style.getPropertyValue('-one-image-inline')) {
-                            cssImage.cssRule.style.removeProperty('-one-image-inline');
+                        if (cssImage.cssRule.style.getPropertyValue('-ag-image-inline')) {
+                            cssImage.cssRule.style.removeProperty('-ag-image-inline');
                             cssAsset.markDirty();
                             cssImage.inline();
                         } else if (!/^_/.test(cssImage.propertyName) && // Underscore hack (IE6), don't inline

--- a/test/inlineCssImagesWithLegacyFallback/imageGreaterThan32KBWithOneImageInlineProperty.css
+++ b/test/inlineCssImagesWithLegacyFallback/imageGreaterThan32KBWithOneImageInlineProperty.css
@@ -1,4 +1,4 @@
 div {
     background-image: url(anotherbigimage.png);
-    -one-image-inline: inline;
+    -ag-image-inline: inline;
 }


### PR DESCRIPTION
Renames the -one- vendor prefix to -ag- in assetgraph, assetgraph-sprite and assetgraph-builder
