### PR TITLE
Implement open graph relations support

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -582,6 +582,17 @@ extendWithGettersAndSetters(Html.prototype, {
                                 node: node
                             }));
                         }
+                    } else if (/^og:(?:url|image|audio|video)(?:(?:$|:)(?:url|secure_url|$))/.test(node.getAttribute('property')) && node.hasAttribute('content')) {
+                        if (this._isRelationUrl(node.getAttribute('content'))) {
+                            addOutgoingRelation(new AssetGraph.HtmlOpenGraph({
+                                from: this,
+                                to: {
+                                    url: node.getAttribute('content')
+                                },
+                                node: node,
+                                ogProperty: node.getAttribute('property')
+                            }));
+                        }
                     } else if (node.getAttribute('name') === 'msapplication-TileImage') {
                         if (this._isRelationUrl(node.getAttribute('content'))) {
                             addOutgoingRelation(new AssetGraph.HtmlMsApplicationTileImageMeta({

--- a/lib/relations/HtmlOpenGraph.js
+++ b/lib/relations/HtmlOpenGraph.js
@@ -1,0 +1,40 @@
+var util = require('util'),
+    extendWithGettersAndSetters = require('../util/extendWithGettersAndSetters'),
+    HtmlRelation = require('./HtmlRelation');
+
+function HtmlOpenGraph(config) {
+    if (!config.to || !config.to.url) {
+        throw new Error('HtmlOpenGraph: The `to` asset must have a url');
+    }
+
+    HtmlRelation.call(this, config);
+}
+
+util.inherits(HtmlOpenGraph, HtmlRelation);
+
+extendWithGettersAndSetters(HtmlOpenGraph.prototype, {
+    get href() {
+        return this.node.getAttribute('content');
+    },
+
+    set href(href) {
+        this.node.setAttribute('content', href);
+    },
+
+    attach: function (asset, position, adjacentRelation) {
+        throw new Error('Not implemented');
+    },
+
+    attachToHead: function (asset, position, adjacentNode) {
+        this.node = asset.parseTree.createElement('meta');
+        this.node.setAttribute('property', this.ogProperty);
+
+        HtmlRelation.prototype.attachToHead.call(this, asset, position, adjacentNode);
+    },
+
+    inline: function () {
+        throw new Error('HtmlOpenGraph: Inlining of open graph relations is not allowed');
+    }
+});
+
+module.exports = HtmlOpenGraph;

--- a/test/relations/HtmlOpenGraph.js
+++ b/test/relations/HtmlOpenGraph.js
@@ -1,0 +1,70 @@
+/*global describe, it*/
+var expect = require('../unexpected-with-plugins'),
+    AssetGraph = require('../../lib');
+
+describe('relations/HtmlOpenGraph', function () {
+    function getHtmlAsset(htmlString) {
+        var graph = new AssetGraph({ root: __dirname });
+        var htmlAsset = new AssetGraph.Html({
+            text: htmlString || '<!doctype html><html><head></head><body></body></html>',
+            url: 'file://' + __dirname + 'doesntmatter.html'
+        });
+
+        graph.addAsset(htmlAsset);
+
+        return htmlAsset;
+    }
+
+    describe('#inline', function () {
+        it('should throw', function () {
+            var relation = new AssetGraph.HtmlOpenGraph({
+                to: { url: 'index.html' }
+            });
+
+            expect(relation.inline, 'to throw', /Inlining of open graph relations is not allowed/);
+        });
+    });
+
+    it('should handle a test case with an existing <link rel="preconnect"> element', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlOpenGraph/'})
+            .loadAssets('index.html')
+            .queue(function (assetGraph) {
+                expect(assetGraph, 'to contain relation including unresolved', 'HtmlOpenGraph', 10);
+            });
+    });
+
+    it('should update the href', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlOpenGraph/'})
+            .loadAssets('index.html')
+            .queue(function (assetGraph) {
+                expect(assetGraph, 'to contain relation including unresolved', 'HtmlOpenGraph', 10);
+
+                var link = assetGraph.findRelations({ type: 'HtmlOpenGraph' }, true)[0];
+
+                link.to.url = 'foo.bar';
+                // This is necessary because link.to is an asset config object, not a real asset that will
+                // propagate url changes:
+                link.refreshHref();
+
+                expect(link, 'to satisfy', {
+                    href: 'foo.bar'
+                });
+            });
+    });
+
+    describe('when programmatically adding a relation', function () {
+        it('should handle crossorigin url', function () {
+            var htmlAsset = getHtmlAsset();
+            var relation = new AssetGraph.HtmlOpenGraph({
+                to: {
+                    url: 'http://assetgraph.org'
+                },
+                ogProperty: 'og:image'
+            });
+
+            relation.attachToHead(htmlAsset, 'first');
+
+            expect(htmlAsset.parseTree.head.firstChild, 'to exhaustively satisfy', '<meta property="og:image" content="http://assetgraph.org">');
+        });
+    });
+});

--- a/testdata/relations/HtmlOpenGraph/index.html
+++ b/testdata/relations/HtmlOpenGraph/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+
+    <meta property="og:url" content="http://assetgraph.org/">
+
+    <meta property="og:image" content="http://assetgraph.org/assets/images/logo-white.svg">
+    <meta property="og:image:url" content="http://assetgraph.org/assets/images/logo-white.svg">
+    <meta property="og:image:secure_url" content="https://assetgraph.org/assets/images/logo-white.svg">
+
+    <meta property="og:image:width" content="500">
+    <meta property="og:image:height" content="500">
+
+    <meta property="og:audio" content="http://assetgraph.org/assets/images/logo-white.svg">
+    <meta property="og:audio:url" content="http://assetgraph.org/assets/images/logo-white.svg">
+    <meta property="og:audio:secure_url" content="https://assetgraph.org/assets/images/logo-white.svg">
+
+    <meta property="og:video" content="http://assetgraph.org/assets/images/logo-white.svg">
+    <meta property="og:video:url" content="http://assetgraph.org/assets/images/logo-white.svg">
+    <meta property="og:video:secure_url" content="https://assetgraph.org/assets/images/logo-white.svg">
+
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #614 

Possibly not ready yet!

Issues to be resolved:
- [x] Should we (can we) get the content type from a sibling node of `<meta property="og:image:type" content="image/jpeg" />` ? **Conclusion: Lets rely on the existing type detection**
- [x] Should each type and sub type have their own relation instead of them all sharing the same and relying on `ogProperty` to figure out what property to set? **Conclusion: we don't care for now**