### PR TITLE
Add preloadAssets transform

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -11,6 +11,23 @@ var util = require('util'),
     JavaScript = require('./JavaScript'),
     AssetGraph = require('../');
 
+// Polyfill HTMLElement.matches
+var Element = jsdom.defaultLevel.HTMLElement;
+if (!Element.prototype.matches) {
+    Element.prototype.matches =
+        Element.prototype.matchesSelector ||
+        Element.prototype.mozMatchesSelector ||
+        Element.prototype.msMatchesSelector ||
+        Element.prototype.oMatchesSelector ||
+        Element.prototype.webkitMatchesSelector ||
+        function (s) {
+            var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+                i = matches.length;
+            while (--i >= 0 && matches.item(i) !== this) {}
+            return i > -1;
+        };
+}
+
 function Html(config) {
     if (typeof config.isFragment !== 'undefined') {
         this._isFragment = config.isFragment;

--- a/lib/relations/HtmlPreloadLink.js
+++ b/lib/relations/HtmlPreloadLink.js
@@ -1,8 +1,16 @@
+/**
+ *  Implementation of http://w3c.github.io/preload/#dfn-preload
+ */
+
 var util = require('util'),
     extendWithGettersAndSetters = require('../util/extendWithGettersAndSetters'),
     HtmlRelation = require('./HtmlRelation');
 
 function HtmlPreloadLink(config) {
+    if (!config.to.url) {
+        throw new Error('HtmlPreloadLink: The `to` asset must have a url');
+    }
+
     HtmlRelation.call(this, config);
 }
 
@@ -23,6 +31,25 @@ extendWithGettersAndSetters(HtmlPreloadLink.prototype, {
         this.node.setAttribute('type', this.to.contentType);
         this.attachNodeBeforeOrAfter(position, adjacentRelation);
         return HtmlRelation.prototype.attach.call(this, asset, position, adjacentRelation);
+    },
+
+    attachToHead: function (asset, position, adjacentNode) {
+        this.node = asset.parseTree.createElement('link');
+        this.node.setAttribute('rel', 'preload');
+
+        if (this.as) {
+            this.node.setAttribute('as', this.as);
+        }
+
+        if (this.to.contentType) {
+            this.node.setAttribute('type', this.to.contentType);
+        }
+
+        HtmlRelation.prototype.attachToHead.call(this, asset, position, adjacentNode);
+
+        if (this.crossorigin) {
+            this.node.setAttribute('crossorigin', this.crossorigin);
+        }
     },
 
     inline: function () {

--- a/lib/relations/HtmlRelation.js
+++ b/lib/relations/HtmlRelation.js
@@ -22,6 +22,102 @@ extendWithGettersAndSetters(HtmlRelation.prototype, {
         return this;
     },
 
+    attachToHead: function (asset, position, adjacentNode) {
+        if (!asset || !asset.isAsset || asset.type !== 'Html') {
+            throw new Error('HtmlRelation.attachToHead: The "asset" parameter must be an Html asset');
+        }
+
+        if (['first', 'last', 'before', 'after'].indexOf(position) === -1) {
+            throw new Error('HtmlRelation.attachToHead: The "position" parameter must be either "first", "last", "before" or "after"');
+        }
+
+        if (position === 'before' || position === 'after') {
+            if (!adjacentNode) {
+                throw new Error('HtmlRelation.attachToHead: The "adjacentNode" parameter must be a DOM node if "position" parameter is "before" or "after"');
+            } else {
+                if (adjacentNode.parentNode !== asset.parseTree.head) {
+                    throw new Error('HtmlRelation.attachToHead: The "adjacentNode" parameter must be a DOM node inside <head>');
+                }
+            }
+        }
+
+        if (!this.node) {
+            throw new Error('HtmlRelation.attachToHead: `this.node` must be a HTML element');
+        }
+
+        var firstBodyRelation;
+        var document = asset.parseTree;
+        var head = document.head;
+
+        // Create head node if it's missing
+        if (!head) {
+            var htmlNode = document.querySelector('html');
+            head = document.createElement('head');
+
+            htmlNode.insertBefore(head, htmlNode.firstChild);
+        }
+
+        var headRelations = asset.outgoingRelations.filter(function (relation) {
+            return relation.node.parentNode === head;
+        });
+        var lastHeadRelation = headRelations[headRelations.length - 1];
+
+        // If there is nothing in <head>, figure out where this new relation fits in
+        if (headRelations.length === 0) {
+            firstBodyRelation = asset.outgoingRelations.find(function (relation) {
+                return relation.node.matches('body *');
+            });
+        }
+
+        if (position === 'first') {
+            head.insertBefore(this.node, head.firstChild);
+
+            if (headRelations[0]) {
+                return Relation.prototype.attach.call(this, asset, 'before', headRelations[0]);
+            } else if (firstBodyRelation) {
+                return Relation.prototype.attach.call(this, asset, 'before', firstBodyRelation);
+            } else {
+                return Relation.prototype.attach.call(this, asset, 'last');
+            }
+        }
+
+        if (position === 'last') {
+            head.appendChild(this.node);
+
+            if (lastHeadRelation) {
+                return Relation.prototype.attach.call(this, asset, 'after', lastHeadRelation);
+            } else if (firstBodyRelation) {
+                return Relation.prototype.attach.call(this, asset, 'before', firstBodyRelation);
+            } else {
+                return Relation.prototype.attach.call(this, asset, 'last');
+            }
+        }
+
+        // For 'before' and 'after' positions we split dom node insertion and relation attachment
+        if (position === 'before') {
+            head.insertBefore(this.node, adjacentNode);
+        }
+
+        if (position === 'after') {
+            head.insertBefore(this.node, adjacentNode.nextSibling);
+        }
+
+        // Figure out which assetgraph relation has a node after the inserted node
+        var headNodes = [].slice.call(head.childNodes);
+        var myNodeIdx = headNodes.indexOf(this.node);
+        var relativeRelation = headRelations.find(function (relation) {
+            return headNodes.indexOf(relation.node) > myNodeIdx;
+        });
+
+        if (relativeRelation) {
+            // Insert before the relation with a higher dom node index
+            return Relation.prototype.attach.call(this, asset, 'before', relativeRelation);
+        } else {
+            // Insert after last head relation
+            return Relation.prototype.attach.call(this, asset, 'after', lastHeadRelation);
+        }
+    },
+
     attachNodeBeforeOrAfter: function (position, adjacentRelation) {
         if (position !== 'before' && position !== 'after') {
             throw new Error('HtmlRelation._attachNode: The "position" parameter must be either "before" or "after"');

--- a/lib/transforms/preloadAssets.js
+++ b/lib/transforms/preloadAssets.js
@@ -1,0 +1,41 @@
+// Map Assetgraph relations to request destination (<link as="${destination}">).
+// See https://fetch.spec.whatwg.org/#concept-request-destination
+var RelationToType = {
+    'HtmlScript': 'script',
+    'HtmlStyle': 'style'
+    // FIXME: Add all relevant relation types
+};
+
+module.exports = function (queryObj) {
+
+    return function preloadAssets(assetGraph) {
+        // Gather all relations that make sense to preload
+        // FIXME: Have a discussion with community about a strategy here
+        var preloadRelations = assetGraph.findRelations({
+            type: ['HtmlStyle', 'HtmlScript'],
+            crossorigin: false,
+            to: {
+                url: function (url) { return url; } // not inline
+            }
+        }, true);
+
+        preloadRelations.forEach(function (relation) {
+            // Make sure a preload link doesn't already exist
+            var existingLink = relation.from.outgoingRelations.some(function (outgoing) {
+                return outgoing.type === 'HtmlPreloadLink' && outgoing.to.url === relation.to.url;
+            });
+
+            if (!existingLink) {
+                var preloadRelation = new assetGraph.HtmlPreloadLink({
+                    to: {
+                        url: relation.to.url
+                    },
+                    as: RelationToType[relation.type]
+                });
+
+                preloadRelation.attachToHead(relation.from, 'last');
+            }
+        });
+
+    };
+};

--- a/test/relations/HtmlRelation.js
+++ b/test/relations/HtmlRelation.js
@@ -1,0 +1,654 @@
+/*global describe, it*/
+var expect = require('../unexpected-with-plugins'),
+    AssetGraph = require('../../lib');
+
+describe('relations/HtmlRelation', function () {
+    describe('#attachToHead', function () {
+        var attachToHead = AssetGraph.HtmlRelation.prototype.attachToHead;
+
+        function getHtmlAsset(htmlString) {
+            var graph = new AssetGraph({ root: __dirname });
+            var htmlAsset = new AssetGraph.Html({
+                text: htmlString || '<!doctype html><html><head></head><body></body></html>',
+                url: 'doesntmatter.html'
+            });
+
+            graph.addAsset(htmlAsset);
+
+            return htmlAsset;
+        }
+
+        function getPreloadLink() {
+            return new AssetGraph.HtmlPreloadLink({
+                to: new AssetGraph.JavaScript({ text: '"use strict"', url: 'foo.js' })
+            });
+        }
+
+        function findRelation(asset, query) {
+            return asset.assetGraph.findRelations(query, true)[0];
+        }
+
+        describe('api', function () {
+            it('should throw when not passing an asset parameter', function () {
+                return expect(function () {
+                    attachToHead.call(null);
+                }, 'to throw', /must be an Html asset/);
+            });
+
+            it('should throw when not passing an asset parameter of the wrong type', function () {
+                return expect(function () {
+                    attachToHead.call(null, { isAsset: true, type: 'JavaScript'});
+                }, 'to throw', /must be an Html asset/);
+            });
+
+            it('should throw when not passing a position parameter', function () {
+                return expect(function () {
+                    attachToHead.call(null, { isAsset: true, type: 'Html'});
+                }, 'to throw', /The "position" parameter must be either "first", "last", "before" or "after"/);
+            });
+
+            it('should throw when passing a wrong position parameter', function () {
+                return expect(function () {
+                    attachToHead.call(null, { isAsset: true, type: 'Html'}, 'foo');
+                }, 'to throw', /The "position" parameter must be either "first", "last", "before" or "after"/);
+            });
+
+            it('should throw when not passing an adjacentNode parameter with a "before" position', function () {
+                return expect(function () {
+                    attachToHead.call(null, { isAsset: true, type: 'Html'}, 'before');
+                }, 'to throw', /The "adjacentNode" parameter must be a DOM node if "position" parameter is "before" or "after"/);
+            });
+
+            it('should throw when not passing an adjacentNode parameter with a "after" position', function () {
+                return expect(function () {
+                    attachToHead.call(null, { isAsset: true, type: 'Html'}, 'after');
+                }, 'to throw', /The "adjacentNode" parameter must be a DOM node if "position" parameter is "before" or "after"/);
+            });
+
+            it('should throw when not passing an adjacentNode that is not a child of <head>', function () {
+                var htmlAsset = getHtmlAsset();
+
+                return expect(function () {
+                    attachToHead.call(null, htmlAsset, 'after', htmlAsset.parseTree.body);
+                }, 'to throw', /The "adjacentNode" parameter must be a DOM node inside <head>/);
+            });
+
+            it('should throw when not defining a HTML element node on the calling scope', function () {
+                return expect(function () {
+                    attachToHead.call(null, { isAsset: true, type: 'Html'}, 'first');
+                }, 'to throw', /must be a HTML element/);
+            });
+        });
+
+        describe('with no <head> tag', function () {
+            it('should create a <head> tag', function () {
+                var html = getHtmlAsset('<html></html>');
+                var relation = getPreloadLink();
+
+                expect(html.parseTree.head, 'to be null');
+                expect(html.outgoingRelations, 'to satisfy', []);
+
+                relation.attachToHead(html, 'first');
+
+                expect(html.parseTree.head, 'not to be null');
+                expect(html.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', relation)
+                ]);
+            });
+        });
+
+        describe('with no relations in <head> tag', function () {
+            describe('with no relations in <body> tag', function () {
+                var html = '<!doctype html><html><head></head><body></body></html>';
+
+                it('should append relation node to <head> when using "first"-position', function () {
+                    var htmlAsset = getHtmlAsset(html);
+                    var relation = getPreloadLink();
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', []);
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', []);
+
+                    relation.attachToHead(htmlAsset, 'first');
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                        expect.it('to be', relation)
+                    ]);
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                        expect.it('to be', relation.node)
+                    ]);
+                });
+
+                it('should append relation node to <head> when using "last"-position', function () {
+                    var htmlAsset = getHtmlAsset(html);
+                    var relation = getPreloadLink();
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', []);
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', []);
+
+                    relation.attachToHead(htmlAsset, 'last');
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                        expect.it('to be', relation)
+                    ]);
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                        expect.it('to be', relation.node)
+                    ]);
+                });
+            });
+
+            describe('with relations in <body> tag', function () {
+                var html = '<!DOCTYPE html><html><head></head><body><script src="bundle.js"></script></body></html>';
+
+                it('should append relation node to <head> when using "first"-position', function () {
+                    var htmlAsset = getHtmlAsset(html);
+                    var relation = getPreloadLink();
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                        expect.it('to be', findRelation(htmlAsset, {
+                            type: 'HtmlScript',
+                            href: 'bundle.js'
+                        }))
+                    ]);
+
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', []);
+
+                    relation.attachToHead(htmlAsset, 'first');
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                        expect.it('to be', relation),
+                        expect.it('to be', findRelation(htmlAsset, {
+                            type: 'HtmlScript',
+                            href: 'bundle.js'
+                        }))
+                    ]);
+
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                        expect.it('to be', relation.node)
+                    ]);
+                });
+
+                it('should append relation node to <head> when using "last"-position', function () {
+                    var htmlAsset = getHtmlAsset(html);
+                    var relation = getPreloadLink();
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                        {
+                            type: 'HtmlScript',
+                            href: 'bundle.js'
+                        }
+                    ]);
+
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', []);
+
+                    relation.attachToHead(htmlAsset, 'last');
+
+                    expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                        expect.it('to be', relation),
+                        expect.it('to be', findRelation(htmlAsset, {
+                            type: 'HtmlScript',
+                            href: 'bundle.js'
+                        }))
+                    ]);
+
+                    expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                        expect.it('to be', relation.node)
+                    ]);
+                });
+            });
+        });
+
+        describe('with relations in <head> tag', function () {
+            var html = ['<!DOCTYPE html><html><head>',
+                '<meta id="tag1" charset="utf-8">',
+                '<link id="tag2" rel="shortcut icon" href="/favicon.ico">',
+                '<meta id="tag3" http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">',
+                '<link id="tag4" rel="shortcut icon" href="/favicon.svg">',
+                '<meta id="tag5" name="description" content="content description">',
+                '</head><body><script src="bundle.js"></script></body></html>'
+            ].join('');
+
+            it('should append relation node first in <head> when using "first"-position', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'first');
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    relation,
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', relation.node),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+            });
+
+            it('should append relation node last in <head> when using "last"-position', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'last');
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', relation),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5')),
+                    expect.it('to be', relation.node)
+                ]);
+            });
+
+            it('should append relation node before <link id="tag2" rel="shortcut icon" href="/favicon.ico">', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'before', htmlAsset.parseTree.querySelector('#tag2'));
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', relation),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', relation.node),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+            });
+
+            it('should append relation node after <meta id="tag1" charset="utf-8">', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'after', htmlAsset.parseTree.querySelector('#tag1'));
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', relation),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', relation.node),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+            });
+
+            it('should append relation node before <meta id="tag3" http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'before', htmlAsset.parseTree.querySelector('#tag3'));
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', relation),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', relation.node),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+            });
+
+            it('should append relation node after <meta id="tag3" http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'after', htmlAsset.parseTree.querySelector('#tag3'));
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', relation),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', relation.node),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+            });
+
+            it('should append relation node before <meta id="tag5" name="description" content="content description">', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'before', htmlAsset.parseTree.querySelector('#tag5'));
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', relation),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', relation.node),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+            });
+
+            it('should append relation node after <link id="tag4" rel="shortcut icon" href="/favicon.svg">', function () {
+                var htmlAsset = getHtmlAsset(html);
+                var relation = getPreloadLink();
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+
+                relation.attachToHead(htmlAsset, 'after', htmlAsset.parseTree.querySelector('#tag4'));
+
+                expect(htmlAsset.outgoingRelations, 'to satisfy', [
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.ico'
+                    })),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlShortcutIcon',
+                        href: '/favicon.svg'
+                    })),
+                    expect.it('to be', relation),
+                    expect.it('to be', findRelation(htmlAsset, {
+                        type: 'HtmlScript',
+                        href: 'bundle.js'
+                    }))
+                ]);
+
+                expect(htmlAsset.parseTree.head.childNodes, 'to satisfy', [
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag1')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag2')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag3')),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag4')),
+                    expect.it('to be', relation.node),
+                    expect.it('to be', htmlAsset.parseTree.querySelector('#tag5'))
+                ]);
+            });
+
+        });
+
+    });
+
+});

