### PR TITLE
Added transform for manipulating the sourceRoot of source maps

### DIFF
--- a/lib/transforms/setSourceMapRoot.js
+++ b/lib/transforms/setSourceMapRoot.js
@@ -1,0 +1,18 @@
+var query = require('../query');
+
+module.exports = function (queryObj, root) {
+    var combinedQuery = {type: 'SourceMap'};
+    if (queryObj) {
+        combinedQuery = query.and(queryObj, combinedQuery);
+    }
+
+    return function setSourceMapRoot(assetGraph) {
+        assetGraph.findAssets(combinedQuery).forEach(function (mapFile) {
+            if (root) {
+                mapFile.parseTree.sourceRoot = root;
+            } else {
+                delete mapFile.parseTree.sourceRoot;
+            }
+        });
+    };
+};

--- a/test/transforms/setSourceMapRoot.js
+++ b/test/transforms/setSourceMapRoot.js
@@ -1,0 +1,16 @@
+/*global describe, it*/
+var expect = require('../unexpected-with-plugins'),
+    AssetGraph = require('../../lib');
+
+describe('transforms/setSourceMapRoot', function () {
+    it('should be able to modify source maps', function (done) {
+        new AssetGraph()
+            .loadAssets(new AssetGraph.SourceMap({text: '{"sourceRoot":"rootFolder"}'}))
+            .setSourceMapRoot(null, "otherFolder")
+            .queue(function (assetGraph) {
+                expect(assetGraph, 'to contain asset', 'SourceMap');
+                expect(assetGraph.findAssets({type: 'SourceMap'})[0].parseTree.sourceRoot, 'to equal', 'otherFolder');
+            })
+            .run(done);
+    });
+});

--- a/test/transforms/setSourceMapRoot.js
+++ b/test/transforms/setSourceMapRoot.js
@@ -3,13 +3,24 @@ var expect = require('../unexpected-with-plugins'),
     AssetGraph = require('../../lib');
 
 describe('transforms/setSourceMapRoot', function () {
-    it('should be able to modify source maps', function (done) {
+    it('should be able to modify source root', function (done) {
         new AssetGraph()
             .loadAssets(new AssetGraph.SourceMap({text: '{"sourceRoot":"rootFolder"}'}))
             .setSourceMapRoot(null, "otherFolder")
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain asset', 'SourceMap');
                 expect(assetGraph.findAssets({type: 'SourceMap'})[0].parseTree.sourceRoot, 'to equal', 'otherFolder');
+            })
+            .run(done);
+    });
+
+    it('should be able to delete source root', function (done) {
+        new AssetGraph()
+            .loadAssets(new AssetGraph.SourceMap({text: '{"sourceRoot":"rootFolder"}'}))
+            .setSourceMapRoot(null, null)
+            .queue(function (assetGraph) {
+                expect(assetGraph, 'to contain asset', 'SourceMap');
+                expect(assetGraph.findAssets({type: 'SourceMap'})[0].parseTree.sourceRoot, 'to equal', void 0);
             })
             .run(done);
     });


### PR DESCRIPTION
This allows for „batch“ updating the source root of source map files. This is super useful when moving sources incl. source maps around using `moveAssetsInOrder` e.g. for flattening/hashing assets. In these cases the sourceRoot has to be removed/resetted to lead to correct resolution of the individual source files.