### PR TITLE
Avoid CommonJSRequire errors in self encapsulated bundles

### DIFF
--- a/lib/assets/JavaScript.js
+++ b/lib/assets/JavaScript.js
@@ -531,24 +531,37 @@ extendWithGettersAndSetters(JavaScript.prototype, {
                             outgoingRelations.push(outgoingRelation);
                         }
                     } else if (!this.isRequired) {
-                        var baseUrl = this.nonInlineAncestor && this.nonInlineAncestor.url;
-                        if (/^file:/.test(baseUrl)) {
-                            var resolvedCommonJsModuleName = resolveCommonJsModuleName(urlTools.fileUrlToFsPath(baseUrl), node.args[0].value);
 
-                            // Skip built-in and unresolvable modules (they just resolve to 'fs', 'util', etc., not a file name):
-                            if (!resolvedCommonJsModuleName) {
-                                warnings.push(new errors.SyntaxError({message: 'Couldn\'t resolve ' + node.print_to_string() + ', skipping', relationType: 'JavaScriptCommonJsRequire'}));
-                            } else if (/^\//.test(resolvedCommonJsModuleName)) {
-                                outgoingRelations.push(new AssetGraph.JavaScriptCommonJsRequire({
-                                    from: this,
-                                    to: {
-                                        url: urlTools.fsFilePathToFileUrl(resolvedCommonJsModuleName)
-                                    },
-                                    node: node
-                                }));
+                        // Walk up the tree to look for require function definitions via arguments:
+                        // (function (require, module) { require('dependency'); })
+                        // Assume self encapsulation if found, like browserify
+                        var argRequireDefinition = walker.stack.some(function (node, idx) {
+                            return node.argnames && node.argnames.some(function (arg) {
+                                return arg.name === 'require';
+                            });
+                        });
+
+                        // Self defined require function not found, assume CommonJs
+                        if (!argRequireDefinition) {
+                            var baseUrl = this.nonInlineAncestor && this.nonInlineAncestor.url;
+                            if (/^file:/.test(baseUrl)) {
+                                var resolvedCommonJsModuleName = resolveCommonJsModuleName(urlTools.fileUrlToFsPath(baseUrl), node.args[0].value);
+
+                                // Skip built-in and unresolvable modules (they just resolve to 'fs', 'util', etc., not a file name):
+                                if (!resolvedCommonJsModuleName) {
+                                    warnings.push(new errors.SyntaxError({message: 'Couldn\'t resolve ' + node.print_to_string() + ', skipping', relationType: 'JavaScriptCommonJsRequire'}));
+                                } else if (/^\//.test(resolvedCommonJsModuleName)) {
+                                    outgoingRelations.push(new AssetGraph.JavaScriptCommonJsRequire({
+                                        from: this,
+                                        to: {
+                                            url: urlTools.fsFilePathToFileUrl(resolvedCommonJsModuleName)
+                                        },
+                                        node: node
+                                    }));
+                                }
+                            } else {
+                                warnings.push(new errors.SyntaxError({message: 'Skipping JavaScriptCommonJsRequire (only supported from file: urls): ' + node.print_to_string(), relationType: 'JavaScriptCommonJsRequire'}));
                             }
-                        } else {
-                            warnings.push(new errors.SyntaxError({message: 'Skipping JavaScriptCommonJsRequire (only supported from file: urls): ' + node.print_to_string(), relationType: 'JavaScriptCommonJsRequire'}));
                         }
                     }
                 }

--- a/test/assets/JavaScript.js
+++ b/test/assets/JavaScript.js
@@ -182,6 +182,35 @@ describe('assets/JavaScript', function () {
             });
     });
 
