### PR TITLE
Updated unexpected-dom to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "stylus": "0.52.4",
     "svgo": "0.4.4",
     "unexpected": "9.6.0",
-    "unexpected-dom": "1.4.1",
+    "unexpected-dom": "2.0.0",
     "unexpected-mitm": "7.7.0",
     "unexpected-sinon": "6.4.2",
     "yui-compressor": "0.1.3"


### PR DESCRIPTION
:rocket:

unexpected-dom just published version 2.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 7 commits (ahead by 7, behind by 0).

- [73f9332](https://github.com/Munter/unexpected-dom/commit/73f93325c9c2ace0748d9efa26d756a802023498): 2.0.0
- [5795bc6](https://github.com/Munter/unexpected-dom/commit/5795bc643afc72951fa5bc6b24d35683e94d365d): Browserify
- [0847ca7](https://github.com/Munter/unexpected-dom/commit/0847ca70a5e6ae6a2e6369f4cf749918aa812de3): Merge pull request #31 from papandreou/fix/surroundingWhitespaceInTextNodes
- [bef489c](https://github.com/Munter/unexpected-dom/commit/bef489c6e885dd47908dd569766b6ff025fc29f4): Consider surrounding whitespace when comparing text nodes for equality.
- [e93bfad](https://github.com/Munter/unexpected-dom/commit/e93bfad7f0c3deac85b6d784bf0ec7f78a764bfa): Merge remote-tracking branch 'origin/master'
- [43d83bb](https://github.com/Munter/unexpected-dom/commit/43d83bb364bfc5ac6d009b2d34a4022d3c785374): Merge pull request #30 from Munter/greenkeeper-mocha-lcov-reporter-1.0.0
- [b809e7f](https://github.com/Munter/unexpected-dom/commit/b809e7f8816ae813dacd163c217b98d98dff2233): chore(package): update mocha-lcov-reporter to version 1.0.0

See the [full diff](https://github.com/Munter/unexpected-dom/compare/9ca5810b31b94a433547820e9964efbb146ff8fd...73f93325c9c2ace0748d9efa26d756a802023498).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>