--- a/test/transforms/preloadAssets.js
+++ b/test/transforms/preloadAssets.js
@@ -1,0 +1,76 @@
+/*global describe, it*/
+var expect = require('../unexpected-with-plugins'),
+    AssetGraph = require('../../lib');
+
+describe('transforms/preloadAssets', function () {
+    it('should add preload link tags to document if they do not exist', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/transforms/preloadAssets/'})
+            .loadAssets('nolinks.html')
+            .queue(function (assetGraph) {
+                var html = assetGraph.findAssets({type: 'Html'})[0];
+
+                expect(html.parseTree.querySelectorAll('link[rel="preload"]'), 'to satisfy', []);
+            })
+            .preloadAssets()
+            .queue(function (assetGraph) {
+                var html = assetGraph.findAssets({type: 'Html'})[0];
+
+                expect(html.parseTree.querySelectorAll('link[rel="preload"]'), 'to satisfy', [
+                    {
+                        attributes: {
+                            as: 'style',
+                            href: 'bundle.css'
+                        }
+                    },
+                    {
+                        attributes: {
+                            as: 'script',
+                            href: 'bundle.js'
+                        }
+                    }
+                ]);
+            });
+    });
+
+    it('should not add preload link tags to document if they already exist', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/transforms/preloadAssets/'})
+            .loadAssets('preexistinglinks.html')
+            .queue(function (assetGraph) {
+                var html = assetGraph.findAssets({type: 'Html'})[0];
+
+                expect(html.parseTree.querySelectorAll('link[rel="preload"]'), 'to satisfy', [
+                    {
+                        attributes: {
+                            as: 'style',
+                            href: 'bundle.css'
+                        }
+                    },
+                    {
+                        attributes: {
+                            as: 'script',
+                            href: 'bundle.js'
+                        }
+                    }
+                ]);
+            })
+            .preloadAssets()
+            .queue(function (assetGraph) {
+                var html = assetGraph.findAssets({type: 'Html'})[0];
+
+                expect(html.parseTree.querySelectorAll('link[rel="preload"]'), 'to satisfy', [
+                    {
+                        attributes: {
+                            as: 'style',
+                            href: 'bundle.css'
+                        }
+                    },
+                    {
+                        attributes: {
+                            as: 'script',
+                            href: 'bundle.js'
+                        }
+                    }
+                ]);
+            });
+    });
+});

