### PR TITLE
Relation.resolve for unknown protocols

### DIFF
--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -394,7 +394,7 @@ Relation.prototype = {
                     resolvedAssetConfigs = [resolvedAssetConfigs];
                 }
                 if (resolvedAssetConfigs.length === 0) {
-                    this.from.assetGraph.emit('error', new Error('The relation ' + this.toString() + ' multiplied to nothing'));
+                    this.from.assetGraph.emit('warn', new Error('The relation ' + this.toString() + ' multiplied to nothing'));
                     this.remove();
                     cb(null, []);
                 } else if (resolvedAssetConfigs.length === 1) {


### PR DESCRIPTION
Relation.resolve: Emit warning instead of error when a relation multiplies to nothing. This relaxes the behavior a bit when encountering unknown protocols like irc://
