### PR TITLE
upgrade lodash to 4.9.0

### DIFF
--- a/lib/assets/CacheManifest.js
+++ b/lib/assets/CacheManifest.js
@@ -104,7 +104,7 @@ extendWithGettersAndSetters(CacheManifest.prototype, {
                     if (sectionName !== 'CACHE' && nodes.length) {
                         this._text += sectionName + ':\n' + getSectionText(nodes);
                     }
-                }, this);
+                }.bind(this));
             } else {
                 this._text = this._getTextFromRawSrc();
             }

--- a/lib/assets/CacheManifest.js
+++ b/lib/assets/CacheManifest.js
@@ -66,7 +66,7 @@ extendWithGettersAndSetters(CacheManifest.prototype, {
                         this.assetGraph.emit('warn', syntaxError);
                     }, this);
                 } else {
-                    throw new Error(_.pluck(syntaxErrors, 'message').join('\n'));
+                    throw new Error(_.map(syntaxErrors, 'message').join('\n'));
                 }
             }
             this._parseTree = parseTree;

--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -903,7 +903,7 @@ extendWithGettersAndSetters(Html.prototype, {
             }
         }
         if (currentConditionalComments.length > 0) {
-            var warning = new errors.SyntaxError({message: 'Html: No end marker found for conditional comment(s):\n' + _.pluck(currentConditionalComments, 'nodeValue').join('\n  '), asset: this});
+            var warning = new errors.SyntaxError({message: 'Html: No end marker found for conditional comment(s):\n' + _.map(currentConditionalComments, 'nodeValue').join('\n  '), asset: this});
             if (this.assetGraph) {
                 this.assetGraph.emit('warn', warning);
             } else {

--- a/lib/relations/HtmlSvgIsland.js
+++ b/lib/relations/HtmlSvgIsland.js
@@ -24,7 +24,7 @@ extendWithGettersAndSetters(HtmlInlineScriptTemplate.prototype, {
             isSeenByAttributeName[attribute.name] = true;
         }
 
-        _.pluck(this.node.attributes, 'name').forEach(function (attributeName) {
+        _.map(this.node.attributes, 'name').forEach(function (attributeName) {
             if (!isSeenByAttributeName[attributeName]) {
                 this.node.removeAttribute(attributeName);
             }

--- a/lib/transforms/bundleRelations.js
+++ b/lib/transforms/bundleRelations.js
@@ -30,7 +30,7 @@ module.exports = function (queryObj, options) {
                 discriminatorFragments.push('body');
             }
             if (relation.conditionalComments) {
-                Array.prototype.push.apply(discriminatorFragments, _.pluck(relation.conditionalComments, 'nodeValue'));
+                Array.prototype.push.apply(discriminatorFragments, _.map(relation.conditionalComments, 'nodeValue'));
             }
             if (relation.node.hasAttribute('bundle')) {
                 discriminatorFragments.push(relation.node.getAttribute('bundle'));
@@ -221,7 +221,7 @@ module.exports = function (queryObj, options) {
             Object.keys(relationsByIncludingAsset).forEach(function (includingAssetId) {
                 var relationsToBundle = relationsByIncludingAsset[includingAssetId];
 
-                _.unique(_.pluck(relationsToBundle, 'type')).forEach(function (relationType) {
+                _.uniq(_.map(relationsToBundle, 'type')).forEach(function (relationType) {
                     var currentBundle = [],
                         bundleDiscriminator,
                         relationsOfTypeToBundle = relationsToBundle.filter(function (relation) {
@@ -289,7 +289,7 @@ module.exports = function (queryObj, options) {
             _.values(seenIncludingAssets).forEach(function (includingAsset) {
                 var relationsToBundle = relationsByIncludingAsset[includingAsset.id];
 
-                _.unique(_.pluck(relationsToBundle, 'type')).forEach(function (relationType) {
+                _.uniq(_.map(relationsToBundle, 'type')).forEach(function (relationType) {
                     var outgoingRelations = assetGraph.findRelations({from: includingAsset, type: [relationType, 'HtmlConditionalComment']}, true), // includeUnresolved
                         previousBundle,
                         bundleDiscriminator,

--- a/lib/transforms/bundleSystemJs.js
+++ b/lib/transforms/bundleSystemJs.js
@@ -399,7 +399,7 @@ module.exports = function (options) {
                 (bRelationsByPageId[incomingRelation.from.id] = bRelationsByPageId[incomingRelation.from.id] || []).push(incomingRelation);
             });
 
-            var pageIds = _.unique(Object.keys(aRelationsByPageId).concat(Object.keys(bRelationsByPageId)));
+            var pageIds = _.uniq(Object.keys(aRelationsByPageId).concat(Object.keys(bRelationsByPageId)));
             if (pageIds.every(function (pageId) {
                 return ((aRelationsByPageId[pageId] || []).every(function (aRelation) {
                     return (bRelationsByPageId[pageId] || []).every(function (bRelation) {
@@ -421,7 +421,7 @@ module.exports = function (options) {
         });
 
         var topLevelSystemImportCalls = assetGraph.systemJsConfig.topLevelSystemImportCalls;
-        var canonicalNames = _.unique(topLevelSystemImportCalls.map(function (topLevelSystemImportCall) {
+        var canonicalNames = _.uniq(topLevelSystemImportCalls.map(function (topLevelSystemImportCall) {
             return topLevelSystemImportCall.argumentString;
         }));
         if (canonicalNames.length === 0) {
@@ -502,7 +502,7 @@ module.exports = function (options) {
             builder.config(_.clone(configStatement.obj, true));
             doneFirstConfigCall = true;
         });
-        var entryPointNames = _.unique(topLevelSystemImportCalls.map(function (topLevelSystemImportCall) {
+        var entryPointNames = _.uniq(topLevelSystemImportCalls.map(function (topLevelSystemImportCall) {
             return topLevelSystemImportCall.argumentString;
         }));
 

--- a/lib/transforms/inlineKnockoutJsTemplates.js
+++ b/lib/transforms/inlineKnockoutJsTemplates.js
@@ -62,7 +62,7 @@ module.exports = function (queryObj) {
                         assetGraph.emit('warn', new Error('inlineKnockoutJsTemplate: Inlining ' + relationToInline.to.urlOrDescription +
                                                           ' into a <script> in ' + htmlAsset.urlOrDescription +
                                                           ' with an id attribute of ' + id + ', which already exists in these assets:\n  ' +
-                                                          _.pluck(assetsBySeenIdAttribute[id], 'urlOrDescription').join('\n  ')));
+                                                          _.map(assetsBySeenIdAttribute[id], 'urlOrDescription').join('\n  ')));
                     }
                     inlinedTemplateAssets.push(relationToInline.to);
                     var node = document.createElement('script');

--- a/lib/transforms/pullGlobalsIntoVariables.js
+++ b/lib/transforms/pullGlobalsIntoVariables.js
@@ -188,7 +188,7 @@ module.exports = function (queryObj, options) {
                             type: 'ExpressionStatement',
                             expression: {
                                 type: 'CallExpression',
-                                arguments: _.pluck(aliasDeclarations, 'valueAst'),
+                                arguments: _.map(aliasDeclarations, 'valueAst'),
                                 callee: {
                                     type: 'FunctionExpression',
                                     params: aliasDeclarations.map(function (aliasDeclaration) {

--- a/lib/transforms/removeDeadIfsInJavaScript.js
+++ b/lib/transforms/removeDeadIfsInJavaScript.js
@@ -31,7 +31,7 @@ module.exports = function (queryObj) {
             });
 
             if (statementArraysToCleanUp.length > 0) {
-                _.unique(statementArraysToCleanUp.reverse()).forEach(function (statementArray) {
+                _.uniq(statementArraysToCleanUp.reverse()).forEach(function (statementArray) {
                     for (var i = 0 ; i < statementArray.length ; i += 1) {
                         if (statementArray[i].type === 'EmptyStatement') {
                             statementArray.splice(i, 1);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "html-minifier": "1.1.1",
     "imageinfo": "1.0.4",
     "jsdom-papandreou": "0.11.0-patch3",
-    "lodash": "3.10.1",
+    "lodash": "4.9.0",
     "minimize": "1.8.0",
     "mkdirp": "0.5.1",
     "normalizeurl": "0.1.3",

--- a/test/assets/Asset.js
+++ b/test/assets/Asset.js
@@ -393,9 +393,9 @@ describe('assets/Asset', function () {
                     expect(assetGraph.findAssets().pop().text, 'to equal', assetGraph.findAssets({url: /\/thelib\.js$/})[0].text);
 
                     expect(
-                        _.pluck(assetGraph.findRelations({from: assetGraph.findAssets().pop()}), 'type'),
+                        _.map(assetGraph.findRelations({from: assetGraph.findAssets().pop()}), 'type'),
                         'to equal',
-                        _.pluck(assetGraph.findRelations({from: {url: /\/thelib\.js$/}}), 'type')
+                        _.map(assetGraph.findRelations({from: {url: /\/thelib\.js$/}}), 'type')
                     );
                 })
                 .run(done);

--- a/test/assets/JavaScript.js
+++ b/test/assets/JavaScript.js
@@ -233,7 +233,7 @@ describe('assets/JavaScript', function () {
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findRelations({from: {type: 'JavaScript'}}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({from: {type: 'JavaScript'}}), 'href'), 'to equal', [
                     './foo',
                     './data.json',
                     './bar'

--- a/test/collectAssetsPostOrder.js
+++ b/test/collectAssetsPostOrder.js
@@ -13,7 +13,7 @@ describe('AssetGraph#collectAssetsPostOrder()', function () {
                 expect(assetGraph, 'to contain assets', 'JavaScript', 6);
                 var initialAsset = assetGraph.findAssets({url: /index\.js$/})[0];
                 expect(
-                    _.pluck(assetGraph.collectAssetsPostOrder(initialAsset, {type: 'JavaScriptInclude'}), 'url').map(function (url) {
+                    _.map(assetGraph.collectAssetsPostOrder(initialAsset, {type: 'JavaScriptInclude'}), 'url').map(function (url) {
                         return Path.basename(url);
                     }),
                     'to equal',

--- a/test/relations/CssAlphaImageLoader.js
+++ b/test/relations/CssAlphaImageLoader.js
@@ -13,7 +13,7 @@ describe('relations/CssAlphaImageLoader', function () {
 
                 assetGraph.findAssets({url: /\/foo.png$/})[0].url = assetGraph.root + 'images/quux.png';
 
-                expect(_.pluck(assetGraph.findRelations({type: 'CssAlphaImageLoader'}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'CssAlphaImageLoader'}), 'href'), 'to equal', [
                     'images/quux.png',
                     'bar.png',
                     '/images/quux.png'

--- a/test/relations/CssImage.js
+++ b/test/relations/CssImage.js
@@ -12,7 +12,7 @@ describe('relations/CssImage', function () {
                 expect(assetGraph, 'to contain relations', 'CssImage', 17);
                 assetGraph.findAssets({url: /\/foo\.png$/})[0].url = assetGraph.root + 'dir/foo2.png';
 
-                expect(_.pluck(assetGraph.findRelations({to: assetGraph.findAssets({url: /\/foo2\.png$/})}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({to: assetGraph.findAssets({url: /\/foo2\.png$/})}), 'href'), 'to equal', [
                     'dir/foo2.png',
                     'dir/foo2.png',
                     'dir/foo2.png',

--- a/test/relations/HtmlAudio.js
+++ b/test/relations/HtmlAudio.js
@@ -18,7 +18,7 @@ describe('relations/HtmlAudio', function () {
                     relation.hrefType = 'relative';
                 });
 
-                expect(_.pluck(assetGraph.findRelations({}, true), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({}, true), 'href'), 'to equal', [
                     '../sound.mp3',
                     '../sound.wav',
                     '../sound.wma',

--- a/test/relations/HtmlJsx.js
+++ b/test/relations/HtmlJsx.js
@@ -10,13 +10,13 @@ describe('relations/HtmlJsx', function () {
             .populate()
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain relations including unresolved', 'HtmlJsx', 2);
-                expect(_.pluck(assetGraph.findRelations(), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations(), 'href'), 'to equal', [
                     'externalWithTypeTextJsx.js',
                     undefined,
                     'external.jsx'
                 ]);
 
-                var assets = _.pluck(assetGraph.findRelations(), 'to');
+                var assets = _.map(assetGraph.findRelations(), 'to');
 
                 expect(assets[0].text, 'to equal', '\'external\'\n');
                 expect(assets[1].text, 'to equal', '\'inline\'');

--- a/test/relations/HtmlObject.js
+++ b/test/relations/HtmlObject.js
@@ -13,14 +13,14 @@ describe('relations/HtmlObject', function () {
                 expect(assetGraph, 'to contain relations including unresolved', 'HtmlObject', 3);
                 expect(assetGraph, 'to contain assets', 'Flash', 3);
                 expect(
-                    _.pluck(assetGraph.findRelations({type: 'HtmlObject'}, true), 'href'),
+                    _.map(assetGraph.findRelations({type: 'HtmlObject'}, true), 'href'),
                     'to equal',
                     ['themovie.swf', 'theothermovie.swf', 'yetanothermovie.swf']
                 );
 
                 assetGraph.findAssets({type: 'Html'})[0].url = urlTools.resolveUrl(assetGraph.root, 'foo/index.html');
                 expect(
-                    _.pluck(assetGraph.findRelations({type: 'HtmlObject'}, true), 'href'),
+                    _.map(assetGraph.findRelations({type: 'HtmlObject'}, true), 'href'),
                     'to equal',
                     ['../themovie.swf', '../theothermovie.swf', '../yetanothermovie.swf']
                 );

--- a/test/relations/HtmlPictureSource.js
+++ b/test/relations/HtmlPictureSource.js
@@ -16,7 +16,7 @@ describe('relations/HtmlPictureSource test', function () {
                 assetGraph.findRelations({}, true).forEach(function (relation) {
                     relation.hrefType = 'relative';
                 });
-                expect(_.pluck(assetGraph.findRelations({}, true), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({}, true), 'href'), 'to equal', [
                     '../image.png',
                     '../otherImage.jpg'
                 ]);

--- a/test/relations/HtmlScript.js
+++ b/test/relations/HtmlScript.js
@@ -10,7 +10,7 @@ describe('relations/HtmlScript', function () {
             .populate()
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain relations including unresolved', 'HtmlScript', 6);
-                expect(_.pluck(assetGraph.findRelations(), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations(), 'href'), 'to equal', [
                     'externalNoType.js',
                     undefined,
                     'externalWithTypeTextJavaScript.js',

--- a/test/relations/HtmlVideo.js
+++ b/test/relations/HtmlVideo.js
@@ -19,7 +19,7 @@ describe('relations/HtmlVideo', function () {
                     relation.hrefType = 'relative';
                 });
 
-                expect(_.pluck(assetGraph.findRelations({}, true), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({}, true), 'href'), 'to equal', [
                     '../movie1.mp4',
                     '../movie1.jpg',
                     '../movie2.png',

--- a/test/relations/JavaScriptGetStaticUrl.js
+++ b/test/relations/JavaScriptGetStaticUrl.js
@@ -93,7 +93,7 @@ describe('relations/JavaScriptGetStaticUrl', function () {
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findRelations({type: 'StaticUrlMapEntry'}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'StaticUrlMapEntry'}), 'href'), 'to equal', [
                     '/images/bar.png',
                     '/images/foo.png'
                 ]);

--- a/test/relations/JavaScriptInclude.js
+++ b/test/relations/JavaScriptInclude.js
@@ -25,7 +25,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'first');
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'bar.js']);
 
                 newJavaScriptAsset = new AssetGraph.JavaScript({
@@ -37,7 +37,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'after', assetGraph.findRelations({to: {url: /\/quux\.js$/}})[0]);
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'baz.js', 'bar.js']);
 
                 newJavaScriptAsset = new AssetGraph.JavaScript({
@@ -49,7 +49,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'before', assetGraph.findRelations({to: {url: /\/bar\.js$/}})[0]);
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'baz.js', 'bazze.js', 'bar.js']);
 
                 newJavaScriptAsset = new AssetGraph.JavaScript({
@@ -61,7 +61,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'last');
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'baz.js', 'bazze.js', 'bar.js', 'prinzenrolle.js']);
             })
             .run(done);
@@ -86,7 +86,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'first');
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'bar.js']);
 
                 newJavaScriptAsset = new AssetGraph.JavaScript({
@@ -98,7 +98,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'after', assetGraph.findRelations({to: {url: /\/quux\.js$/}})[0]);
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'baz.js', 'bar.js']);
 
                 newJavaScriptAsset = new AssetGraph.JavaScript({
@@ -110,7 +110,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'before', assetGraph.findRelations({to: {url: /\/bar\.js$/}})[0]);
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'baz.js', 'bazze.js', 'bar.js']);
 
                 newJavaScriptAsset = new AssetGraph.JavaScript({
@@ -122,7 +122,7 @@ describe('relations/JavaScriptInclude', function () {
                     to: newJavaScriptAsset
                 }).attach(assetGraph.findAssets({url: /\/index\.js$/})[0], 'last');
 
-                expect(_.pluck(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
+                expect(_.map(assetGraph.findRelations({from: {url: /\/index\.js$/}}), 'href'), 'to equal',
                                  ['quux.js', 'baz.js', 'bazze.js', 'bar.js', 'prinzenrolle.js']);
             })
             .run(done);

--- a/test/relations/Relation.js
+++ b/test/relations/Relation.js
@@ -11,14 +11,14 @@ describe('relations/Relation', function () {
                 .queue(function (assetGraph) {
                     expect(assetGraph, 'to contain asset', 'Html');
 
-                    expect(_.pluck(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'href'), 'to equal', [
+                    expect(_.map(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'href'), 'to equal', [
                         'relative.html',
                         '/rootRelative.html',
                         '//example.com/protocolRelative.html',
                         'http://example.com/absolute.html'
                     ]);
 
-                    expect(_.pluck(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'hrefType'), 'to equal', [
+                    expect(_.map(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'hrefType'), 'to equal', [
                         'relative',
                         'rootRelative',
                         'protocolRelative',
@@ -30,7 +30,7 @@ describe('relations/Relation', function () {
                         htmlAnchor.refreshHref();
                     });
 
-                    expect(_.pluck(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'href'), 'to equal', [
+                    expect(_.map(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'href'), 'to equal', [
                         'relative2.html',
                         '/rootRelative2.html',
                         '//example.com/protocolRelative2.html',
@@ -50,7 +50,7 @@ describe('relations/Relation', function () {
                         asset.text = asset.text.replace(/href="/g, 'href=" ');
                     });
 
-                    expect(_.pluck(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'hrefType'), 'to equal', [
+                    expect(_.map(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'hrefType'), 'to equal', [
                         'relative',
                         'rootRelative',
                         'protocolRelative',
@@ -62,7 +62,7 @@ describe('relations/Relation', function () {
     });
 
     function getTargetFileNames(relations) {
-        return _.pluck(_.pluck(relations, 'to'), 'url').map(function (url) {
+        return _.map(_.map(relations, 'to'), 'url').map(function (url) {
             return url.replace(/^.*\//, '');
         });
     }

--- a/test/transforms/addCacheManifest.js
+++ b/test/transforms/addCacheManifest.js
@@ -62,7 +62,7 @@ describe('transforms/addCacheManifest', function () {
             .addCacheManifest({isInitial: true})
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain asset', 'CacheManifest');
-                expect(_.pluck(assetGraph.findRelations({from: {type: 'CacheManifest'}}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({from: {type: 'CacheManifest'}}), 'href'), 'to equal', [
                     'foo.png',
                     'style.css',
                     'modernBrowsers.js'

--- a/test/transforms/flattenRequireJs.js
+++ b/test/transforms/flattenRequireJs.js
@@ -471,13 +471,13 @@ describe('transforms/flattenRequireJs', function () {
             .populate()
             .flattenRequireJs({type: 'Html'})
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findRelations({type: 'HtmlStyle', from: {url: /\/index\.html$/}}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'HtmlStyle', from: {url: /\/index\.html$/}}), 'href'), 'to equal', [
                     'b.less',
                     'a.less',
                     'c.less'
                 ]);
 
-                expect(_.pluck(assetGraph.findRelations({type: 'HtmlStyle', from: {url: /\/index2\.html$/}}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'HtmlStyle', from: {url: /\/index2\.html$/}}), 'href'), 'to equal', [
                     'b.less',
                     'a.less',
                     'c.less'
@@ -542,7 +542,7 @@ describe('transforms/flattenRequireJs', function () {
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findAssets({type: 'JavaScript'}), 'url').sort(), 'to equal', [
+                expect(_.map(assetGraph.findAssets({type: 'JavaScript'}), 'url').sort(), 'to equal', [
                     assetGraph.root + 'main.js',
                     assetGraph.root + 'require.js',
                     assetGraph.root + 'something.js'
@@ -561,7 +561,7 @@ describe('transforms/flattenRequireJs', function () {
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findAssets({type: 'JavaScript'}), 'url').sort(), 'to equal', [
+                expect(_.map(assetGraph.findAssets({type: 'JavaScript'}), 'url').sort(), 'to equal', [
                     assetGraph.root + 'main.js',
                     assetGraph.root + 'require.js',
                     assetGraph.root + 'subdir/bar.js',
@@ -609,7 +609,7 @@ describe('transforms/flattenRequireJs', function () {
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findAssets({type: 'JavaScript'}), 'url').sort(), 'to equal', [
+                expect(_.map(assetGraph.findAssets({type: 'JavaScript'}), 'url').sort(), 'to equal', [
                     assetGraph.root + 'main.js',
                     assetGraph.root + 'require.js',
                     assetGraph.root + 'subdir/bar.js',
@@ -656,7 +656,7 @@ describe('transforms/flattenRequireJs', function () {
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findAssets({type: 'JavaScript', isInline: false}), 'url').sort(), 'to equal', [
+                expect(_.map(assetGraph.findAssets({type: 'JavaScript', isInline: false}), 'url').sort(), 'to equal', [
                     assetGraph.root + 'main.js',
                     assetGraph.root + 'require.js',
                     'http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js'

--- a/test/transforms/flattenStaticIncludes.js
+++ b/test/transforms/flattenStaticIncludes.js
@@ -14,7 +14,7 @@ describe('transforms/flattenStaticIncludes', function () {
             })
             .flattenStaticIncludes({type: 'Html'})
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findRelations({from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
                     'a.js',
                     'b.js',
                     'c.js',
@@ -41,7 +41,7 @@ describe('transforms/flattenStaticIncludes', function () {
             })
             .flattenStaticIncludes({type: 'Html'})
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findRelations({type: 'HtmlScript', from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'HtmlScript', from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
                     'a.js',
                     'b.js',
                     'c.js',
@@ -49,7 +49,7 @@ describe('transforms/flattenStaticIncludes', function () {
                     'd.js'
                 ]);
 
-                expect(_.pluck(assetGraph.findRelations({type: 'HtmlStyle', from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'HtmlStyle', from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
 
                     'a.css',
                     'c.css',
@@ -81,7 +81,7 @@ describe('transforms/flattenStaticIncludes', function () {
             })
             .flattenStaticIncludes({type: 'Html'})
             .queue(function (assetGraph) {
-                expect(_.pluck(assetGraph.findRelations({type: 'HtmlStyle', from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'HtmlStyle', from: assetGraph.findAssets({type: 'Html'})[0]}), 'href'), 'to equal', [
                     'a.css',
                     'b.less',
                     'c.css'

--- a/test/transforms/populate.js
+++ b/test/transforms/populate.js
@@ -46,7 +46,7 @@ describe('transforms/populate', function () {
                 expect(assetGraph, 'to contain assets', 3);
                 expect(assetGraph, 'to contain relations', 'HtmlScript', 3);
 
-                expect(_.pluck(assetGraph.findRelations({type: 'HtmlScript'}), 'href'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'HtmlScript'}), 'href'), 'to equal', [
                     '//ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js',
                     'http://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js',
                     'https://ajax.googleapis.com/ajax/libs/jquery/1.8.1/jquery.min.js'
@@ -62,7 +62,7 @@ describe('transforms/populate', function () {
                     javaScript.url = javaScript.url.match(/^(https?:)/)[1] + '//cdn.example.com/' + javaScript.fileName;
                 });
 
-                expect(_.pluck(assetGraph.findRelations({type: 'HtmlScript'}), 'hrefType'), 'to equal', [
+                expect(_.map(assetGraph.findRelations({type: 'HtmlScript'}), 'hrefType'), 'to equal', [
                     'protocolRelative',
                     'absolute',
                     'absolute'

--- a/test/transforms/splitCssIfIeLimitIsReached.js
+++ b/test/transforms/splitCssIfIeLimitIsReached.js
@@ -141,7 +141,7 @@ describe('transforms/splitCssIfIeLimitIsReached', function () {
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 3);
                 expect(assetGraph, 'to contain relations', 'HtmlStyle', 3);
-                expect(_.pluck(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
+                expect(_.map(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
                     [
                         '\n          .a {color: #aaa;}\n          .b {color: #bbb;}',
                         '\n          .c {color: #ccc;}\n          .d {color: #ddd;}',
@@ -169,7 +169,7 @@ describe('transforms/splitCssIfIeLimitIsReached', function () {
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 4);
                 expect(assetGraph, 'to contain relations', 'HtmlStyle', 4);
-                expect(_.pluck(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
+                expect(_.map(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
                     [
                         '\n          @media screen {\n              .a, .quux, .baz {color: #aaa;}\n          }',
                         '\n          .b {color: #bbb;}\n          .c {color: #ccc;}',

--- a/testdata/transforms/bundleSystemJs/test-tree/node_modules/babel-core/browser.js
+++ b/testdata/transforms/bundleSystemJs/test-tree/node_modules/babel-core/browser.js
@@ -39107,7 +39107,7 @@ var baseCallback = require('../internal/baseCallback'),
  * ];
  *
  * // using the `_.property` callback shorthand
- * _.pluck(_.sortBy(users, 'user'), 'user');
+ * _.map(_.sortBy(users, 'user'), 'user');
  * // => ['barney', 'fred', 'pebbles']
  */
 function sortBy(collection, iteratee, thisArg) {
@@ -42767,7 +42767,7 @@ var baseProperty = require('../internal/baseProperty'),
  * _.map(objects, _.property('a.b.c'));
  * // => [2, 1]
  *
- * _.pluck(_.sortBy(objects, _.property(['a', 'b', 'c'])), 'a.b.c');
+ * _.map(_.sortBy(objects, _.property(['a', 'b', 'c'])), 'a.b.c');
  * // => [1, 2]
  */
 function property(path) {


### PR DESCRIPTION
I upgraded assetgraph-builder to lodash 4.9.0. They deprecated two methods we used, and that was also the only thing we had to change in assetgraph:

- `_.unique` was renamed to `_.uniq`
- `_.pluck` was removed as `_.map` did the same thing
    
https://github.com/lodash/lodash/wiki/Changelog#v400

---

But it wasn't smooth sailing here... I have no idea why, but two of the addCacheManifest tests started failing because of a leaked global called _text. But there's no such variable in lodash, or in any of the assetgraph code... :-/

Any ideas?

```
 assetgraph on feature/lodash4 $ mocha -g 'transforms/addCacheManifest'


  transforms/addCacheManifest
    1) should handle a single page with an existing cache manifest
    2) should handle a single page with an existing cache manifest
    ✓ should add a cache manifest to a page that does not already have one (40ms)
    ✓ should add cache manifest to multiple pages
    ✓ should add a cache manifest and update the existing one in a multi-page test case with one existing manifest


  3 passing (244ms)
  2 failing

  1) transforms/addCacheManifest should handle a single page with an existing cache manifest:
     Error: global leak detected: _text
      at lib/TransformQueue.js:52:25
      at node_modules/passerror/lib/passError.js:21:17
      at Object._onImmediate (lib/index.js:666:28)

  2) transforms/addCacheManifest should handle a single page with an existing cache manifest:
     Error: global leak detected: _text
      at lib/TransformQueue.js:52:25
      at node_modules/passerror/lib/passError.js:21:17
      at Object._onImmediate (lib/index.js:666:28)
```