### PR TITLE
Fix circular dependency with source maps when using moveAssetsInOrder transform

### DIFF
--- a/lib/transforms/moveAssetsInOrder.js
+++ b/lib/transforms/moveAssetsInOrder.js
@@ -12,7 +12,10 @@ function findAssetMoveOrderBatches(assetGraph, queryObj) {
 
     assetGraph.findAssets({isInline: false}).forEach(function (asset) {
         if (assetMatcher(asset)) {
-            outgoingRelationsByAssetId[asset.id] = assetGraph.findRelations({from: assetGraph.collectAssetsPostOrder(asset, {to: {isInline: true}}), to: {isInline: false}});
+            var relationFrom = assetGraph.collectAssetsPostOrder(asset, {to: {isInline: true}});
+            var relationTo = {isInline: false};
+            // Filter source map file relation to prevent possible recursion
+            outgoingRelationsByAssetId[asset.id] = assetGraph.findRelations({from: relationFrom, to: relationTo, type: query.not(["SourceMapFile"])});
         }
     });
 


### PR DESCRIPTION
With this fixed we are able to move everything, including source files references in source maps to a destination directory which gives us the awesomeness of a flat hashed directory not only containing the build files, but also the used source files.

Without this fixed it’s not possible to include source maps at all in the move process at otherwise we get cirular references which breaks the move tool.