### PR TITLE
Make relations owned by the asset containing them

### DIFF
--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -575,10 +575,12 @@ extendWithGettersAndSetters(Asset.prototype, {
     },
 
     removeRelation: function (relation) {
-        var outgoingRelations = this.outgoingRelations;
-        var i = outgoingRelations.indexOf(relation);
-        if (i !== -1) {
-            outgoingRelations.splice(i, 1);
+        if (this._outgoingRelations) {
+            var outgoingRelations = this.outgoingRelations;
+            var i = outgoingRelations.indexOf(relation);
+            if (i !== -1) {
+                outgoingRelations.splice(i, 1);
+            }
         }
         return this;
     },

--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -396,16 +396,6 @@ extendWithGettersAndSetters(Asset.prototype, {
      * .rawSrc or .text.
      */
     unload: function () {
-        // Remove inline assets and outgoing relations:
-        if (this.assetGraph && this.isPopulated) {
-            this.outgoingRelations.forEach(function (outgoingRelation) {
-                this.assetGraph.removeRelation(outgoingRelation);
-                if (outgoingRelation.to.isAsset && outgoingRelation.to.isInline) {
-                    // Remove inline asset
-                    this.assetGraph.removeAsset(outgoingRelation.to);
-                }
-            }, this);
-        }
         this.isPopulated = undefined;
         this._outgoingRelations = undefined;
         this._rawSrc = undefined;
@@ -537,24 +527,60 @@ extendWithGettersAndSetters(Asset.prototype, {
      * asset.outgoingRelations (getter)
      * ================================
      *
-     * Get the outgoing relations of the asset. Only supported by a
-     * few subclasses (`Css`, `Html`, `CacheManifest`, and
-     * `JavaScript`), all others return an empty array.
-     *
-     * If the asset is part of an AssetGraph, it will be queried for
-     * the relations, otherwise the parse tree will be traversed.
+     * Get the outgoing relations of the asset.
      *
      * @return {Array[Relation]} The outgoing relations.
      * @api public
      */
     get outgoingRelations() {
-        if (this.assetGraph && this.isPopulated) {
-            return this.assetGraph.findRelations({from: this}, true);
-        }
         if (!this._outgoingRelations) {
             this._outgoingRelations = this.findOutgoingRelationsInParseTree();
         }
         return this._outgoingRelations;
+    },
+
+    set outgoingRelations(outgoingRelations) {
+        this._outgoingRelations = outgoingRelations;
+    },
+
+    addRelation: function (relation, position, adjacentRelation) {
+        if (!relation || !relation.id || !relation.isRelation) {
+            throw new Error('addRelation: Not a relation: ' + relation);
+        }
+        if (!relation.to) {
+            throw new Error('addRelation: \'to\' property of relation is missing');
+        }
+        relation.from = this;
+        relation.assetGraph = this.assetGraph;
+        position = position || 'last';
+        var outgoingRelations = this.outgoingRelations;
+        if (position === 'last') {
+            outgoingRelations.push(relation);
+        } else if (position === 'first') {
+            outgoingRelations.unshift(relation);
+        } else if (position === 'before' || position === 'after') { // Assume 'before' or 'after'
+            if (!adjacentRelation || !adjacentRelation.isRelation) {
+                throw new Error('addRelation: Adjacent relation is not a relation: ' + adjacentRelation);
+            }
+            var i = outgoingRelations.indexOf(adjacentRelation) + (position === 'after' ? 1 : 0);
+            if (i === -1) {
+                throw new Error('addRelation: Adjacent relation ' + adjacentRelation.toString() + ' is not among the outgoing relations of ' + this.urlOrDescription);
+            }
+            outgoingRelations.splice(i, 0, relation);
+        } else {
+            throw new Error('addRelation: Illegal \'position\' argument: ' + position);
+        }
+        this.assetGraph.emit('addRelation', relation); // Consider getting rid of this
+        return this;
+    },
+
+    removeRelation: function (relation) {
+        var outgoingRelations = this.outgoingRelations;
+        var i = outgoingRelations.indexOf(relation);
+        if (i !== -1) {
+            outgoingRelations.splice(i, 1);
+        }
+        return this;
     },
 
     get externalRelations() {
@@ -661,13 +687,10 @@ extendWithGettersAndSetters(Asset.prototype, {
                                 if (targetAssets.length) {
                                     outgoingRelation.to = targetAssets[targetAssets.length - 1];
                                 }
-
                             }
                         }
-                        this.assetGraph.addRelation(outgoingRelation);
                     } else {
                         // Inline asset
-                        this.assetGraph.addRelation(outgoingRelation);
                         if (!outgoingRelation.to.assetGraph) {
                             this.assetGraph.addAsset(outgoingRelation.to);
                         }
@@ -791,14 +814,9 @@ extendWithGettersAndSetters(Asset.prototype, {
                 }
                 incomingRelations.forEach(function (incomingRelation) {
                     if (!incomingRelation || !incomingRelation.isRelation) {
-                        throw new Error('asset.clone(): Incoming relation is not a relation: ', incomingRelation);
+                        throw new Error('asset.clone(): Incoming relation is not a relation: ' + incomingRelation.toString());
                     }
-                    if (this.assetGraph.idIndex[incomingRelation.id]) {
-                        incomingRelation.to = clone;
-                    } else {
-                        incomingRelation.to = clone;
-                        this.assetGraph.addRelation(incomingRelation); // Hmm, what about position and adjacentRelation?
-                    }
+                    incomingRelation.to = clone;
                     incomingRelation.refreshHref();
                 }, this);
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -197,7 +197,7 @@ _.extend(AssetGraph.prototype, {
             throw new Error('AssetGraph.removeAsset: ' + asset + ' not in graph');
         }
         if (asset._outgoingRelations) {
-            asset.outgoingRelations.forEach(function (outgoingRelation) {
+            [].concat(asset.outgoingRelations).forEach(function (outgoingRelation) {
                 if (outgoingRelation.to.isAsset && outgoingRelation.to.isInline) {
                     // Remove inline asset
                     this.removeAsset(outgoingRelation.to);

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,6 @@ function AssetGraph(options) {
     this.root = normalizeUrl(urlTools.urlOrFsPathToUrl(this.root, true)); // ensureTrailingSlash
 
     this._assets = [];
-    this._relations = [];
     this.idIndex = {};
 
     this.teepee = new Teepee({
@@ -197,14 +196,14 @@ _.extend(AssetGraph.prototype, {
         if (!this.idIndex[asset.id]) {
             throw new Error('AssetGraph.removeAsset: ' + asset + ' not in graph');
         }
-        asset._outgoingRelations = this.findRelations({from: asset}, true);
-        asset._outgoingRelations.forEach(function (outgoingRelation) {
-            this.removeRelation(outgoingRelation);
-            if (outgoingRelation.to.isAsset && outgoingRelation.to.isInline) {
-                // Remove inline asset
-                this.removeAsset(outgoingRelation.to);
-            }
-        }, this);
+        if (asset._outgoingRelations) {
+            asset.outgoingRelations.forEach(function (outgoingRelation) {
+                if (outgoingRelation.to.isAsset && outgoingRelation.to.isInline) {
+                    // Remove inline asset
+                    this.removeAsset(outgoingRelation.to);
+                }
+            }, this);
+        }
         this.findRelations({to: asset}).forEach(function (incomingRelation) {
             if (detachIncomingRelations) {
                 incomingRelation.detach();
@@ -221,98 +220,6 @@ _.extend(AssetGraph.prototype, {
         this.idIndex[asset.id] = undefined;
         asset.assetGraph = undefined;
         this.emit('removeAsset', asset);
-        return this;
-    },
-
-    /**
-     * assetGraph.addRelation(relation, position[, adjacentRelation])
-     * ==============================================================
-     *
-     * Add a relation to the graph.
-     *
-     * The ordering of certain relation types is significant
-     * (`HtmlScript`, for instance), so it's important that the order
-     * isn't scrambled in the indices. Therefore the caller must
-     * explicitly specify a position at which to insert the object.
-     *
-     * @param {Relation} relation The relation to add to the graph.
-     * @param {String} position "first", "last", "before", or "after".
-     * @param {Relation} adjacentRelation The adjacent relation, mandatory if position is "before" or "after".
-     * @return {AssetGraph} The AssetGraph instance (chaining-friendly).
-     * @api private
-     */
-    addRelation: function (relation, position, adjacentRelation) { // position and adjacentRelation are optional
-        if (Array.isArray(relation)) {
-            relation.forEach(function (_relation) {
-                this.addRelation(_relation, position, adjacentRelation);
-            }, this);
-            return;
-        }
-        if (!relation || !relation.id || !relation.isRelation) {
-            throw new Error('AssetGraph.addRelation: Not a relation: ' + relation);
-        }
-        if (this.idIndex[relation.id]) {
-            throw new Error('AssetGraph.addRelation: Relation already in graph: ' + relation);
-        }
-        if (!relation.from || !relation.from.isAsset) {
-            throw new Error('AssetGraph.addRelation: \'from\' property of relation is not an asset: ' + relation.from);
-        }
-        if (!this.idIndex[relation.from.id]) {
-            throw new Error('AssetGraph.addRelation: \'from\' property of relation is not in the graph: ' + relation.from);
-        }
-        if (!relation.to) {
-            throw new Error('AssetGraph.addRelation: \'to\' property of relation is missing');
-        }
-        position = position || 'last';
-        relation.assetGraph = this;
-        if (position === 'last') {
-            this._relations.push(relation);
-        } else if (position === 'first') {
-            this._relations.unshift(relation);
-        } else if (position === 'before' || position === 'after') { // Assume 'before' or 'after'
-            if (!adjacentRelation || !adjacentRelation.isRelation) {
-                throw new Error('AssetGraph.addRelation: Adjacent relation is not a relation: ' + adjacentRelation);
-            }
-            var i = this._relations.indexOf(adjacentRelation) + (position === 'after' ? 1 : 0);
-            if (i === -1) {
-                throw new Error('AssetGraph.addRelation: Adjacent relation is not in the graph: ' + adjacentRelation);
-            }
-            this._relations.splice(i, 0, relation);
-        } else {
-            throw new Error('AssetGraph.addRelation: Illegal \'position\' argument: ' + position);
-        }
-        this.idIndex[relation.id] = relation;
-        this.emit('addRelation', relation);
-        return this;
-    },
-
-    /**
-     * assetGraph.removeRelation(relation)
-     * ===================================
-     *
-     * Remove a relation from the graph. Leaves the relation attached
-     * to the source asset.
-     *
-     * @param {Relation} relation The relation to remove.
-     * @return {AssetGraph} The AssetGraph instance (chaining-friendly).
-     * @api public
-     */
-    removeRelation: function (relation) {
-        if (!relation || !relation.isRelation) {
-            throw new Error('AssetGraph.removeRelation: Not a relation: ' + relation);
-        }
-        if (!this.idIndex[relation.id]) {
-            throw new Error('AssetGraph.removeRelation: ' + relation + ' not in graph');
-        }
-        this.idIndex[relation.id] = undefined;
-        var relationIndex = this._relations.indexOf(relation);
-        if (relationIndex === -1) {
-            throw new Error('removeRelation: ' + relation + ' not in graph');
-        } else {
-            this._relations.splice(relationIndex, 1);
-        }
-        relation.assetGraph = undefined;
-        this.emit('removeRelation', relation);
         return this;
     },
 
@@ -375,7 +282,33 @@ _.extend(AssetGraph.prototype, {
      * @api public
      */
     findRelations: function (queryObj, includeUnpopulated) {
-        var relations = AssetGraph.query.queryAssetGraph(this, 'relation', queryObj);
+        var sourceAssets;
+        if (queryObj && typeof queryObj.from !== 'undefined') {
+            if (queryObj.from && queryObj.from.isAsset) {
+                sourceAssets = [queryObj.from];
+            } else if (queryObj.from && Array.isArray(queryObj.from)) {
+                sourceAssets = [];
+                queryObj.from.forEach(function (fromEntry) {
+                    if (fromEntry.isAsset) {
+                        sourceAssets.push(fromEntry);
+                    } else {
+                        Array.prototype.push.apply(sourceAssets, this.findAssets(fromEntry));
+                    }
+                }, this);
+                sourceAssets = _.uniq(sourceAssets);
+            } else {
+                sourceAssets = this.findAssets(queryObj.from);
+            }
+        } else {
+            sourceAssets = this._assets;
+        }
+        var candidateRelations = [];
+        sourceAssets.forEach(function (sourceAsset) {
+            if (sourceAsset.isLoaded && sourceAsset._outgoingRelations) {
+                Array.prototype.push.apply(candidateRelations, sourceAsset.outgoingRelations);
+            }
+        });
+        var relations = AssetGraph.query.queryAssetGraph(this, 'relation', queryObj, candidateRelations);
         if (includeUnpopulated) {
             return relations;
         } else {

--- a/lib/query.js
+++ b/lib/query.js
@@ -64,7 +64,7 @@ query.createPrefixMatcher = function (prefix) {
     };
 };
 
-query.queryAssetGraph = function (assetGraph, objType, queryObj) {
+query.queryAssetGraph = function (assetGraph, objType, queryObj, candidates) {
     queryObj = queryObj || {};
     var filters = [];
     if (typeof queryObj === 'function') {
@@ -87,7 +87,7 @@ query.queryAssetGraph = function (assetGraph, objType, queryObj) {
         }
         filters.unshift(query.queryObjToMatcherFunction(filteredQueryObj));
     }
-    var result = assetGraph['_' + objType + 's'];
+    var result = candidates || assetGraph['_' + objType + 's'];
 
     filters.forEach(function (filter) {
         result = result.filter(filter);

--- a/lib/relations/JavaScriptStaticUrl.js
+++ b/lib/relations/JavaScriptStaticUrl.js
@@ -15,11 +15,11 @@ extendWithGettersAndSetters(JavaScriptStaticUrl.prototype, {
     },
 
     set href(href) {
-        if (this.assetGraph && /^file:/.test(this.assetGraph.root) && href.indexOf(this.assetGraph.root) === 0) {
+        if (this.from && this.from.assetGraph && /^file:/.test(this.from.assetGraph.root) && href.indexOf(this.from.assetGraph.root) === 0) {
             // Hack: Force a root-relative url instead of an absolute file url
             // when eg. pointing back into the root from eg. a CDN and we
             // don't know the canonical root:
-            href = '/' + href.substr(this.assetGraph.root.length);
+            href = '/' + href.substr(this.from.assetGraph.root.length);
         }
         this.argumentNode.value = href;
     },

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -105,12 +105,13 @@ Relation.prototype = {
         // if (this.to.isInline) won't work because relation.to might be unresolved and thus not an Asset instance:
         var targetUrl = this.to && this.to.url;
         if (targetUrl) {
+            var assetGraph = this.from && this.from.assetGraph;
             var currentHref = this.href;
             var canonical = this.canonical;
             var hrefType = this.hrefType;
             var href;
             if (hrefType === 'rootRelative' && !canonical) {
-                href = urlTools.buildRootRelativeUrl(this.baseUrl, targetUrl, this.assetGraph && this.assetGraph.root);
+                href = urlTools.buildRootRelativeUrl(this.baseUrl, targetUrl, assetGraph && assetGraph.root);
             } else if (hrefType === 'relative' && !canonical) {
                 href = urlTools.buildRelativeUrl(this.baseUrl, targetUrl);
             } else if (hrefType === 'protocolRelative') {
@@ -119,13 +120,12 @@ Relation.prototype = {
                 // Absolute
                 href = this.to.url;
             }
-
             // Hack: Avoid adding index.html to an href pointing at file://.../index.html if it's not already there:
             if (/^file:\/\/.*\/index\.html(?:[?#]|$)/.test(targetUrl) && !/(?:^|\/)index\.html(?:[?#]:|$)/.test(this.href)) {
                 href = href.replace(/(^|\/)index\.html(?=[?#]|$)/, '$1');
             }
-            if (canonical) {
-                href = href.replace(this.assetGraph.root, this.assetGraph.canonicalRoot);
+            if (canonical && assetGraph) {
+                href = href.replace(assetGraph.root, assetGraph.canonicalRoot);
             }
             var matchCurrentFragment = currentHref && currentHref.match(/#.*$/);
             if (matchCurrentFragment) {
@@ -163,8 +163,8 @@ Relation.prototype = {
         if (typeof this._canonical === 'undefined') {
             var canonical = false;
 
-            if (this.href && this.assetGraph && this.assetGraph.canonicalRoot) {
-                var canonicalRootObj = urlModule.parse(this.assetGraph.canonicalRoot, false, true);
+            if (this.href && this.from && this.from.assetGraph && this.from.assetGraph.canonicalRoot) {
+                var canonicalRootObj = urlModule.parse(this.from.assetGraph.canonicalRoot, false, true);
                 var hrefObj = urlModule.parse(this.href, false, true);
 
                 canonical = hrefObj.slashes === true
@@ -181,7 +181,7 @@ Relation.prototype = {
     },
 
     set canonical(isCanonical) {
-        if (this.assetGraph && this.assetGraph.canonicalRoot) {
+        if (this.from && this.from.assetGraph && this.from.assetGraph.canonicalRoot) {
             isCanonical = !!isCanonical;
             if (this._canonical !== isCanonical) {
                 this._canonical = isCanonical;
@@ -299,11 +299,12 @@ Relation.prototype = {
      * @api public
      */
     attach: function (asset, position, adjacentRelation) {
+        if (this.from && this.from.outgoingRelations.indexOf(this) !== -1) {
+            this.remove();
+        }
         this.from = asset;
         this.from.markDirty();
-        if (this.from.assetGraph && !this.assetGraph) {
-            this.from.assetGraph.addRelation(this, position, adjacentRelation);
-        }
+        this.from.addRelation(this, position, adjacentRelation);
         if (this.to && this.to.url) {
             this.refreshHref();
         }
@@ -327,9 +328,7 @@ Relation.prototype = {
      */
     detach: function () {
         this.from.markDirty();
-        if (this.assetGraph) {
-            this.assetGraph.removeRelation(this);
-        }
+        this.remove();
         return this;
     },
 
@@ -345,10 +344,7 @@ Relation.prototype = {
      * @api public
      */
     remove: function () {
-        if (!this.assetGraph) {
-            throw new Error('relation.remove(): Not in a graph');
-        }
-        this.assetGraph.removeRelation(this);
+        this.from.removeRelation(this);
         return this;
     },
 
@@ -383,9 +379,7 @@ Relation.prototype = {
         var baseUrl = this.baseUrl;
         if (baseUrl) {
             var assetGraph = this.from.assetGraph;
-            var resolvedAssetConfig = assetGraph.resolveAssetConfig(this.to, baseUrl);
-
-            this.to = resolvedAssetConfig;
+            this.to = assetGraph.resolveAssetConfig(this.to, baseUrl);
             this.refreshHref();
             return this;
         } else {

--- a/lib/relations/SvgStyle.js
+++ b/lib/relations/SvgStyle.js
@@ -21,15 +21,14 @@ extendWithGettersAndSetters(SvgStyle.prototype, {
         document.insertBefore(styleSheetNode, document.getElementsByTagName('svg')[0]);
 
         var xmlStylesheet = new AssetGraph.XmlStylesheet({
-            from: this.from,
             to: this.to,
             node: styleSheetNode
         });
-        this.assetGraph.addRelation(xmlStylesheet);
+        this.from.addRelation(xmlStylesheet);
 
         // Cleanup
         this.node.parentNode.removeChild(this.node);
-        this.assetGraph.removeRelation(this);
+        this.from.removeRelation(this);
 
         this.from.markDirty();
 
@@ -55,7 +54,6 @@ extendWithGettersAndSetters(SvgStyle.prototype, {
             if (!inserted) {
                 svg.insertBefore(this.node, svg.firstChild);
             }
-
         } else {
             this.attachNodeBeforeOrAfter(position, adjacentRelation);
         }

--- a/lib/transforms/bundleRelations.js
+++ b/lib/transforms/bundleRelations.js
@@ -144,8 +144,8 @@ module.exports = function (queryObj, options) {
             var bundleAsset = new AssetGraph[type](constructorOptions);
 
             bundleAsset.url = urlTools.resolveUrl(assetGraph.root, 'bundle-' + bundleAsset.id + bundleAsset.extension);
-            bundleAsset._outgoingRelations = assetGraph.findRelations({from: assetsToBundle}, true);
-            bundleAsset._outgoingRelations.forEach(function (outgoingRelation) {
+            bundleAsset.outgoingRelations = assetGraph.findRelations({from: assetsToBundle}, true);
+            bundleAsset.outgoingRelations.forEach(function (outgoingRelation) {
                 outgoingRelation.remove();
                 outgoingRelation.from = bundleAsset;
             });

--- a/lib/transforms/bundleSystemJs.js
+++ b/lib/transforms/bundleSystemJs.js
@@ -755,7 +755,7 @@ module.exports = function (options) {
             if (pageIds.every(function (pageId) {
                 return ((aRelationsByPageId[pageId] || []).every(function (aRelation) {
                     return (bRelationsByPageId[pageId] || []).every(function (bRelation) {
-                        return assetGraph._relations.indexOf(aRelation) <= assetGraph._relations.indexOf(bRelation);
+                        return aRelation.from.outgoingRelations.indexOf(aRelation) <= bRelation.from.outgoingRelations.indexOf(bRelation);
                     });
                 }));
             })) {
@@ -763,7 +763,7 @@ module.exports = function (options) {
             } else if (pageIds.every(function (pageId) {
                 return ((bRelationsByPageId[pageId] || []).every(function (bRelation) {
                     return (aRelationsByPageId[pageId] || []).every(function (aRelation) {
-                        return assetGraph._relations.indexOf(bRelation) <= assetGraph._relations.indexOf(aRelation);
+                        return bRelation.from.outgoingRelations.indexOf(bRelation) <= aRelation.from.outgoingRelations.indexOf(aRelation);
                     });
                 }));
             })) {

--- a/lib/transforms/bundleWebpack.js
+++ b/lib/transforms/bundleWebpack.js
@@ -336,8 +336,8 @@ module.exports = function (queryObj, options) {
                         });
                         if (replacementsMade) {
                             asset.markDirty();
-                            asset._outgoingRelations.forEach(function (relation) {
-                                assetGraph.removeRelation(relation);
+                            asset.outgoingRelations.forEach(function (relation) {
+                                asset.removeRelation(relation);
                             });
                             asset._outgoingRelations = undefined;
                             asset.isPopulated = false;

--- a/lib/transforms/convertHtmlStylesToInlineCssImports.js
+++ b/lib/transforms/convertHtmlStylesToInlineCssImports.js
@@ -28,12 +28,11 @@ module.exports = function (queryObj) {
                 var cssImportRule = currentInlineCssAsset.parseTree.last;
 
                 var cssImport = new AssetGraph.CssImport({
-                    from: currentInlineCssAsset,
                     to: htmlStyle.to,
                     node: cssImportRule,
                     hrefType: htmlStyle.hrefType
                 });
-                assetGraph.addRelation(cssImport, 'last');
+                currentInlineCssAsset.addRelation(cssImport, 'last');
                 cssImport.refreshHref();
                 htmlStyle.detach();
             });

--- a/lib/transforms/convertStylesheetsToInlineStyles.js
+++ b/lib/transforms/convertStylesheetsToInlineStyles.js
@@ -62,11 +62,10 @@ module.exports = function (queryObj, media) {
                                     inlineCssAsset = new assetGraph.Css({text: 'bogusselector {}'});
                                     htmlStyleAttributeRelation = new AssetGraph.HtmlStyleAttribute({
                                         node: node,
-                                        from: htmlAsset,
                                         to: inlineCssAsset
                                     });
                                     assetGraph.addAsset(inlineCssAsset);
-                                    assetGraph.addRelation(htmlStyleAttributeRelation);
+                                    htmlAsset.addRelation(htmlStyleAttributeRelation);
                                 }
                                 var styleRuleIndex = inlineCssAsset.parseTree.nodes.length;
 
@@ -79,11 +78,10 @@ module.exports = function (queryObj, media) {
                                         return _node === node;
                                     }
                                 }).forEach(function (cssRelation) {
-                                    assetGraph.addRelation(new cssRelation.constructor({
+                                    inlineCssAsset.addRelation(new cssRelation.constructor({
                                         parentNode: inlineCssAsset.parseTree,
                                         node: inlineCssAsset.parseTree.nodes[0],
                                         propertyNode: inlineCssAsset.parseTree.nodes[styleRuleIndex],
-                                        from: inlineCssAsset,
                                         to: cssRelation.to
                                     }));
                                 });

--- a/lib/transforms/inlineHtmlTemplates.js
+++ b/lib/transforms/inlineHtmlTemplates.js
@@ -82,11 +82,10 @@ module.exports = function (queryObj) {
                     }
                     document.body.appendChild(node);
                     var htmlInlineScriptTemplate = new assetGraph.HtmlInlineScriptTemplate({
-                        from: htmlAsset,
                         to: relationToInline.to,
                         node: node
                     });
-                    assetGraph.addRelation(htmlInlineScriptTemplate);
+                    htmlAsset.addRelation(htmlInlineScriptTemplate);
                     htmlInlineScriptTemplate.inline();
                     // These are attached separately
                     assetGraph.findRelations({from: htmlInlineScriptTemplate.to, type: 'HtmlInlineScriptTemplate'}).forEach(function (htmlInlineScriptTemplate) {

--- a/lib/transforms/startOverIfAssetSourceFilesChange.js
+++ b/lib/transforms/startOverIfAssetSourceFilesChange.js
@@ -19,7 +19,7 @@ module.exports = function (queryObj) {
                 isIdle = false;
                 changedFilesByName = {};
                 assetGraph.findRelations().forEach(function (relation) {
-                    assetGraph.removeRelation(relation);
+                    relation.from.removeRelation(relation);
                 });
                 assetGraph.findAssets().forEach(function (asset) {
                     assetGraph.removeAsset(asset);

--- a/test/assets/Asset.js
+++ b/test/assets/Asset.js
@@ -382,7 +382,7 @@ describe('assets/Asset', function () {
 
                     expect(assetGraph, 'to contain assets', 'Png', 2);
                     assetGraph.findAssets({type: 'Css'}).forEach(function (cssAsset) {
-                        expect(assetGraph, 'to contain relations', {from: cssAsset, to: {isInline: true, isImage: true}}, 1);
+                        expect(assetGraph, 'to contain relation', {from: cssAsset, to: {isInline: true, isImage: true}});
                     });
                 })
                 .run(done);

--- a/test/findAssets.js
+++ b/test/findAssets.js
@@ -41,20 +41,17 @@ describe('AssetGraph.findAssets', function () {
 
                 expect(assetGraph, 'to contain no assets', {outgoing: {type: 'HtmlAnchor'}});
 
-                assetGraph.addRelation(new AssetGraph.HtmlAnchor({
-                    from: assetGraph.findAssets({text: 'a'})[0],
+
+                assetGraph.findAssets({text: 'a'})[0].addRelation(new AssetGraph.HtmlAnchor({
                     to: assetGraph.findAssets({text: 'b'})[0]
                 }));
-                assetGraph.addRelation(new AssetGraph.HtmlAnchor({ // Identical to the first
-                    from: assetGraph.findAssets({text: 'a'})[0],
+                assetGraph.findAssets({text: 'a'})[0].addRelation(new AssetGraph.HtmlAnchor({ // Identical to the first
                     to: assetGraph.findAssets({text: 'b'})[0]
                 }));
-                assetGraph.addRelation(new AssetGraph.HtmlAnchor({
-                    from: assetGraph.findAssets({text: 'a'})[0],
+                assetGraph.findAssets({text: 'a'})[0].addRelation(new AssetGraph.HtmlAnchor({
                     to: assetGraph.findAssets({text: 'c'})[0]
                 }));
-                assetGraph.addRelation(new AssetGraph.CssImage({
-                    from: assetGraph.findAssets({text: 'e'})[0],
+                assetGraph.findAssets({text: 'e'})[0].addRelation(new AssetGraph.CssImage({
                     to: assetGraph.findAssets({text: 'f'})[0]
                 }));
 

--- a/test/findRelations.js
+++ b/test/findRelations.js
@@ -4,8 +4,8 @@ var expect = require('./unexpected-with-plugins'),
     query = AssetGraph.query;
 
 describe('AssetGraph.findAssets', function () {
-    it('should handle a simple test case', function (done) {
-        new AssetGraph()
+    it('should handle a simple test case', function () {
+        return new AssetGraph()
             .loadAssets(
                 new AssetGraph.Html({url: 'a', text: 'a', foo: 'bar'}),
                 new AssetGraph.Html({url: 'b', text: 'b', foo: 'bar'}),
@@ -16,32 +16,25 @@ describe('AssetGraph.findAssets', function () {
             )
             .queue(
                 function (assetGraph) {
-                    assetGraph.addRelation(new AssetGraph.HtmlStyle({
-                        from: assetGraph.findAssets({text: 'a'})[0],
+                    assetGraph.findAssets({text: 'a'})[0].addRelation(new AssetGraph.HtmlStyle({
                         to: assetGraph.findAssets({text: 'd'})[0]
                     }));
-                    assetGraph.addRelation(new AssetGraph.HtmlAnchor({
-                        from: assetGraph.findAssets({text: 'a'})[0],
+                    assetGraph.findAssets({text: 'a'})[0].addRelation(new AssetGraph.HtmlAnchor({
                         to: assetGraph.findAssets({text: 'b'})[0]
                     }));
-                    assetGraph.addRelation(new AssetGraph.HtmlAnchor({
-                        from: assetGraph.findAssets({text: 'a'})[0],
+                    assetGraph.findAssets({text: 'a'})[0].addRelation(new AssetGraph.HtmlAnchor({
                         to: assetGraph.findAssets({text: 'c'})[0]
                     }));
-                    assetGraph.addRelation(new AssetGraph.HtmlAnchor({
-                        from: assetGraph.findAssets({text: 'b'})[0],
+                    assetGraph.findAssets({text: 'b'})[0].addRelation(new AssetGraph.HtmlAnchor({
                         to: assetGraph.findAssets({text: 'c'})[0]
                     }));
-                    assetGraph.addRelation(new AssetGraph.HtmlStyle({
-                        from: assetGraph.findAssets({text: 'b'})[0],
+                    assetGraph.findAssets({text: 'b'})[0].addRelation(new AssetGraph.HtmlStyle({
                         to: assetGraph.findAssets({text: 'e'})[0]
                     }));
-                    assetGraph.addRelation(new AssetGraph.CssImage({
-                        from: assetGraph.findAssets({text: 'd'})[0],
+                    assetGraph.findAssets({text: 'd'})[0].addRelation(new AssetGraph.CssImage({
                         to: assetGraph.findAssets({rawSrc: new Buffer('f')})[0]
                     }));
-                    assetGraph.addRelation(new AssetGraph.CssImage({
-                        from: assetGraph.findAssets({text: 'e'})[0],
+                    assetGraph.findAssets({text: 'e'})[0].addRelation(new AssetGraph.CssImage({
                         to: assetGraph.findAssets({rawSrc: new Buffer('f')})[0]
                     }));
                 }
@@ -96,7 +89,6 @@ describe('AssetGraph.findAssets', function () {
                         foo: function (val) {return typeof val === 'undefined';}
                     }
                 }, 1);
-            })
-            .run(done);
+            });
     });
 });

--- a/test/relations/CssAlphaImageLoader.js
+++ b/test/relations/CssAlphaImageLoader.js
@@ -4,8 +4,8 @@ var expect = require('../unexpected-with-plugins'),
     AssetGraph = require('../../lib');
 
 describe('relations/CssAlphaImageLoader', function () {
-    it('should handle a simple test case', function (done) {
-        new AssetGraph({root: __dirname + '/../../testdata/relations/CssAlphaImageLoader/'})
+    it('should handle a simple test case', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/relations/CssAlphaImageLoader/'})
             .loadAssets('index.html')
             .populate()
             .queue(function (assetGraph) {
@@ -27,7 +27,6 @@ describe('relations/CssAlphaImageLoader', function () {
 
                 expect(assetGraph.findAssets({type: 'Css'})[0].text, 'to contain', 'body {\n}')
                     .and('to contain', 'div {\n}');
-            })
-            .run(done);
+            });
     });
 });

--- a/test/relations/SvgStyle.js
+++ b/test/relations/SvgStyle.js
@@ -3,8 +3,8 @@ var expect = require('../unexpected-with-plugins'),
     AssetGraph = require('../../lib');
 
 describe('relations/SvgStyle', function () {
-    it('should handle a test case with inline <style> elements', function (done) {
-        new AssetGraph({root: __dirname + '/../../testdata/relations/SvgStyle/'})
+    it('should handle a test case with inline <style> elements', function () {
+        return new AssetGraph({root: __dirname + '/../../testdata/relations/SvgStyle/'})
             .loadAssets('kiwi.svg')
             .populate()
             .queue(function (assetGraph) {
@@ -69,7 +69,6 @@ describe('relations/SvgStyle', function () {
                 expect(assetGraph, 'to contain assets', 'Css', 3);
                 expect(svg.parseTree.getElementsByTagName('svg')[0].childNodes[0], 'to be', svgStyle.node);
                 expect(svg.parseTree.getElementsByTagName('svg')[0].childNodes[1], 'to be', cloneSvgStyle.node);
-            })
-            .run(done);
+            });
     });
 });

--- a/test/transforms/addCacheManifest.js
+++ b/test/transforms/addCacheManifest.js
@@ -87,12 +87,12 @@ describe('transforms/addCacheManifest', function () {
             .queue(function (assetGraph) {
                 expect(assetGraph, 'to contain assets', 'CacheManifest', 2);
 
-                var cacheManifest = assetGraph.findAssets({type: 'CacheManifest', incoming: {from: {url: /\/index\.html$/}}});
+                var cacheManifest = assetGraph.findAssets({type: 'CacheManifest', incoming: {from: {url: /\/index\.html$/}}})[0];
                 expect(assetGraph, 'to contain relations', {from: cacheManifest}, 2);
                 expect(assetGraph, 'to contain relation', {from: cacheManifest, to: {url: /\/foo\.png$/}});
                 expect(assetGraph, 'to contain relation', {from: cacheManifest, to: {url: /\/otherpage\.html$/}});
 
-                var otherCacheManifest = assetGraph.findAssets({type: 'CacheManifest', incoming: {from: {url: /\/otherpage\.html$/}}});
+                var otherCacheManifest = assetGraph.findAssets({type: 'CacheManifest', incoming: {from: {url: /\/otherpage\.html$/}}})[0];
                 expect(assetGraph, 'to contain relation', {from: otherCacheManifest});
                 expect(assetGraph.findRelations({from: cacheManifest})[0].to, 'to equal', assetGraph.findAssets({url: /\/foo\.png$/})[0]);
             })


### PR DESCRIPTION
This needs some more polish, but shows the general idea. ag-b tests don't pass yet.

Preserves the `findRelations` API (for now).

CC: @Munter