+    it('should assume self encapsulation when require function is exposed as argument from outer scope', function (done) {
+        sinon.stub(console, 'warn');
+
+        var selfEncapsulated = new AssetGraph.JavaScript({
+            text: '(function (require, module) { require("dependency"); })'
+        });
+
+        selfEncapsulated.findOutgoingRelationsInParseTree();
+
+        expect(console.warn, 'was not called');
+
+        console.warn.restore();
+
+        var warnings = [];
+        new AssetGraph({ root: '.' })
+            .on('warn', function (warning) {
+                warnings.push(warning);
+            })
+            .loadAssets([
+                selfEncapsulated
+            ])
+            .populate()
+            .queue(function (assetGraph) {
+                expect(warnings, 'to have length', 0);
+                expect(assetGraph, 'to contain relations', 0);
+            })
+            .run(done);
+    });
+
     it('should handle non-file-scheme RequireJS.require dependency errors', function (done) {
         sinon.stub(console, 'warn');
 


### PR DESCRIPTION
In JavaScript CommonJS require AST walker branch, first check if the require function was defined as an argument further up the stack. If so, assume self encapsulation and don't add relations

Ping @papandreou 

Fixes https://github.com/Munter/hyperlink/issues/7

Hyperlink output before:
```tap
TAP version 13
# Crawling internal assets
ok 1 loading http://sarasoueidan.com/
not ok 2
  ---
    operator: error
    expected:
      
    actual:
      "Skipping JavaScriptCommonJsRequire (only supported from file: urls): require(\"./SearchStrategies/fuzzy\")"
    at: inline JavaScript in http://sarasoueidan.com/
        SyntaxError: Skipping JavaScriptCommonJsRequire (only supported from file: urls): require("./SearchStrategies/fuzzy")
              at JavaScript.<anonymous> (/home/munter/assetgraph/core/lib/assets/JavaScript.js:563:47)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:922:24)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:565:24)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:551:40)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:549:24)
              at /home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:528:21
              at Array.forEach (native)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:527:30)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
  ...
not ok 3
  ---
    operator: error
    expected:
      
    actual:
      "Skipping JavaScriptCommonJsRequire (only supported from file: urls): require(\"./SearchStrategies/literal\")"
    at: inline JavaScript in http://sarasoueidan.com/
        SyntaxError: Skipping JavaScriptCommonJsRequire (only supported from file: urls): require("./SearchStrategies/literal")
              at JavaScript.<anonymous> (/home/munter/assetgraph/core/lib/assets/JavaScript.js:563:47)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:922:24)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:565:24)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:551:40)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:549:24)
              at /home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:528:21
              at Array.forEach (native)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:527:30)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
  ...
not ok 4
  ---
    operator: error
    expected:
      
    actual:
      "Skipping JavaScriptCommonJsRequire (only supported from file: urls): require(\"./Searcher\")"
    at: inline JavaScript in http://sarasoueidan.com/
        SyntaxError: Skipping JavaScriptCommonJsRequire (only supported from file: urls): require("./Searcher")
              at JavaScript.<anonymous> (/home/munter/assetgraph/core/lib/assets/JavaScript.js:563:47)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:922:24)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:565:24)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:551:40)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:549:24)
              at /home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:528:21
              at Array.forEach (native)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:527:30)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
  ...
not ok 5
  ---
    operator: error
    expected:
      
    actual:
      "Skipping JavaScriptCommonJsRequire (only supported from file: urls): require(\"./Templater\")"
    at: inline JavaScript in http://sarasoueidan.com/
        SyntaxError: Skipping JavaScriptCommonJsRequire (only supported from file: urls): require("./Templater")
              at JavaScript.<anonymous> (/home/munter/assetgraph/core/lib/assets/JavaScript.js:563:47)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:922:24)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:565:24)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:551:40)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:549:24)
              at /home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:528:21
              at Array.forEach (native)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:527:30)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
  ...
not ok 6
  ---
    operator: error
    expected:
      
    actual:
      "Skipping JavaScriptCommonJsRequire (only supported from file: urls): require(\"./Store\")"
    at: inline JavaScript in http://sarasoueidan.com/
        SyntaxError: Skipping JavaScriptCommonJsRequire (only supported from file: urls): require("./Store")
              at JavaScript.<anonymous> (/home/munter/assetgraph/core/lib/assets/JavaScript.js:563:47)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:922:24)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:565:24)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:551:40)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:549:24)
              at /home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:528:21
              at Array.forEach (native)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:527:30)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
  ...
not ok 7
  ---
    operator: error
    expected:
      
    actual:
      "Skipping JavaScriptCommonJsRequire (only supported from file: urls): require(\"./JSONLoader\")"
    at: inline JavaScript in http://sarasoueidan.com/
        SyntaxError: Skipping JavaScriptCommonJsRequire (only supported from file: urls): require("./JSONLoader")
              at JavaScript.<anonymous> (/home/munter/assetgraph/core/lib/assets/JavaScript.js:563:47)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:922:24)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:565:24)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:551:40)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
              at AST_Node.DEFNODE._walk (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:549:24)
              at /home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:528:21
              at Array.forEach (native)
              at AST_Node.<anonymous> (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:527:30)
              at Object.TreeWalker._visit (/home/munter/assetgraph/core/node_modules/uglify-js-papandreou/lib/ast.js:926:21)
  ...
ok 8 loading http://sarasoueidan.com/stylesheets/screen.css
ok 9 loading http://sarasoueidan.com/fonts/texgyreadventor-bold-webfont.woff
ok 10 loading http://sarasoueidan.com/images/logo.png
ok 11 loading http://sarasoueidan.com/images/book.svg
ok 12 loading http://sarasoueidan.com/images/codrops-logo.svg
ok 13 loading http://sarasoueidan.com/images/map.svg
# Crawling 5 outgoing urls
ok 14 URI should have no redirects - http://html5shiv.googlecode.com/svn/trunk/html5.js
ok 15 URI should have no redirects - http://feeds.feedburner.com/sarasoueidan
ok 16 URI should have no redirects - http://blogs.adobe.com/dreamweaver/2015/02/extending-the-color-cascade-with-the-css-currentcolor-variable.html
ok 17 URI should have no redirects - https://twitter.com/SaraSoueidan
ok 18 URI should have no redirects - http://blogs.adobe.com/dreamweaver/2015/03/a-primer-to-background-positioning-in-css.html

1..18
# tests 18
# pass  12
# fail  6
```

Hyperlink output after:
```tap
TAP version 13
# Crawling internal assets
ok 1 loading http://sarasoueidan.com/
ok 2 loading http://sarasoueidan.com/stylesheets/screen.css
ok 3 loading http://sarasoueidan.com/fonts/texgyreadventor-bold-webfont.woff
ok 4 loading http://sarasoueidan.com/images/logo.png
ok 5 loading http://sarasoueidan.com/images/book.svg
ok 6 loading http://sarasoueidan.com/images/codrops-logo.svg
ok 7 loading http://sarasoueidan.com/images/map.svg
# Crawling 5 outgoing urls
ok 8 URI should have no redirects - http://html5shiv.googlecode.com/svn/trunk/html5.js
ok 9 URI should have no redirects - http://feeds.feedburner.com/sarasoueidan
ok 10 URI should have no redirects - http://blogs.adobe.com/dreamweaver/2015/03/a-primer-to-background-positioning-in-css.html
ok 11 URI should have no redirects - https://twitter.com/SaraSoueidan
ok 12 URI should have no redirects - http://blogs.adobe.com/dreamweaver/2015/02/extending-the-color-cascade-with-the-css-currentcolor-variable.html

1..12
# tests 12
# pass  12

# ok
```