### PR TITLE
transforms/flattenRequireJs: When adding a require call at the end of a ...

### DIFF
--- a/lib/transforms/flattenRequireJs.js
+++ b/lib/transforms/flattenRequireJs.js
@@ -238,12 +238,18 @@ module.exports = function (queryObj) {
                     if (defineStatementAst && injectDefineStatementAfter) {
                         asset.parseTree.body.push(defineStatementAst);
                     }
+                    // This file is referenced by requirejs via a data-main attribute, but is only calling define.
+                    // Default requirejs behavior is to require the defined module.
                     if (isHtmlRequireJsMainWithNoRequires) {
                         asset.parseTree.body.push(new uglifyJs.AST_SimpleStatement({
                             body: new uglifyJs.AST_Call({
                                 expression: new uglifyJs.AST_SymbolRef({name: 'require'}),
                                 args: [
-                                    new uglifyJs.AST_String({value: moduleName})
+                                    new uglifyJs.AST_Array({
+                                        elements: [
+                                            new uglifyJs.AST_String({value: moduleName})
+                                        ]
+                                    })
                                 ]
                             })
                         }));

--- a/test/flattenRequireJs-test.js
+++ b/test/flattenRequireJs-test.js
@@ -905,7 +905,7 @@ vows.describe('transforms.flattenRequireJs').addBatch({
                     define('main', function () {
                         alert('It gets lonely in here if nobody runs me');
                     });
-                    require('main');
+                    require(['main']);
                 });
             }
         }


### PR DESCRIPTION
...data-main included file with only a define call, use the async require version. Avoids this error: http://requirejs.org/docs/errors.html#notloaded
