### PR TITLE
transforms/registerRequireJsConfig: Run config detection on already load...

### DIFF
--- a/lib/transforms/registerRequireJsConfig.js
+++ b/lib/transforms/registerRequireJsConfig.js
@@ -191,6 +191,14 @@ module.exports = function (options) {
             }
         };
 
+        // Find config in all previously loaded JavaScript assets
+        assetGraph.findAssets({ type: 'JavaScript' }).forEach(function (asset) {
+            if (!requireJsConfig.foundConfig) {
+                requireJsConfig.registerConfigInJavaScript(asset);
+            }
+        });
+
+        // Run config detection on all new incoming JavaScript assets
         assetGraph.on('addAsset', function (asset) {
             if (asset.type === 'JavaScript' && !requireJsConfig.foundConfig) {
                 if (requireJsConfig.preventPopulationOfJavaScriptAssetsUntilConfigHasBeenFound) {

--- a/test/transforms/registerRequireJsConfig.js
+++ b/test/transforms/registerRequireJsConfig.js
@@ -79,4 +79,20 @@ describe('transforms/requireJsConfig', function () {
             })
             .run(done);
     });
+
+    it('should pick up requirejs configuration when it is in an already loaded asset when transform is run', function (done) {
+        new AssetGraph({root: __dirname + '/../../testdata/transforms/registerRequireJsConfig/windowRequirejs'})
+            .loadAssets('index.html')
+            .registerRequireJsConfig()
+            .queue(function (assetGraph) {
+                expect(assetGraph.requireJsConfig, 'to satisfy', {
+                    foundConfig: true,
+                    paths: {
+                        underscore: '../vendor/underscore',
+                        backbone: '../vendor/backbone'
+                    }
+                });
+            })
+            .run(done);
+    });
 });


### PR DESCRIPTION
...ed JavaScript assets when transform is run

This makes it easier for people to use the transform. This example would previously fail:

```js
new AssetGraph({ root: 'app' })
  .loadAssets('index.html') // has requirejs config in inline script tag
  .registerRequireJsConfig()
  .run();
```