### PR TITLE
Update jsdom to 9.4.2.

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -226,7 +226,9 @@ extendWithGettersAndSetters(Html.prototype, {
                     'getElementById',
                     'getElementsByName'
                 ].forEach(function (methodName) {
-                    this._parseTree[methodName] = document[methodName].bind(document);
+                    if (typeof document[methodName] === 'function') {
+                        this._parseTree[methodName] = document[methodName].bind(document);
+                    }
                 }, this);
             } else {
                 this._parseTree = document;

--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -2,8 +2,7 @@
 var util = require('util'),
     _ = require('lodash'),
     esprima = require('esprima'),
-    jsdom = require('jsdom-papandreou'),
-    domtohtml = require('jsdom-papandreou/lib/jsdom/browser/domtohtml'),
+    jsdom = require('jsdom'),
     htmlMinifier = require('html-minifier'),
     extendWithGettersAndSetters = require('../util/extendWithGettersAndSetters'),
     errors = require('../errors'),
@@ -161,7 +160,7 @@ extendWithGettersAndSetters(Html.prototype, {
     get internalText() {
         if (typeof this._text !== 'string') {
             if (this._parseTree) {
-                this._text = domtohtml.domToHtml(this._parseTree, !this.isPretty);
+                this._text = this.isFragment ? this._parseTree.innerHTML : jsdom.serializeDocument(this._parseTree);
             } else {
                 this._text = this._replaceTemplates(this._getTextFromRawSrc());
             }
@@ -195,11 +194,11 @@ extendWithGettersAndSetters(Html.prototype, {
 
     get parseTree() {
         if (!this._parseTree) {
-            var text = this.internalText,
-                isEmpty = /^\s*$/.test(text);
+            var text = this.internalText;
+            var isFragment = this.isFragment;
+            var document;
             try {
-                // Compensate for jsdom 0.10.2+ creating <html><head></head><body>...</body> around the document if text === '':
-                this._parseTree = jsdom.jsdom(isEmpty ?  '<span></span>' : text, undefined, {
+                document = jsdom.jsdom(isFragment ? '<body>' + text + '</body>' : text, undefined, {
                     features: {
                         ProcessExternalResources: [],
                         FetchExternalResources: [],
@@ -214,9 +213,23 @@ extendWithGettersAndSetters(Html.prototype, {
                     throw err;
                 }
             }
-            if (isEmpty) {
-                // Remove the sole text node caused by the text === '' hack above:
-                this._parseTree.removeChild(this._parseTree.firstChild);
+            if (isFragment) {
+                this._parseTree = document.body;
+                // Install an assortment of bound methods from the document object on the parse tree:
+                [
+                    'createElement', 'createElementNS',
+                    'createTextNode', 'createComment', 'createDocumentFragment', 'createProcessingInstruction', 'importNode', 'adoptNode',
+                    'createAttribute', 'createAttributeNS',
+                    'createEvent',
+                    'createTreeWalker',
+                    'createNodeIterator',
+                    'getElementById',
+                    'getElementsByName'
+                ].forEach(function (methodName) {
+                    this._parseTree[methodName] = document[methodName].bind(document);
+                }, this);
+            } else {
+                this._parseTree = document;
             }
         }
         return this._parseTree;
@@ -230,9 +243,13 @@ extendWithGettersAndSetters(Html.prototype, {
 
     get isFragment() {
         if (typeof this._isFragment === 'undefined' && this.isLoaded) {
-            var document = this.parseTree;
-            this._isFragment = !document.doctype && !document.body &&
-                document.getElementsByTagName('head').length === 0;
+            if (this._parseTree) {
+                var document = this.parseTree;
+                this._isFragment = !document.doctype && !document.body &&
+                    document.getElementsByTagName('head').length === 0;
+            } else {
+                this._isFragment = !/<html/i.test(this.text);
+            }
         }
         return this._isFragment;
     },

--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -214,22 +214,17 @@ extendWithGettersAndSetters(Html.prototype, {
                 }
             }
             if (isFragment) {
-                this._parseTree = document.body;
-                // Install an assortment of bound methods from the document object on the parse tree:
-                [
-                    'createElement', 'createElementNS',
-                    'createTextNode', 'createComment', 'createDocumentFragment', 'createProcessingInstruction', 'importNode', 'adoptNode',
-                    'createAttribute', 'createAttributeNS',
-                    'createEvent',
-                    'createTreeWalker',
-                    'createNodeIterator',
-                    'getElementById',
-                    'getElementsByName'
-                ].forEach(function (methodName) {
-                    if (typeof document[methodName] === 'function') {
-                        this._parseTree[methodName] = document[methodName].bind(document);
+                // Install the properties of document on the HtmlBodyElement used as the parse tree:
+                for (var propertyName in document) {
+                    if (!(propertyName in document.body) && propertyName !== 'head') {
+                        if (typeof document[propertyName] === 'function') {
+                            document.body[propertyName] = document[propertyName].bind(document);
+                        } else {
+                            document.body[propertyName] = document[propertyName];
+                        }
                     }
-                }, this);
+                }
+                this._parseTree = document.body;
             } else {
                 this._parseTree = document;
             }

--- a/lib/relations/HtmlConditionalComment.js
+++ b/lib/relations/HtmlConditionalComment.js
@@ -27,7 +27,7 @@ extendWithGettersAndSetters(HtmlConditionalComment.prototype, {
     },
 
     attach: function (asset, position, adjacentRelation) {
-        this.node = asset.parseTree.createComment();
+        this.node = asset.parseTree.createComment('');
         this.attachNodeBeforeOrAfter(position, adjacentRelation);
         return HtmlRelation.prototype.attach.call(this, asset, position, adjacentRelation);
     }

--- a/lib/relations/HtmlEdgeSideIncludeSafeComment.js
+++ b/lib/relations/HtmlEdgeSideIncludeSafeComment.js
@@ -24,7 +24,7 @@ extendWithGettersAndSetters(HtmlEdgeSideIncludeSafeComment.prototype, {
     },
 
     attach: function (asset, position, adjacentRelation) {
-        this.node = asset.parseTree.createComment();
+        this.node = asset.parseTree.createComment('');
         this.attachNodeBeforeOrAfter(position, adjacentRelation);
         return HtmlRelation.prototype.attach.call(this, asset, position, adjacentRelation);
     }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "glob": "^7.0.5",
     "html-minifier": "^3.0.1",
     "imageinfo": "1.0.4",
-    "jsdom-papandreou": "0.11.0-patch4",
+    "jsdom": "9.4.2",
     "lodash": "^4.11.2",
     "mkdirp": "^0.5.1",
     "normalizeurl": "1.0.0",

--- a/test/assets/Asset.js
+++ b/test/assets/Asset.js
@@ -396,7 +396,7 @@ describe('assets/Asset', function () {
                     expect(asset.text, 'to contain', 'æøåÆØÅ');
                 });
 
-                expect(assetGraph.findAssets()[0].parseTree.body.firstChild.nodeValue, 'to equal', 'æøåÆØÅ');
+                expect(assetGraph.findAssets()[0].parseTree.body.firstChild.nodeValue, 'to begin with', 'æøåÆØÅ');
                 expect(assetGraph.findAssets()[0].rawSrc.toString('binary'), 'to contain', '\u00e6\u00f8\u00e5\u00c6\u00d8\u00c5');
             })
             .run(done);

--- a/test/assets/Html.js
+++ b/test/assets/Html.js
@@ -66,7 +66,7 @@ describe('assets/Html', function () {
             });
             htmlAsset.parseTree.body.firstChild.nodeValue = 'Not so much!';
             htmlAsset.markDirty();
-            expect(htmlAsset.text, 'to equal', '<!DOCTYPE html><html><body>Not so much!</body></html>');
+            expect(htmlAsset.text, 'to equal', '<!DOCTYPE html><html><head></head><body>Not so much!</body></html>');
         });
 
         it('should get text of AssetGraph.Html with rawSrcProxy and modified parse tree', function () {
@@ -78,7 +78,7 @@ describe('assets/Html', function () {
             return htmlAsset.load().then(function () {
                 htmlAsset.parseTree.body.firstChild.nodeValue = 'Not so much!';
                 htmlAsset.markDirty();
-                expect(htmlAsset.text, 'to equal', '<!DOCTYPE html><html><body>Not so much!</body></html>');
+                expect(htmlAsset.text, 'to equal', '<!DOCTYPE html><html><head></head><body>Not so much!</body></html>');
             });
         });
 
@@ -88,53 +88,53 @@ describe('assets/Html', function () {
             });
             htmlAsset.parseTree.body.firstChild.nodeValue = 'Not so much!';
             htmlAsset.markDirty();
-            expect(htmlAsset.text, 'to equal', '<!DOCTYPE html><html><body>Not so much!</body></html>');
+            expect(htmlAsset.text, 'to equal', '<!DOCTYPE html><html><head></head><body>Not so much!</body></html>');
         });
     });
 
     describe('#rawSrc', function () {
         it('should get rawSrc of AssetGraph.Html with rawSrc property', function () {
             expect(new AssetGraph.Html({
-                rawSrc: new Buffer('<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>')
-            }).rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>', 'utf-8'));
+                rawSrc: new Buffer('<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>')
+            }).rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>', 'utf-8'));
         });
 
         it('should get rawSrc of AssetGraph.Html with rawSrcProxy', function () {
             var asset = new AssetGraph.Html({
                 rawSrcProxy: function () {
-                    return Promise.resolve([new Buffer('<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>')]);
+                    return Promise.resolve([new Buffer('<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>')]);
                 }
             });
             return asset.load().then(function () {
-                expect(asset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>', 'utf-8'));
+                expect(asset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>', 'utf-8'));
             });
         });
 
         it('should get rawSrc of AssetGraph.Html instantiated with text property', function () {
             expect(new AssetGraph.Html({
-                text: '<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>'
-            }).rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>', 'utf-8'));
+                text: '<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>'
+            }).rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>', 'utf-8'));
         });
 
         it('should get rawSrc of AssetGraph.Html with rawSrc property and modified parse tree', function () {
             var htmlAsset = new AssetGraph.Html({
-                rawSrc: new Buffer('<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>')
+                rawSrc: new Buffer('<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>')
             });
             htmlAsset.parseTree.body.firstChild.nodeValue = 'Not so much!';
             htmlAsset.markDirty();
-            expect(htmlAsset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><body>Not so much!</body></html>', 'utf-8'));
+            expect(htmlAsset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><head></head><body>Not so much!</body></html>', 'utf-8'));
         });
 
         it('should get rawSrc of AssetGraph.Html with rawSrcProxy and modified parse tree', function () {
             var htmlAsset = new AssetGraph.Html({
                 rawSrcProxy: function () {
-                    return Promise.resolve([new Buffer('<!DOCTYPE html><html><body>Hello, world!\u263a</body></html>')]);
+                    return Promise.resolve([new Buffer('<!DOCTYPE html><html><head></head><body>Hello, world!\u263a</body></html>')]);
                 }
             });
             return htmlAsset.load().then(function () {
                 htmlAsset.parseTree.body.firstChild.nodeValue = 'Not so much!';
                 htmlAsset.markDirty();
-                expect(htmlAsset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><body>Not so much!</body></html>', 'utf-8'));
+                expect(htmlAsset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><head></head><body>Not so much!</body></html>', 'utf-8'));
             });
         });
 
@@ -144,7 +144,7 @@ describe('assets/Html', function () {
             });
             htmlAsset.parseTree.body.firstChild.nodeValue = 'Not so much!';
             htmlAsset.markDirty();
-            expect(htmlAsset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><body>Not so much!</body></html>', 'utf-8'));
+            expect(htmlAsset.rawSrc, 'to equal', new Buffer('<!DOCTYPE html><html><head></head><body>Not so much!</body></html>', 'utf-8'));
         });
     });
 
@@ -435,9 +435,9 @@ describe('assets/Html', function () {
 
         it('should remove whitespace between </title> and conditional comment in <head>', function () {
             expect(
-                '<html><head><title>The title</title> <!--[if lt IE 8]><![endif]--></head></html>',
+                '<html><head><title>The title</title> <!--[if lt IE 8]><![endif]--></head><body></body></html>',
                 'to minify to',
-                '<html><head><title>The title</title><!--[if lt IE 8]><![endif]--></head></html>'
+                '<html><head><title>The title</title><!--[if lt IE 8]><![endif]--></head><body></body></html>'
             );
         });
 

--- a/test/relations/HtmlEdgeSideInclude.js
+++ b/test/relations/HtmlEdgeSideInclude.js
@@ -18,7 +18,7 @@ describe('relations/HtmlEdgeSideInclude', function () {
                 expect(
                     assetGraph.findRelations({to: {url: /\.php$/}, type: 'HtmlEdgeSideInclude'}, true)[0].href,
                     'to equal',
-                     '../dynamicStuff/getTitleForReferringPage.php'
+                     '../dynamicStuff/metaTags.php'
                 );
             })
             .run(done);

--- a/test/relations/HtmlScript.js
+++ b/test/relations/HtmlScript.js
@@ -96,8 +96,8 @@ describe('relations/HtmlScript', function () {
             .run(done);
     });
 
-    it('should attach script node as the last node in document.head if there is no ocuemnt.body and no other scripts exist when using the `first` position', function (done) {
-        new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlScript/'})
+    it('should attach script node as the last node in document.body if no other scripts exist when using the `first` position', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlScript/'})
             .loadAssets(new AssetGraph.Html({
                 url: 'index.html',
                 text: '<html><head><title>first test</title></head></html>'
@@ -114,11 +114,10 @@ describe('relations/HtmlScript', function () {
 
                 relation.attach(html, 'first');
 
-                expect(relation.node.parentNode, 'not to be', document.body);
-                expect(relation.node.parentNode, 'to be', document.head);
-                expect(relation.node, 'to be', document.head.lastChild);
-            })
-            .run(done);
+                expect(relation.node.parentNode, 'not to be', document.head);
+                expect(relation.node.parentNode, 'to be', document.body);
+                expect(relation.node, 'to be', document.body.lastChild);
+            });
     });
 
     it('should attach script node before another when using the `before` position', function (done) {

--- a/test/relations/HtmlSvgIsland.js
+++ b/test/relations/HtmlSvgIsland.js
@@ -3,8 +3,8 @@ var expect = require('../unexpected-with-plugins'),
     AssetGraph = require('../../lib');
 
 describe('relations/HtmlSvgIsland', function () {
-    it('should handle a test case with an existing <svg> element', function (done) {
-        new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlSvgIsland/'})
+    it('should handle a test case with an existing <svg> element', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlSvgIsland/'})
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
@@ -12,9 +12,7 @@ describe('relations/HtmlSvgIsland', function () {
                 expect(assetGraph, 'to contain assets', 'Svg', 2);
                 expect(assetGraph, 'to contain asset', {type: 'Svg', isInline: true});
                 assetGraph.findAssets({fileName: 'gaussianBlur.svg'})[0].fileName = 'blah.svg';
-                expect(assetGraph.findAssets({type: 'Html'})[0].parseTree, 'queried for', 'svg use', 'to satisfy', [
-                    { attributes: { 'xlink:href': 'blah.svg' }}
-                ]);
+                expect(assetGraph.findAssets({type: 'Html'})[0].text, 'to contain', 'xlink:href="blah.svg"');
 
                 // Make sure that the set of attributes on the <svg> element in the containing document are synced with those
                 // on the documentElement of the inline asset:
@@ -30,7 +28,6 @@ describe('relations/HtmlSvgIsland', function () {
                         }
                     }
                 ]);
-            })
-            .run(done);
+            });
     });
 });

--- a/test/relations/JavaScriptGetText.js
+++ b/test/relations/JavaScriptGetText.js
@@ -13,13 +13,13 @@ describe('relations/JavaScriptGetText', function () {
             })
             .inlineRelations({type: 'JavaScriptGetText'})
             .queue(function (assetGraph) {
-                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><body>Boo!<\/body><\/html>\\n\1/);
+                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><head><\/head><body>Boo!<\/body><\/html>\\n\1/);
                 var htmlAsset = assetGraph.findAssets({type: 'Html', isInline: true})[0],
                     document = htmlAsset.parseTree;
                 document.body.appendChild(document.createElement('div')).appendChild(document.createTextNode('foo'));
                 htmlAsset.markDirty();
 
-                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><body>Boo!<div>foo<\/div><\/body><\/html>\\n\1/);
+                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><head><\/head><body>Boo!\\n<div>foo<\/div><\/body><\/html>\1/);
 
                 assetGraph.findAssets({type: 'Html', isInline: true})[0].url = 'http://example.com/template.html';
 

--- a/test/relations/JavaScriptTrHtml.js
+++ b/test/relations/JavaScriptTrHtml.js
@@ -26,7 +26,7 @@ describe('relations/JavaScriptTrHtml', function () {
 
                 expect(assetGraph.findRelations({type: 'JavaScriptTrHtml'})[0].href, 'to be undefined');
 
-                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><body>Boo!<div>foo<\/div><\/body><\/html>\\n\1/);
+                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><head><\/head><body>Boo!\\n<div>foo<\/div><\/body><\/html>\1/);
 
                 assetGraph.findAssets({type: 'Html', isInline: true})[0].url = 'http://example.com/template.html';
             });
@@ -47,14 +47,14 @@ describe('relations/JavaScriptTrHtml', function () {
             })
             .inlineRelations({type: 'JavaScriptTrHtml'})
             .queue(function (assetGraph) {
-                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><body>Boo!<\/body><\/html>\\n\1/);
+                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><head><\/head><body>Boo!<\/body><\/html>\\n\1/);
 
                 var htmlAsset = assetGraph.findAssets({type: 'Html', isInline: true})[0],
                     document = htmlAsset.parseTree;
                 document.body.appendChild(document.createElement('div')).appendChild(document.createTextNode('foo'));
                 htmlAsset.markDirty();
 
-                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><body>Boo!<div>foo<\/div><\/body><\/html>\\n\1/);
+                expect(assetGraph.findAssets({type: 'JavaScript'})[0].text, 'to match', /var myHtmlString\s*=\s*(['"])<html><head><\/head><body>Boo!\\n<div>foo<\/div><\/body><\/html>\1/);
             });
     });
 

--- a/test/resolvers/data.js
+++ b/test/resolvers/data.js
@@ -9,8 +9,8 @@ describe('resolvers/data', function () {
             .populate()
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain assets', 8);
-                expect(assetGraph.findAssets({type: 'Html'})[1].parseTree.body.firstChild.nodeValue, 'to equal', '\u263a');
-                expect(assetGraph.findAssets({type: 'Html'})[2].parseTree.body.firstChild.nodeValue, 'to equal', 'æøå');
+                expect(assetGraph.findAssets({type: 'Html'})[1].parseTree.body.firstChild.nodeValue, 'to equal', '\u263a\n');
+                expect(assetGraph.findAssets({type: 'Html'})[2].parseTree.body.firstChild.nodeValue, 'to equal', 'æøå\n');
                 expect(assetGraph.findAssets({type: 'Html'})[3].text, 'to match', /^<!DOCTYPE html>/);
                 expect(assetGraph.findAssets({type: 'Text'})[0].text, 'to equal', 'ΩδΦ');
                 expect(assetGraph.findAssets({type: 'Text'})[1].text, 'to equal', 'Hellö');

--- a/test/transforms/duplicateFavicon.js
+++ b/test/transforms/duplicateFavicon.js
@@ -19,14 +19,13 @@ describe('transforms.duplicateFavicon', function () {
                 expect(assetGraph, 'to contain asset', {url: urlTools.resolveUrl(assetGraph.root, 'favicon.ico')});
                 expect(assetGraph, 'to contain asset', {url: urlTools.resolveUrl(assetGraph.root, 'favicon.copy.ico')});
                 expect(assetGraph.findAssets({type: 'Html'})[0].text, 'to equal',
-                    '<!DOCTYPE html>\n' +
-                    '<html>\n' +
-                    '    <head>\n' +
+                    '<!DOCTYPE html><html><head>\n' +
                     '        <link rel="shortcut icon" href="favicon.copy.ico">\n' +
                     '    </head>\n' +
                     '    <body>\n' +
-                    '    </body>\n' +
-                    '</html>\n');
+                    '    \n' +
+                    '\n' +
+                    '</body></html>');
             });
     });
 
@@ -44,20 +43,18 @@ describe('transforms.duplicateFavicon', function () {
                 expect(assetGraph, 'to contain asset', {url: urlTools.resolveUrl(assetGraph.root, 'favicon.ico'), isInitial: true});
                 expect(assetGraph, 'to contain asset', {url: urlTools.resolveUrl(assetGraph.root, 'favicon.copy.ico'), isInitial: function (isInitial) {return !isInitial; }});
                 expect(assetGraph.findAssets({type: 'Html', fileName: 'index.html'})[0].text, 'to equal',
-                    '<!DOCTYPE html>\n' +
-                    '<html>\n' +
-                    '    <head>\n' +
+                    '<!DOCTYPE html><html><head>\n' +
                     '    <link rel="shortcut icon" href="favicon.copy.ico"></head>\n' +
                     '    <body>\n' +
-                    '    </body>\n' +
-                    '</html>\n'
+                    '    \n' +
+                    '\n' +
+                    '</body></html>'
                 );
                 expect(assetGraph.findAssets({type: 'Html', fileName: 'noHead.html'})[0].text, 'to equal',
-                    '<!DOCTYPE html>\n' +
-                    '<html><head><link rel="shortcut icon" href="favicon.copy.ico"></head>\n' +
-                    '    <body>\n' +
-                    '    </body>\n' +
-                    '</html>\n'
+                    '<!DOCTYPE html><html><head><link rel="shortcut icon" href="favicon.copy.ico"></head><body>\n' +
+                    '    \n' +
+                    '\n' +
+                    '</body></html>'
                 );
             });
     });

--- a/test/transforms/inlineHtmlTemplates.js
+++ b/test/transforms/inlineHtmlTemplates.js
@@ -38,7 +38,7 @@ describe('transforms/inlineHtmlTemplates', function () {
                     '<script type="text/html" id="theEmbeddedTemplate" foo="bar">\n    <h1>This is the embedded template, which should also end up in the main document</h1>\n</script>' +
                     '<script type="text/html" foo="bar1">\n    <h1>This embedded template has no id. This too should end up in the main document, along with it\'s attributes</h1>\n</script>' +
                     '<script type="text/html" foo="bar2">\n    <h1>This embedded template has no id. This too should end up in the main document, along with it\'s attributes</h1>\n</script>' +
-                    '<script type="text/html" id="foo"><img data-bind="attr: {src: \'/foo.png\'.toString(\'url\')}">\n</script><script type="text/html" id="bar"><div>\n    <h1>bar.ko</h1>\n</div>\n</script><script type="text/html" id="templateWithEmbeddedTemplate"><div data-bind="template: \'theEmbeddedTemplate\'"></div>\n\n\n\n</script></body>\n</html>\n'
+                    '<script type="text/html" id="foo"><img data-bind="attr: {src: \'/foo.png\'.toString(\'url\')}">\n</script><script type="text/html" id="bar"><div>\n    <h1>bar.ko</h1>\n</div>\n</script><script type="text/html" id="templateWithEmbeddedTemplate"><div data-bind="template: \'theEmbeddedTemplate\'"></div>\n\n\n\n</script></body></html>'
                 );
 
                 var relation = assetGraph.findRelations({type: 'HtmlInlineScriptTemplate', node: function (node) { return node.getAttribute('id') === 'foo'; }})[0];

--- a/test/transforms/minifySvgAssetsWithSvgo.js
+++ b/test/transforms/minifySvgAssetsWithSvgo.js
@@ -34,7 +34,7 @@ describe('transforms/minifySvgAssetsWithSvgo', function () {
                 expect(
                     assetGraph.findAssets({type: 'Html'})[0].text,
                     'to contain',
-                    '<svg role="img" viewbox="0 0 250 250"'
+                    '<svg viewBox="0 0 250 250" role="img"'
                 );
             });
     });

--- a/testdata/relations/HtmlEdgeSideInclude/index.html
+++ b/testdata/relations/HtmlEdgeSideInclude/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title><esi:include src='dynamicStuff/getTitleForReferringPage.php' /></title>
+    <title></title>
+    <esi:include src='dynamicStuff/metaTags.php' />
 </head>
 <body>
     <esi:include src='header.html' />

--- a/testdata/relations/JavaScriptGetText/template.html
+++ b/testdata/relations/JavaScriptGetText/template.html
@@ -1,1 +1,1 @@
-<html><body>Boo!</body></html>
+<html><head></head><body>Boo!</body></html>

--- a/testdata/relations/JavaScriptTrHtml/TrHtmlGetText/template.html
+++ b/testdata/relations/JavaScriptTrHtml/TrHtmlGetText/template.html
@@ -1,1 +1,1 @@
-<html><body>Boo!</body></html>
+<html><head></head><body>Boo!</body></html>


### PR DESCRIPTION
I think I got this working acceptably now.

I was eager to start using `jsdom.nodeLocation(node)` to fix generation of source maps of inline scripts and stylesheets, but turns out we need to wait for jsdom to update the parse5 module to 2.x. The parse5 currently used by jsdom only provides start/end index, but we need line/col to be able to be able to make proper source maps. The work is being tracked here: https://github.com/tmpvar/jsdom/pull/1316