### PR TITLE
Add support for humans.txt/author relations.

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -433,6 +433,20 @@ extendWithGettersAndSetters(Html.prototype, {
                                     node: node
                                 }));
                             }
+                        } else if (/(?:^| )author(?:$| )/i.test(rel)) {
+                            if (this._isRelationUrl(node.getAttribute('href'))) {
+                                var assetConfig = {
+                                    url: node.getAttribute('href')
+                                };
+                                if (node.hasAttribute('type')) {
+                                    assetConfig.contentType = node.getAttribute('type');
+                                }
+                                addOutgoingRelation(new AssetGraph.HtmlAuthorLink({
+                                    from: this,
+                                    to: assetConfig,
+                                    node: node
+                                }));
+                            }
                         } else if (/(?:^| )search(?:$| )/i.test(rel)) {
                             if (this._isRelationUrl(node.getAttribute('href'))) {
                                 var assetConfig = {

--- a/lib/relations/HtmlAuthorLink.js
+++ b/lib/relations/HtmlAuthorLink.js
@@ -1,0 +1,29 @@
+var util = require('util'),
+    extendWithGettersAndSetters = require('../util/extendWithGettersAndSetters'),
+    HtmlRelation = require('./HtmlRelation');
+
+function HtmlAuthorLink(config) {
+    HtmlRelation.call(this, config);
+}
+
+util.inherits(HtmlAuthorLink, HtmlRelation);
+
+extendWithGettersAndSetters(HtmlAuthorLink.prototype, {
+    get href() {
+        return this.node.getAttribute('href');
+    },
+
+    set href(href) {
+        this.node.setAttribute('href', href);
+    },
+
+    attach: function (asset, position, adjacentRelation) {
+        this.node = asset.parseTree.createElement('link');
+        this.node.setAttribute('rel', 'author');
+        this.node.setAttribute('type', this.to.contentType);
+        this.attachNodeBeforeOrAfter(position, adjacentRelation);
+        return HtmlRelation.prototype.attach.call(this, asset, position, adjacentRelation);
+    }
+});
+
+module.exports = HtmlAuthorLink;

--- a/test/HtmlAuthorLink-test.js
+++ b/test/HtmlAuthorLink-test.js
@@ -1,0 +1,21 @@
+var vows = require('vows'),
+    assert = require('assert'),
+    AssetGraph = require('../lib');
+
+vows.describe('Html with <link rel="author">').addBatch({
+    'After loading the test case': {
+        topic: function () {
+            new AssetGraph({root: __dirname + '/HtmlAuthorLink/'})
+                .loadAssets('index.html')
+                .populate()
+                .run(this.callback);
+        },
+
+        'the graph should contain HtmlAuthorLink relations': function (assetGraph) {
+            assert.equal(assetGraph.findRelations({type: 'HtmlAuthorLink'}).length, 2);
+        },
+        'the graph should contain two Text assets': function (assetGraph) {
+            assert.equal(assetGraph.findAssets({type: 'Text'}).length, 2);
+        }
+    }
+})['export'](module);

--- a/test/HtmlAuthorLink/humans.txt
+++ b/test/HtmlAuthorLink/humans.txt
@@ -1,0 +1,3 @@
+/* SITE */
+
+  This site was made by humans.

--- a/test/HtmlAuthorLink/index.html
+++ b/test/HtmlAuthorLink/index.html
@@ -1,0 +1,6 @@
+<html>
+<head>
+<link rel="author" href="humans.txt" type="text/plain">
+<link rel="author" href="otherhumans.txt" type="text/plain">
+</head>
+</html>

--- a/test/HtmlAuthorLink/otherhumans.txt
+++ b/test/HtmlAuthorLink/otherhumans.txt
@@ -1,0 +1,3 @@
+/* SITE */
+
+  Some other humans who worked on the site.


### PR DESCRIPTION
This adds support for [humans.txt](http://humanstxt.org/). We should discuss whether or not adding this is a good idea. The humans.txt website specifies that the `humans.txt` file should be located in the root and be linked to using `<link rel="author" type="text/plain" href="humans.txt">`. This change supports that syntax but still rewrites the asset to be in the static directory. I'm not sure it is a good idea to move it to the site root as that will mess up caching. On the other hand, the `humans.txt` file won't be requested often. Discuss.
