### PR TITLE
Respect source root as prefix for all sources (same like Chrome, etc. do).

### DIFF
--- a/lib/assets/SourceMap.js
+++ b/lib/assets/SourceMap.js
@@ -71,6 +71,10 @@ extendWithGettersAndSetters(SourceMap.prototype, {
             }));
         }
         if (Array.isArray(parseTree.sources)) {
+            var sourceRoot = parseTree.sourceRoot || "";
+            if (sourceRoot && !sourceRoot.endsWith("/")) {
+                sourceRoot += "/";
+            }
             parseTree.sources.forEach(function (sourceUrl, i) {
                 outgoingRelations.push(new AssetGraph.SourceMapSource({
                     from: this,


### PR DESCRIPTION
Added missing part to prepend the „sourceRoot“ for all files references in „sources“. This seems to be identical to the behavior Chrome shows. „sourceRoot“ can be both: an URL prefix but also just a relative directory reference.