--- a/testdata/transforms/preloadAssets/nohead.html
+++ b/testdata/transforms/preloadAssets/nohead.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+    <script type="text/javascript" src="bundle.js"></script>
+</body>
+</html>

--- a/testdata/transforms/preloadAssets/nolinks.html
+++ b/testdata/transforms/preloadAssets/nolinks.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+
+    <link rel="stylesheet" type="text/css" href="bundle.css">
+</head>
+<body>
+
+    <script type="text/javascript" src="bundle.js"></script>
+    <script>
+        window.onload = function () {
+            console.log('loaded');
+        };
+    </script>
+</body>
+</html>

--- a/testdata/transforms/preloadAssets/preexistinglinks.html
+++ b/testdata/transforms/preloadAssets/preexistinglinks.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+
+    <link rel="preload" as="style" href="bundle.css">
+    <link rel="preload" as="script" href="bundle.js">
+
+    <link rel="stylesheet" type="text/css" href="bundle.css">
+</head>
+<body>
+
+    <script type="text/javascript" src="bundle.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This transform adds `<link rel="preload">` for relevant assets.

I had to create a new method `HtmlRelation.attachToHead` to be able to have fine grained control over positioning in the DOM. This method lets you define position relative to a dom node instead of an existing relation, which can be hard to trace down to a DOM position.

Before we merge this we need discussion on the following topics
- [ ] Should the transform take a query object and blindly follow it, or should it be highly opinionated about what gets preloaded and in what order?
- [ ] If we are opinionated, which assets are most important to preload?
- [ ] What is the best order of tags in `<head>` and where do the `<link rel="preload">`-tags go?