### PR TITLE
Make writeAssetsToDisc more intuitive

### DIFF
--- a/lib/transforms/writeAssetsToDisc.js
+++ b/lib/transforms/writeAssetsToDisc.js
@@ -20,7 +20,9 @@ var mkpathAndWriteFile = function (fileName, contents, encoding, cb) {
 };
 
 module.exports = function (queryObj, outRoot, root) {
-    outRoot = urlTools.fsDirToFileUrl(outRoot);
+    if (outRoot.indexOf('file://') === -1) {
+        outRoot = urlTools.fsDirToFileUrl(outRoot);
+    }
 
     return function writeAssetsToDisc(assetGraph, cb) {
         seq(assetGraph.findAssets(_.extend({isInline: false}, queryObj || {})))


### PR DESCRIPTION
This ensures the outroot is a proper file path before handing it off to a function that strips the first few chars based on the assumption of it starting with `file://`.

It's now possible to pass a string as `outRoot`, which will be treated as a relative path to `Process.cwd()` if it doesn't start with `file://`.
