### PR TITLE
Add ability to handle canonical relative urls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ function AssetGraph(options) {
 
     // this.root might be undefined, in which case urlTools.urlOrFsPathToUrl will use process.cwd()
     this.root = normalizeUrl(urlTools.urlOrFsPathToUrl(this.root, true)); // ensureTrailingSlash
+    this.canonicalRoot = normalizeUrl(urlTools.urlOrFsPathToUrl(this.canonicalRoot, true)); // ensureTrailingSlash
 
     this._assets = [];
     this._relations = [];

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,15 +51,34 @@ var util = require('util'),
  * @api public
  */
 function AssetGraph(options) {
+    options = options || {};
+
     if (!(this instanceof AssetGraph)) {
         return new AssetGraph(options);
     }
     EventEmitter.call(this);
+
+    if ('canonicalRoot' in options) {
+        if (typeof options.canonicalRoot !== 'string') {
+            throw new Error('AssetGraph: options.canonicalRoot must be a URL string');
+        }
+
+        // Validate that the given canonicalRoot is actually a URL
+        // regexes lifted from one-validation fragments.domainPart and fragments.tld
+        if (!(/^(?:https?:)?\/\/[a-z0-9](?:[\-a-z0-9]*[a-z0-9])?\.[a-z][\-a-z]*[a-z]/i).test(options.canonicalRoot)) {
+            throw new Error('AssetGraph: options.canonicalRoot must be a URL string');
+        }
+
+        // Ensure trailing slash on canonical root
+        if (options.canonicalRoot[options.canonicalRoot.length - 1] !== '/') {
+            options.canonicalRoot += '/';
+        }
+    }
+
     _.extend(this, options);
 
     // this.root might be undefined, in which case urlTools.urlOrFsPathToUrl will use process.cwd()
     this.root = normalizeUrl(urlTools.urlOrFsPathToUrl(this.root, true)); // ensureTrailingSlash
-    this.canonicalRoot = normalizeUrl(urlTools.urlOrFsPathToUrl(this.canonicalRoot, true)); // ensureTrailingSlash
 
     this._assets = [];
     this._relations = [];

--- a/lib/index.js
+++ b/lib/index.js
@@ -383,6 +383,13 @@ _.extend(AssetGraph.prototype, {
                 url = assetConfig.url = that.resolveUrl(fromUrl, url);
             }
 
+            if (that.canonicalRoot) {
+                if (url.indexOf(that.canonicalRoot) === 0) {
+                    url = url.replace(that.canonicalRoot, that.root);
+                    assetConfig.url = url;
+                }
+            }
+
             var protocol = url.substr(0, url.indexOf(':')).toLowerCase();
             if (protocol === 'javascript') {
                 assetConfig.text = url.replace(/^javascript:/i, '');

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -111,6 +111,8 @@ Relation.prototype = {
                 href = urlTools.buildRootRelativeUrl(this.baseUrl, targetUrl, this.assetGraph && this.assetGraph.root);
             } else if (hrefType === 'relative') {
                 href = urlTools.buildRelativeUrl(this.baseUrl, targetUrl);
+            } else if (hrefType === 'canonical' && this.assetGraph) {
+                href = targetUrl.replace(this.assetGraph.root, this.assetGraph.canonicalRoot);
             } else if (hrefType === 'protocolRelative') {
                 href = urlTools.buildProtocolRelativeUrl(this.baseUrl, targetUrl);
             } else {
@@ -177,6 +179,8 @@ Relation.prototype = {
                 this._hrefType = 'protocolRelative';
             } else if (/^\//.test(href)) {
                 this._hrefType = 'rootRelative';
+            } else if (this.assetGraph && this.assetGraph.canonicalRoot && href.indexOf(this.assetGraph.canonicalRoot) === 0) {
+                this._hrefType = 'canonical';
             } else if (/^[a-z\+]+:/i.test(href)) {
                 this._hrefType = 'absolute';
             } else {

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -111,8 +111,6 @@ Relation.prototype = {
                 href = urlTools.buildRootRelativeUrl(this.baseUrl, targetUrl, this.assetGraph && this.assetGraph.root);
             } else if (hrefType === 'relative') {
                 href = urlTools.buildRelativeUrl(this.baseUrl, targetUrl);
-            } else if (hrefType === 'canonical' && this.assetGraph) {
-                href = targetUrl.replace(this.assetGraph.root, this.assetGraph.canonicalRoot);
             } else if (hrefType === 'protocolRelative') {
                 href = urlTools.buildProtocolRelativeUrl(this.baseUrl, targetUrl);
             } else {
@@ -123,6 +121,10 @@ Relation.prototype = {
             // Hack: Avoid adding index.html to an href pointing at file://.../index.html if it's not already there:
             if (/^file:\/\/.*\/index\.html(?:[?#]|$)/.test(targetUrl) && !/(?:^|\/)index\.html(?:[?#]:|$)/.test(this.href)) {
                 href = href.replace(/(^|\/)index\.html(?=[?#]|$)/, '$1');
+            }
+
+            if (this.canonical) {
+                href = href.replace(this.assetGraph.root, this.assetGraph.canonicalRoot);
             }
 
             if (this.href !== href) {
@@ -140,6 +142,9 @@ Relation.prototype = {
             // Inline
             return false;
         }
+        if (this.canonical) {
+            return false;
+        }
         var fromUrlObj = urlModule.parse(fromUrl);
         var toUrlObj = urlModule.parse(urlModule.resolve(fromUrl, toUrl));
         if (fromUrlObj.protocol !== toUrlObj.protocol || fromUrlObj.hostname !== toUrlObj.hostname) {
@@ -148,6 +153,36 @@ Relation.prototype = {
         var fromPort = fromUrlObj.port ? parseInt(fromUrlObj.port, 10) : {'http:': 80, 'https:': 443}[fromUrlObj.protocol];
         var toPort = toUrlObj.port ? parseInt(toUrlObj.port, 10) : {'http:': 80, 'https:': 443}[toUrlObj.protocol];
         return fromPort !== toPort;
+    },
+
+    get canonical() {
+        if (!('_canonical' in this)) {
+            var canonical = false;
+
+            if (this.assetGraph && this.assetGraph.canonicalRoot) {
+                var canonicalRootObj = urlModule.parse(this.assetGraph.canonicalRoot, false, true);
+                var hrefObj = urlModule.parse(this.href, false, true);
+
+                canonical = canonicalRootObj.host === hrefObj.host
+                    && hrefObj.path.indexOf(canonicalRootObj.path) === 0
+                    && (canonicalRootObj.protocol === hrefObj.protocol || canonicalRootObj.protocol === null);
+            }
+
+            this._canonical = canonical;
+        }
+
+        return this._canonical;
+    },
+
+    set canonical(isCanonical) {
+        this._canonical = !!isCanonical;
+
+        var hrefTypeRoot = this._canonical ? this.assetGraph.canonicalRoot : '';
+        // We need to update the hrefType manually here because otherwise hrefType in refreshHref
+        // will be based on the old href value, not the new one
+        this._hrefType = Object.getOwnPropertyDescriptor(Relation.prototype, 'hrefType').get.call({ href: hrefTypeRoot });
+
+        this.refreshHref();
     },
 
     get baseUrl() {
@@ -179,8 +214,6 @@ Relation.prototype = {
                 this._hrefType = 'protocolRelative';
             } else if (/^\//.test(href)) {
                 this._hrefType = 'rootRelative';
-            } else if (this.assetGraph && this.assetGraph.canonicalRoot && href.indexOf(this.assetGraph.canonicalRoot) === 0) {
-                this._hrefType = 'canonical';
             } else if (/^[a-z\+]+:/i.test(href)) {
                 this._hrefType = 'absolute';
             } else {

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -156,7 +156,7 @@ Relation.prototype = {
     },
 
     get canonical() {
-        if (!('_canonical' in this)) {
+        if (typeof this._canonical === 'undefined') {
             var canonical = false;
 
             if (this.assetGraph && this.assetGraph.canonicalRoot) {

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -337,7 +337,9 @@ Relation.prototype = {
         }
         var baseUrl = this.baseUrl;
         if (baseUrl) {
-            var resolvedAssetConfig = this.from.assetGraph.resolveAssetConfig(this.to, baseUrl);
+            var assetGraph = this.from.assetGraph;
+            var resolvedAssetConfig = assetGraph.resolveAssetConfig(this.to, baseUrl);
+
             this.to = resolvedAssetConfig;
             this.refreshHref();
             return this;

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -105,11 +105,12 @@ Relation.prototype = {
         // if (this.to.isInline) won't work because relation.to might be unresolved and thus not an Asset instance:
         var targetUrl = this.to && this.to.url;
         if (targetUrl) {
-            var hrefType = this.hrefType,
-                href;
-            if (hrefType === 'rootRelative') {
+            var canonical = this.canonical;
+            var hrefType = this.hrefType;
+            var href;
+            if (hrefType === 'rootRelative' && !canonical) {
                 href = urlTools.buildRootRelativeUrl(this.baseUrl, targetUrl, this.assetGraph && this.assetGraph.root);
-            } else if (hrefType === 'relative') {
+            } else if (hrefType === 'relative' && !canonical) {
                 href = urlTools.buildRelativeUrl(this.baseUrl, targetUrl);
             } else if (hrefType === 'protocolRelative') {
                 href = urlTools.buildProtocolRelativeUrl(this.baseUrl, targetUrl);
@@ -122,8 +123,7 @@ Relation.prototype = {
             if (/^file:\/\/.*\/index\.html(?:[?#]|$)/.test(targetUrl) && !/(?:^|\/)index\.html(?:[?#]:|$)/.test(this.href)) {
                 href = href.replace(/(^|\/)index\.html(?=[?#]|$)/, '$1');
             }
-
-            if (this.canonical) {
+            if (canonical) {
                 href = href.replace(this.assetGraph.root, this.assetGraph.canonicalRoot);
             }
 
@@ -175,14 +175,18 @@ Relation.prototype = {
     },
 
     set canonical(isCanonical) {
-        this._canonical = !!isCanonical;
+        isCanonical = !!isCanonical;
+        if (this._canonical !== isCanonical) {
+            this._canonical = isCanonical;
 
-        var hrefTypeRoot = this._canonical ? this.assetGraph.canonicalRoot : '';
-        // We need to update the hrefType manually here because otherwise hrefType in refreshHref
-        // will be based on the old href value, not the new one
-        this._hrefType = Object.getOwnPropertyDescriptor(Relation.prototype, 'hrefType').get.call({ href: hrefTypeRoot });
-
-        this.refreshHref();
+            if (!isCanonical && (this._hrefType === 'absolute' || this._hrefType !== 'protocolRelative')) {
+                // We're switching to non-canonical mode. Degrade the href type
+                // to rootRelative so we won't issue absolute file:// urls
+                // This is based on guesswork, though.
+                this._hrefType = 'rootRelative';
+            }
+            this.refreshHref();
+        }
     },
 
     get baseUrl() {

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -16,7 +16,7 @@ describe('Assetgraph', function () {
             }, 'to throw', /canonicalRoot must be a URL string/);
         });
 
-        it('should accept a http URL', function () {
+        it('should accept an http URL', function () {
             return expect(function () {
                 var ag = new AssetGraph({ canonicalRoot: 'http://fisk.dk/' });
 
@@ -24,7 +24,15 @@ describe('Assetgraph', function () {
             }, 'not to throw');
         });
 
-        it('should accept a http URL with a path', function () {
+        it('should add a trailing slash', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: 'http://fisk.dk' });
+
+                expect(ag.canonicalRoot, 'to be', 'http://fisk.dk/');
+            }, 'not to throw');
+        });
+
+        it('should accept an http URL with a path', function () {
             return expect(function () {
                 var ag = new AssetGraph({ canonicalRoot: 'http://fisk.dk/foo/bar/baz/' });
 
@@ -32,7 +40,15 @@ describe('Assetgraph', function () {
             }, 'not to throw');
         });
 
-        it('should accept a http URL with a subdomain', function () {
+        it('should accept an http URL with a port', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: 'http://fisk.dk:3000/' });
+
+                expect(ag.canonicalRoot, 'to be', 'http://fisk.dk:3000/');
+            }, 'not to throw');
+        });
+
+        it('should accept an http URL with a subdomain', function () {
             return expect(function () {
                 var ag = new AssetGraph({ canonicalRoot: 'http://sub.fisk.dk/' });
 
@@ -40,7 +56,7 @@ describe('Assetgraph', function () {
             }, 'not to throw');
         });
 
-        it('should accept a https URL', function () {
+        it('should accept an https URL', function () {
             return expect(function () {
                 var ag = new AssetGraph({ canonicalRoot: 'https://fisk.dk/' });
 

--- a/test/constructor.js
+++ b/test/constructor.js
@@ -1,0 +1,67 @@
+/*global describe, it*/
+var AssetGraph = require('../lib'),
+    expect = require('./unexpected-with-plugins');
+
+describe('Assetgraph', function () {
+    describe('canonicalRoot option', function () {
+        it('should throw when canonicalRoot is not a string', function () {
+            return expect(function () {
+                return new AssetGraph({ canonicalRoot: true });
+            }, 'to throw', /canonicalRoot must be a URL string/);
+        });
+
+        it('should throw when canonicalRoot is not a URL', function () {
+            return expect(function () {
+                return new AssetGraph({ canonicalRoot: 'foo' });
+            }, 'to throw', /canonicalRoot must be a URL string/);
+        });
+
+        it('should accept a http URL', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: 'http://fisk.dk/' });
+
+                expect(ag.canonicalRoot, 'to be', 'http://fisk.dk/');
+            }, 'not to throw');
+        });
+
+        it('should accept a http URL with a path', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: 'http://fisk.dk/foo/bar/baz/' });
+
+                expect(ag.canonicalRoot, 'to be', 'http://fisk.dk/foo/bar/baz/');
+            }, 'not to throw');
+        });
+
+        it('should accept a http URL with a subdomain', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: 'http://sub.fisk.dk/' });
+
+                expect(ag.canonicalRoot, 'to be', 'http://sub.fisk.dk/');
+            }, 'not to throw');
+        });
+
+        it('should accept a https URL', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: 'https://fisk.dk/' });
+
+                expect(ag.canonicalRoot, 'to be', 'https://fisk.dk/');
+            }, 'not to throw');
+        });
+
+        it('should accept a protocol relative URL', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: '//fisk.dk/' });
+
+                expect(ag.canonicalRoot, 'to be', '//fisk.dk/');
+            }, 'not to throw');
+        });
+
+        it('should ensure a trailing slash ', function () {
+            return expect(function () {
+                var ag = new AssetGraph({ canonicalRoot: '//fisk.dk' });
+
+                expect(ag.canonicalRoot, 'to be', '//fisk.dk/');
+            }, 'not to throw');
+        });
+    });
+});

--- a/test/relations/Relation.js
+++ b/test/relations/Relation.js
@@ -162,7 +162,7 @@ describe('relations/Relation', function () {
                 relation.canonical = true;
 
                 expect(relation, 'to satisfy', {
-                    hrefType: 'absolute',
+                    hrefType: 'relative',
                     canonical: true,
                     crossorigin: false,
                     href: 'http://canonical.com/local.js',
@@ -198,8 +198,8 @@ describe('relations/Relation', function () {
                 relation.canonical = false;
 
                 expect(relation, 'to satisfy', {
-                    hrefType: 'relative',
-                    href: 'local.js',
+                    hrefType: 'rootRelative',
+                    href: '/local.js',
                     to: {
                         url: 'file://' + pathModule.join(testDataDir, 'local.js')
                     }

--- a/test/relations/Relation.js
+++ b/test/relations/Relation.js
@@ -23,7 +23,7 @@ describe('relations/Relation', function () {
                     expect(_.map(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'hrefType'), 'to equal', [
                         'relative',
                         'rootRelative',
-                        'canonical',
+                        'absolute',
                         'protocolRelative',
                         'absolute'
                     ]);
@@ -57,7 +57,7 @@ describe('relations/Relation', function () {
                     expect(_.map(assetGraph.findRelations({type: 'HtmlAnchor'}, true), 'hrefType'), 'to equal', [
                         'relative',
                         'rootRelative',
-                        'canonical',
+                        'absolute',
                         'protocolRelative',
                         'absolute'
                     ]);
@@ -66,7 +66,7 @@ describe('relations/Relation', function () {
         });
     });
 
-    describe('with canonical hrefType', function () {
+    describe('#canonical', function () {
         var testDataDir = pathModule.resolve(__dirname + '/../../testdata/relations/Relation/canonicalHref/');
 
         it('should populate "canonical" from the local root', function () {
@@ -80,7 +80,9 @@ describe('relations/Relation', function () {
                 .queue(function (assetGraph) {
                     expect(assetGraph.findRelations(), 'to satisfy', [
                         {
-                            hrefType: 'canonical',
+                            canonical: true,
+                            crossorigin: false,
+                            hrefType: 'absolute',
                             href: 'http://canonical.com/local.js',
                             to: {
                                 url: 'file://' + pathModule.join(testDataDir, 'local.js')
@@ -102,7 +104,8 @@ describe('relations/Relation', function () {
                 .queue(function (assetGraph) {
                     expect(assetGraph.findRelations({}, true), 'to satisfy', [
                         {
-                            hrefType: 'canonical',
+                            hrefType: 'absolute',
+                            canonical: true,
                             crossorigin: false
                         }
                     ]);
@@ -136,7 +139,7 @@ describe('relations/Relation', function () {
             }, 'with http mocked out', [], 'not to error');
         });
 
-        it('should add the canonical root to a local file with canonical hrefType', function () {
+        it('should add the canonical root to the href of a local file', function () {
             return new AssetGraph({
                 root: testDataDir,
                 canonicalRoot: 'http://canonical.com/'
@@ -156,11 +159,47 @@ describe('relations/Relation', function () {
                     }
                 });
 
-                relation.hrefType = 'canonical';
+                relation.canonical = true;
 
                 expect(relation, 'to satisfy', {
-                    hrefType: 'canonical',
+                    hrefType: 'absolute',
+                    canonical: true,
+                    crossorigin: false,
                     href: 'http://canonical.com/local.js',
+                    to: {
+                        url: 'file://' + pathModule.join(testDataDir, 'local.js')
+                    }
+                });
+            });
+        });
+
+        it('should remove the canonical root fromthe href of a local file', function () {
+            return new AssetGraph({
+                root: testDataDir,
+                canonicalRoot: 'http://canonical.com/'
+            })
+            .loadAssets('canonical.html')
+            .populate()
+            .queue(function (assetGraph) {
+                expect(assetGraph, 'to contain relations', 1);
+
+                var relation = assetGraph.findRelations()[0];
+
+                expect(relation, 'to satisfy', {
+                    hrefType: 'absolute',
+                    canonical: true,
+                    crossorigin: false,
+                    href: 'http://canonical.com/local.js',
+                    to: {
+                        url: 'file://' + pathModule.join(testDataDir, 'local.js')
+                    }
+                });
+
+                relation.canonical = false;
+
+                expect(relation, 'to satisfy', {
+                    hrefType: 'relative',
+                    href: 'local.js',
                     to: {
                         url: 'file://' + pathModule.join(testDataDir, 'local.js')
                     }

--- a/test/relations/Relation.js
+++ b/test/relations/Relation.js
@@ -69,7 +69,7 @@ describe('relations/Relation', function () {
     describe('with canonical hrefType', function () {
         var testDataDir = pathModule.resolve(__dirname + '/../../testdata/relations/Relation/canonicalHref/');
 
-        it('should populate "canonical" similar to root relative', function () {
+        it('should populate "canonical" from the local root', function () {
             return expect(function () {
                 return new AssetGraph({
                     root: testDataDir,
@@ -88,16 +88,7 @@ describe('relations/Relation', function () {
                         }
                     ]);
                 });
-            }, 'with http mocked out', [
-                {
-                    request: 'GET http://canonical.com/local.js',
-                    response: {
-                        statusCode: 200,
-                        headers: 'Content-Type: application/javascript',
-                        body: new Buffer("console.log('Not the JavaScript you are looking for');")
-                    }
-                }
-            ], 'not to error');
+            }, 'with http mocked out', [], 'not to error');
         });
 
         it('should treat "canonical" as non-crossorigin', function () {
@@ -116,16 +107,33 @@ describe('relations/Relation', function () {
                         }
                     ]);
                 });
-            }, 'with http mocked out', [
-                {
-                    request: 'GET http://canonical.com/local.js',
-                    response: {
-                        statusCode: 200,
-                        headers: 'Content-Type: application/javascript',
-                        body: new Buffer("console.log('Not the JavaScript you are looking for');")
-                    }
-                }
-            ], 'not to error');
+            }, 'with http mocked out', [], 'not to error');
+        });
+
+        it('should keep "canonical" relative href when moving target asset', function () {
+            return expect(function () {
+                return new AssetGraph({
+                    root: testDataDir,
+                    canonicalRoot: 'http://canonical.com/'
+                })
+                .loadAssets('canonical.html')
+                .populate()
+                .queue(function (assetGraph) {
+                    expect(assetGraph, 'to contain relations', 1);
+
+                    var relation = assetGraph.findRelations()[0];
+
+                    expect(relation, 'to satisfy', {
+                        href: 'http://canonical.com/local.js'
+                    });
+
+                    relation.to.fileName = 'movedLocal.js';
+
+                    expect(relation, 'to satisfy', {
+                        href: 'http://canonical.com/movedLocal.js'
+                    });
+                });
+            }, 'with http mocked out', [], 'not to error');
         });
 
         it('should add the canonical root to a local file with canonical hrefType', function () {
@@ -158,7 +166,6 @@ describe('relations/Relation', function () {
                     }
                 });
             });
-
         });
     });
 

--- a/test/relations/Relation.js
+++ b/test/relations/Relation.js
@@ -173,7 +173,7 @@ describe('relations/Relation', function () {
             });
         });
 
-        it('should remove the canonical root fromthe href of a local file', function () {
+        it('should remove the canonical root from the href of a local file', function () {
             return new AssetGraph({
                 root: testDataDir,
                 canonicalRoot: 'http://canonical.com/'

--- a/testdata/relations/Relation/canonicalHref/canonical.html
+++ b/testdata/relations/Relation/canonicalHref/canonical.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+
+    <script src="http://canonical.com/local.js"></script>
+</head>
+<body>
+
+</body>
+</html>

--- a/testdata/relations/Relation/canonicalHref/local.html
+++ b/testdata/relations/Relation/canonicalHref/local.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+
+    <script src="local.js"></script>
+</head>
+<body>
+
+</body>
+</html>

--- a/testdata/relations/Relation/canonicalHref/local.js
+++ b/testdata/relations/Relation/canonicalHref/local.js
@@ -1,0 +1,1 @@
+console.log('I am a javascript');

--- a/testdata/relations/Relation/refreshHref/index.html
+++ b/testdata/relations/Relation/refreshHref/index.html
@@ -4,6 +4,7 @@
 <body>
     <a href="relative.html">Foo</a>
     <a href="/rootRelative.html">Foo</a>
+    <a href="http://canonical.com/canonical.html">Foo</a>
     <a href="//example.com/protocolRelative.html">Foo</a>
     <a href="http://example.com/absolute.html">Foo</a>
 </body>


### PR DESCRIPTION
This adds a new configuration for the assetgraph constructor: `canonicalRoot`
A new `relation.hrefType: 'canonical'`has also been added.

The idea is to let assetgraph populate any href to a URL that is inside the `canonicalRoot` as if it was inside `assetGraph.root`.

This will enable us to pick up absolute URL's, like you often see in blog setups like jekyll or wordpress, where the deployment domain is prepended to the url. The same problem goes for OpenGraph relations, where the specification says to use an absolute url, but the assets are locally available.

Am I even using canonical correctly at this point? Should this be called `deploymentRoot` and `deploymentRelative` instead?

Work in progress...