### PR TITLE
Introduce new 'info' warning level.

### DIFF
--- a/lib/transforms/splitCssIfIeLimitIsReached.js
+++ b/lib/transforms/splitCssIfIeLimitIsReached.js
@@ -48,7 +48,7 @@ module.exports = function () {
                 warning = new Error(count + ' CSS rules, ' + (count - rulesPerStylesheetLimit) + ' would be ignored by IE9 and below. Splitting into smaller chunks to resolve the problem.');
                 warning.asset = cssAsset;
 
-                assetGraph.emit('warn', warning);
+                assetGraph.emit('info', warning);
 
                 replacements = splitStyleSheet(cssAsset);
 

--- a/test/splitCssIfIeLimitReached-test.js
+++ b/test/splitCssIfIeLimitReached-test.js
@@ -29,13 +29,13 @@ vows.describe('transforms.splitCssIfIeLimitIsReached').addBatch({
                 assetGraph.__warnings = [];
 
                 assetGraph
-                    .on('warn', function (err) {
+                    .on('info', function (err) {
                         assetGraph.__warnings.push(err);
                     })
                     .splitCssIfIeLimitIsReached()
                     .run(this.callback);
             },
-            'the graph should have 1 emitted warning': function (assetGraph) {
+            'the graph should have 1 emitted info': function (assetGraph) {
                 assert.equal(assetGraph.__warnings.length, 1);
             },
             'the graph should contain 2 Css asset': function (assetGraph) {


### PR DESCRIPTION
There are some messages that may be relevant to developers when looking at the log from assetgraph, but are not a fatal event. This introduces a new event `info` which implementations can hook into.

The `info` event enables certain messages to be sent without implementations that break on `warn` stopping when the event is sent. An example of this is `buildProduction --stoponwarning`.

The changeset here changes the `splitCssIfIeLimitIsReached` transform to emit `info` instead of `warn`, since the nature of the message is a hint for the developer to improve the code base, but the built code base still works as intended.

This change should of course be followed by an event listener for `info` events in assetgraph-builder. And we might also want to evaluate the error levels in the rest of the transforms to see if their level can be degraded.
