### PR TITLE
remove engineStrict from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "unexpected-sinon": "8.0.0",
     "yui-compressor": "0.1.3"
   },
-  "engineStrict": true,
   "publishConfig": {
     "registry": "http://registry.npmjs.org/"
   },


### PR DESCRIPTION
Since there's no engine specified, this doesn't do anything. Also, engineStrict was deprecated with npm 3.0.0