### PR TITLE
data-main-attribute now accepts '.js' file endings. Relates to #97

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -239,7 +239,7 @@ extendWithGettersAndSetters(Html.prototype, {
                             }
                         }
                         if (node.hasAttribute('data-main')) {
-                            var url = node.getAttribute('data-main') + '.js';
+                            var url = node.getAttribute('data-main').replace(/(?:\.js)?$/, '.js');
                             if (this.assetGraph && this.assetGraph.requireJsConfig) {
                                 url = this.assetGraph.requireJsConfig.resolveUrl(url);
                             }

--- a/lib/relations/HtmlRequireJsMain.js
+++ b/lib/relations/HtmlRequireJsMain.js
@@ -13,7 +13,7 @@ util.inherits(HtmlRequireJsMain, HtmlRelation);
 
 extendWithGettersAndSetters(HtmlRequireJsMain.prototype, {
     get href() {
-        return this.node.getAttribute('data-main') + '.js';
+        return this.node.getAttribute('data-main').replace(/(?:\.js)?$/, '.js');
     },
 
     set href(href) {


### PR DESCRIPTION
@papandreou Can you verify that this is a valid fix?
