### PR TITLE
Implement transform to inline critical CSS rules

### DIFF
--- a/lib/relations/HtmlRelation.js
+++ b/lib/relations/HtmlRelation.js
@@ -52,6 +52,13 @@ extendWithGettersAndSetters(HtmlRelation.prototype, {
         // Create head node if it's missing
         if (!head) {
             var htmlNode = document.querySelector('html');
+
+            if (!htmlNode) {
+                var err = new Error('HtmlRelation.attachToHead: Could not attach asset ' + this.to.toString() + ' to <head>. Missing <html> and <head>');
+                err.asset = asset;
+                throw err;
+            }
+
             head = document.createElement('head');
 
             htmlNode.insertBefore(head, htmlNode.firstChild);

--- a/lib/relations/HtmlStyle.js
+++ b/lib/relations/HtmlStyle.js
@@ -61,6 +61,20 @@ extendWithGettersAndSetters(HtmlStyle.prototype, {
         return this;
     },
 
+    attachToHead: function (asset, position, adjacentNode) {
+        var parseTree = asset.parseTree;
+
+        if (this.to.isInline) {
+            this.node = parseTree.createElement('style');
+            this.node.appendChild(parseTree.createTextNode(this.to.text));
+        } else {
+            this.node = parseTree.createElement('link');
+            this.node.setAttribute('rel', 'stylesheet');
+        }
+
+        HtmlRelation.prototype.attachToHead.call(this, asset, position, adjacentNode);
+    },
+
     attach: function (asset, position, adjacentRelation) {
         var parseTree = asset.parseTree,
             found = false;

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -21,7 +21,7 @@
 var postcss = require('postcss');
 
 function getDomNodesAboveFold(fold) {
-    var currentNode = fold.previousSibling || fold.parentNode;
+    var currentNode = fold;
     var criticalNodes = [];
 
     while (currentNode) {
@@ -33,7 +33,16 @@ function getDomNodesAboveFold(fold) {
             break;
         }
 
-        currentNode = currentNode.previousSibling || currentNode.parentNode;
+        if (currentNode.previousSibling) {
+            // Collect all child nodes of previous siblings
+            if (currentNode.previousSibling.nodeType === 1) {
+                Array.prototype.push.apply(criticalNodes, currentNode.previousSibling.querySelectorAll('*'));
+            }
+
+            currentNode = currentNode.previousSibling;
+        } else {
+            currentNode = currentNode.parentNode;
+        }
     }
 
     return criticalNodes;

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -1,0 +1,91 @@
+/*
+ * This transform works on an assumption about browser loading and rendering behavior of CSS:
+ * When a browser loads CSS in <head> it render blocks untill all CSS in <head> has loaded.
+ *
+ * This might be slow.
+ *
+ * To appear faster, browsers will render what they have in buffer already if they meet a style <link> in <body>
+ * before they dive into the render blocking load.
+ * This lets you potentially inline critical css in <head> and put the bulk of your CSS "below the fold".
+ * The effect will be a quick render with critical styles applied, just before the render blocking starts.
+ *
+ * We can leverage this behavior by letting the developer declaratively define their critical CSS if we
+ * treat <body> <link> ad "the fold", assuming that everything above it is critical and should have styling applied
+ * for the render flush that happens just before the <link> starts loading.
+ *
+ * Assetgraph can figure out what CSS to extract from the bundle and inline in <head> before the render blocking load starts.
+ * This way the developer will only have to place the <link> at the relevant place in the DOM and not think any more about
+ * builds and optimization.
+ */
+
+function getDomNodesAboveFold(fold) {
+    var currentNode = fold.previousSibling || fold.parentNode;
+    var criticalNodes = [];
+
+    while (currentNode) {
+        if (currentNode.nodeType === 1) {
+            criticalNodes.push(currentNode);
+        }
+
+        if (currentNode.tagName === 'BODY') {
+            break;
+        }
+
+        currentNode = currentNode.previousSibling || currentNode.parentNode;
+    }
+
+    return criticalNodes;
+}
+
+module.exports = function (options) {
+    options = options || {};
+
+    return function (assetGraph) {
+        // For each html page with <link> tags in <body> and not in <head>
+        var pages = assetGraph.findAssets({ type: 'Html', isLoaded: true, isInline: false })
+            .filter(function (page) {
+                var nodes = assetGraph.findRelations({ type: 'HtmlStyle', from: page, isInline: false }, true)
+                    .map(function (relation) { return relation.node; });
+
+                return nodes.every(function (node) {
+                    return node.matches('body link');
+                });
+            });
+
+        pages.forEach(function (page) {
+            // Find the first external HtmlStyle relation inside <body>
+            var fold = assetGraph.findRelations({ type: 'HtmlStyle', from: page, isInline: false }, true);
+
+            // Traverse back up the DOM to find all elements to check critical CSS for
+            var criticalNodes = getDomNodesAboveFold(fold);
+
+            // Find all CSS included on the page
+            var stylesheets = assetGraph.collectAssetsPreOrder(page, {
+                to: {
+                    type: 'Css'
+                }
+            });
+
+            // Create a new stylesheet with critical CSS rules
+            var criticalCss = new assetGraph.Css();
+
+            stylesheets.forEach(function (stylesheet) {
+                // For each critical DOM-node, check if each style rule applies
+                stylesheet.eachRuleInParseTree(function (cssRule) {
+                    var criticalMatch = criticalNodes.any(function (node) {
+                        return node.matches(cssRule.selector);
+                    });
+
+                    // Collect all matching style rules that match critical DOM-nodes
+                    if (criticalMatch) {
+                        // TODO
+                    }
+                });
+            });
+
+            // Inline critical stylesheet in <head>
+            // TODO
+        });
+
+    };
+};

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -40,7 +40,7 @@ function getDomNodesAboveFold(fold) {
 module.exports = function (options) {
     options = options || {};
 
-    return function (assetGraph) {
+    return function inlineCriticalCss(assetGraph) {
         // For each html page with <link> tags in <body> and not in <head>
         var pages = assetGraph.findAssets({ type: 'Html', isLoaded: true, isInline: false })
             .filter(function (page) {

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -30,6 +30,7 @@ function getDomNodesAboveFold(fold) {
         }
 
         if (currentNode.tagName === 'BODY') {
+            criticalNodes.push(currentNode.parentNode); // Lets get the <html> node in there as well
             break;
         }
 

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -48,8 +48,47 @@ function getDomNodesAboveFold(fold) {
     return criticalNodes;
 }
 
+var clonedAtRuleMap = [];
+
+function getClonedAtRuleScaffold(rule, root) {
+    clonedRule;
+    var cacheHit = clonedAtRuleMap.find(function (mapping) {
+        if (mapping.original === rule) {
+            return mapping.clone;
+        }
+    });
+
+    if (cacheHit) {
+        return cacheHit.clone;
+    }
+
+    var clonedRule = rule.clone();
+
+    clonedRule.removeAll();
+
+    clonedAtRuleMap.push({
+        original: rule,
+        clone: clonedRule
+    });
+
+    if (rule.parent.type === 'atrule') {
+        var parentRule = getClonedAtRuleScaffold(rule.parent, root);
+
+        clonedRule.parent = parentRule;
+
+        parentRule.nodes.push(clonedRule);
+    } else {
+        root.nodes.push(clonedRule);
+    }
+
+    return clonedRule;
+}
+
 module.exports = function (options) {
     options = options || {};
+
+    // Make sure to run on a clean slate on every invokation
+    clonedAtRuleMap = [];
 
     return function inlineCriticalCss(assetGraph) {
         // For each html page with <link> tags in <body> and not in <head>
@@ -113,9 +152,18 @@ module.exports = function (options) {
                     // Collect all matching style rules that match critical DOM-nodes
                     if (criticalMatch) {
                         var clonedRule = cssRule.clone();
-                        clonedRule.parent = criticalParseTree;
 
-                        criticalParseTree.nodes.push(clonedRule);
+                        if (cssRule.parent.type === 'atrule') {
+                            var parentRule = getClonedAtRuleScaffold(cssRule.parent, criticalParseTree);
+
+                            clonedRule.parent = parentRule;
+
+                            parentRule.nodes.push(clonedRule);
+                        } else {
+                            clonedRule.parent = criticalParseTree;
+
+                            criticalParseTree.nodes.push(clonedRule);
+                        }
                     }
                 });
             });

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -79,6 +79,7 @@ function getClonedAtRuleScaffold(rule, root) {
 
         parentRule.nodes.push(clonedRule);
     } else {
+        clonedRule.parent = root;
         root.nodes.push(clonedRule);
     }
 

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -72,7 +72,7 @@ module.exports = function (options) {
             stylesheets.forEach(function (stylesheet) {
                 // For each critical DOM-node, check if each style rule applies
                 stylesheet.eachRuleInParseTree(function (cssRule) {
-                    var criticalMatch = criticalNodes.any(function (node) {
+                    var criticalMatch = criticalNodes.some(function (node) {
                         return node.matches(cssRule.selector);
                     });
 

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -18,6 +18,8 @@
  * builds and optimization.
  */
 
+var postcss = require('postcss');
+
 function getDomNodesAboveFold(fold) {
     var currentNode = fold.previousSibling || fold.parentNode;
     var criticalNodes = [];
@@ -76,10 +78,8 @@ module.exports = function (options) {
                 return asset.type === 'Css';
             });
 
-            // Create a new stylesheet with critical CSS rules
-            var criticalCss = new assetGraph.Css({
-                text: ''
-            });
+
+            var criticalParseTree = postcss.parse('');
 
             stylesheets.forEach(function (stylesheet) {
                 // For each critical DOM-node, check if each style rule applies
@@ -89,25 +89,38 @@ module.exports = function (options) {
                     }
 
                     var criticalMatch = criticalNodes.some(function (node) {
-                        return node.matches(cssRule.selector);
+                        var match;
+
+                        try {
+                            match = node.matches(cssRule.selector);
+                        } catch (err) {
+                            // jsdom doesn't understand this selector
+                        }
+
+                        return match;
                     });
 
                     // Collect all matching style rules that match critical DOM-nodes
                     if (criticalMatch) {
-                        criticalCss.parseTree.nodes.push(cssRule.clone());
+                        var clonedRule = cssRule.clone();
+                        clonedRule.parent = criticalParseTree;
+
+                        criticalParseTree.nodes.push(clonedRule);
                     }
                 });
             });
 
             // Inline critical stylesheet in <head>
-            if (criticalCss.parseTree.nodes.length) {
+            if (criticalParseTree.nodes.length) {
                 var criticalRelation = new assetGraph.HtmlStyle({
-                    to: criticalCss
+                    to: new assetGraph.Css({
+                        parseTree: criticalParseTree
+                    })
                 });
 
                 try {
                     criticalRelation.attachToHead(page, 'last');
-                    assetGraph.addAsset(criticalCss);
+                    assetGraph.addAsset(criticalRelation.to);
                 } catch (err) {
                     if (err.message.match(/Missing <html> and <head>/)) {
                         assetGraph.emit('warn', err);
@@ -115,8 +128,6 @@ module.exports = function (options) {
                         throw err;
                     }
                 }
-
-                criticalCss.markDirty();
             }
         });
 

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -47,8 +47,14 @@ module.exports = function (options) {
         var pages = assetGraph
             .findAssets({ type: 'Html', isLoaded: true, isInline: false })
             .filter(function (page) {
-                return assetGraph
-                    .findRelations({ type: 'HtmlStyle', from: page, isInline: false }, true)
+                var relations = assetGraph
+                    .findRelations({ type: 'HtmlStyle', from: page, to: { isInline: false }}, true);
+
+                if (relations.length === 0) {
+                    return false;
+                }
+
+                return relations
                     .every(function (relation) {
                         return relation.node.matches('body link');
                     });
@@ -57,10 +63,6 @@ module.exports = function (options) {
         pages.forEach(function (page) {
             // Find the first external HtmlStyle relation inside <body>
             var cssRelations = assetGraph.findRelations({ type: 'HtmlStyle', from: page, to: { isInline: false }}, true);
-
-            if (!cssRelations[0]) {
-                return;
-            }
 
             var fold = cssRelations[0].node;
 

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -105,8 +105,16 @@ module.exports = function (options) {
                     to: criticalCss
                 });
 
-                criticalRelation.attachToHead(page, 'last');
-                assetGraph.addAsset(criticalCss);
+                try {
+                    criticalRelation.attachToHead(page, 'last');
+                    assetGraph.addAsset(criticalCss);
+                } catch (err) {
+                    if (err.message.match(/Missing <html> and <head>/)) {
+                        assetGraph.emit('warn', err);
+                    } else {
+                        throw err;
+                    }
+                }
 
                 criticalCss.markDirty();
             }

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -54,7 +54,14 @@ module.exports = function (options) {
 
         pages.forEach(function (page) {
             // Find the first external HtmlStyle relation inside <body>
-            var fold = assetGraph.findRelations({ type: 'HtmlStyle', from: page, isInline: false }, true);
+            var cssRelations = assetGraph.findRelations({ type: 'HtmlStyle', from: page, to: { isInline: false }}, true);
+            var fold;
+
+            if (cssRelations[0]) {
+                fold = cssRelations[0].node;
+            } else {
+                return;
+            }
 
             // Traverse back up the DOM to find all elements to check critical CSS for
             var criticalNodes = getDomNodesAboveFold(fold);
@@ -77,8 +84,11 @@ module.exports = function (options) {
             stylesheets.forEach(function (stylesheet) {
                 // For each critical DOM-node, check if each style rule applies
                 stylesheet.eachRuleInParseTree(function (cssRule) {
+                    if (!cssRule.selector) {
+                        return;
+                    }
+
                     var criticalMatch = criticalNodes.some(function (node) {
-                        console.log(node, cssRule.selector);
                         return node.matches(cssRule.selector);
                     });
 

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -94,14 +94,22 @@ module.exports = function (options) {
 
                     // Collect all matching style rules that match critical DOM-nodes
                     if (criticalMatch) {
-                        console.log('match', cssRule);
-                        // TODO
+                        criticalCss.parseTree.nodes.push(cssRule.clone());
                     }
                 });
             });
 
             // Inline critical stylesheet in <head>
-            // TODO
+            if (criticalCss.parseTree.nodes.length) {
+                var criticalRelation = new assetGraph.HtmlStyle({
+                    to: criticalCss
+                });
+
+                criticalRelation.attachToHead(page, 'last');
+                assetGraph.addAsset(criticalCss);
+
+                criticalCss.markDirty();
+            }
         });
 
     };

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -44,26 +44,25 @@ module.exports = function (options) {
 
     return function inlineCriticalCss(assetGraph) {
         // For each html page with <link> tags in <body> and not in <head>
-        var pages = assetGraph.findAssets({ type: 'Html', isLoaded: true, isInline: false })
+        var pages = assetGraph
+            .findAssets({ type: 'Html', isLoaded: true, isInline: false })
             .filter(function (page) {
-                var nodes = assetGraph.findRelations({ type: 'HtmlStyle', from: page, isInline: false }, true)
-                    .map(function (relation) { return relation.node; });
-
-                return nodes.every(function (node) {
-                    return node.matches('body link');
-                });
+                return assetGraph
+                    .findRelations({ type: 'HtmlStyle', from: page, isInline: false }, true)
+                    .every(function (relation) {
+                        return relation.node.matches('body link');
+                    });
             });
 
         pages.forEach(function (page) {
             // Find the first external HtmlStyle relation inside <body>
             var cssRelations = assetGraph.findRelations({ type: 'HtmlStyle', from: page, to: { isInline: false }}, true);
-            var fold;
 
-            if (cssRelations[0]) {
-                fold = cssRelations[0].node;
-            } else {
+            if (!cssRelations[0]) {
                 return;
             }
+
+            var fold = cssRelations[0].node;
 
             // Traverse back up the DOM to find all elements to check critical CSS for
             var criticalNodes = getDomNodesAboveFold(fold);

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -64,20 +64,27 @@ module.exports = function (options) {
                 to: {
                     type: 'Css'
                 }
+            })
+            .filter(function (asset) {
+                return asset.type === 'Css';
             });
 
             // Create a new stylesheet with critical CSS rules
-            var criticalCss = new assetGraph.Css();
+            var criticalCss = new assetGraph.Css({
+                text: ''
+            });
 
             stylesheets.forEach(function (stylesheet) {
                 // For each critical DOM-node, check if each style rule applies
                 stylesheet.eachRuleInParseTree(function (cssRule) {
                     var criticalMatch = criticalNodes.some(function (node) {
+                        console.log(node, cssRule.selector);
                         return node.matches(cssRule.selector);
                     });
 
                     // Collect all matching style rules that match critical DOM-nodes
                     if (criticalMatch) {
+                        console.log('match', cssRule);
                         // TODO
                     }
                 });

--- a/test/transforms/inlineCriticalCss.js
+++ b/test/transforms/inlineCriticalCss.js
@@ -79,6 +79,31 @@ describe('tranforms/inlineCriticalCss', function () {
             });
     });
 
+    it('should handle at-rule block nested CSS rules', function () {
+        return new AssetGraph({ root: __dirname + '/../../testdata/transforms/inlineCriticalCss/' })
+            .loadAssets('media.html')
+            .populate()
+            .inlineCriticalCss()
+            .queue(function (assetGraph) {
+                expect(assetGraph.findRelations({ type: 'HtmlStyle' }), 'to satisfy', [
+                    {
+                        to: {
+                            isInline: true,
+                            text: '@media screen {\n    h1 {\n        color: red\n    }\n    p {\n        color: green\n    }\n}@media print {\n    h1 {\n        background: black\n    }\n}'
+                        },
+                        node: function (node) {
+                            return node && node.parentNode && node.parentNode.tagName === 'HEAD';
+                        }
+                    },
+                    {
+                        to: {
+                            fileName: 'media.css'
+                        }
+                    }
+                ]);
+            });
+    });
+
     it('should combine with other CSS transforms without throwing', function () {
         return new AssetGraph({ root: __dirname + '/../../testdata/transforms/inlineCriticalCss/' })
             .loadAssets('simple.html')

--- a/test/transforms/inlineCriticalCss.js
+++ b/test/transforms/inlineCriticalCss.js
@@ -114,7 +114,7 @@ describe('tranforms/inlineCriticalCss', function () {
                     {
                         to: {
                             isInline: true,
-                            text: '@media screen {\n    h1 {\n        color: red\n    }\n    p {\n        color: green\n    }\n}@media print {\n    h1 {\n        background: black\n    }\n}'
+                            text: '@media screen {\n    h1 {\n        color: red\n    }\n    p {\n        color: green\n    }\n}\n@media print {\n    h1 {\n        background: black\n    }\n}'
                         },
                         node: function (node) {
                             return node && node.parentNode && node.parentNode.tagName === 'HEAD';

--- a/test/transforms/inlineCriticalCss.js
+++ b/test/transforms/inlineCriticalCss.js
@@ -64,7 +64,7 @@ describe('tranforms/inlineCriticalCss', function () {
                     {
                         to: {
                             isInline: true,
-                            text: 'h1 {\n    color: red\n}'
+                            text: 'h1 {\n    color: red\n}\na {\n    color: rebeccapurple\n}'
                         },
                         node: function (node) {
                             return node && node.parentNode && node.parentNode.tagName === 'HEAD';
@@ -94,7 +94,7 @@ describe('tranforms/inlineCriticalCss', function () {
                     {
                         to: {
                             isInline: true,
-                            text: 'h1{color:red}'
+                            text: 'h1{color:red}a{color:#639}'
                         },
                         node: function (node) {
                             return node && node.parentNode && node.parentNode.tagName === 'HEAD';

--- a/test/transforms/inlineCriticalCss.js
+++ b/test/transforms/inlineCriticalCss.js
@@ -26,4 +26,34 @@ describe('tranforms/inlineCriticalCss', function () {
                 ]);
             });
     });
+
+    it('should combine with other CSS transforms without throwing', function () {
+        return new AssetGraph({ root: __dirname + '/../../testdata/transforms/inlineCriticalCss/' })
+            .loadAssets('simple.html')
+            .populate()
+            .minifyAssets({isLoaded: true, isInline: false})
+            .inlineHtmlTemplates()
+            .bundleRelations({type: 'HtmlStyle', to: {type: 'Css', isLoaded: true}, node: function (node) {return !node.hasAttribute('nobundle');}})
+            .inlineCriticalCss()
+            .mergeIdenticalAssets({isLoaded: true, isInline: false, type: ['JavaScript', 'Css']}) // The bundling might produce several identical files, especially the 'oneBundlePerIncludingAsset' strategy.
+            .minifyAssets({isLoaded: true})
+            .queue(function (assetGraph) {
+                expect(assetGraph.findRelations({ type: 'HtmlStyle' }), 'to satisfy', [
+                    {
+                        to: {
+                            isInline: true,
+                            text: 'h1{color:red}'
+                        },
+                        node: function (node) {
+                            return node && node.parentNode && node.parentNode.tagName === 'HEAD';
+                        }
+                    },
+                    {
+                        to: {
+                            fileName: 'simple.css'
+                        }
+                    }
+                ]);
+            });
+    });
 });

--- a/test/transforms/inlineCriticalCss.js
+++ b/test/transforms/inlineCriticalCss.js
@@ -1,0 +1,25 @@
+var expect = require('../unexpected-with-plugins');
+var AssetGraph = require('../../lib');
+
+describe('tranforms/inlineCriticalCss', function () {
+    it('should inline the heading style of a simple test case', function () {
+        return new AssetGraph({ root: __dirname + '/../../testdata/transforms/inlineCriticalCss/' })
+            .loadAssets('simple.html')
+            .populate()
+            .inlineCriticalCss()
+            .queue(function (assetGraph) {
+                expect(assetGraph.findAssets({ type: 'Css' }), 'to satisfy', [
+                    {
+                        inline: true,
+                        text: 'h1{color:red}',
+                        node: function (node) {
+                            return node && node.parentNode && node.parentNode.tagName === 'HEAD';
+                        }
+                    },
+                    {
+                        fileName: 'simple.css'
+                    }
+                ]);
+            });
+    });
+});

--- a/test/transforms/inlineCriticalCss.js
+++ b/test/transforms/inlineCriticalCss.js
@@ -8,16 +8,20 @@ describe('tranforms/inlineCriticalCss', function () {
             .populate()
             .inlineCriticalCss()
             .queue(function (assetGraph) {
-                expect(assetGraph.findAssets({ type: 'Css' }), 'to satisfy', [
+                expect(assetGraph.findRelations({ type: 'HtmlStyle' }), 'to satisfy', [
                     {
-                        inline: true,
-                        text: 'h1{color:red}',
+                        to: {
+                            isInline: true,
+                            text: 'h1 {\n    color: red\n}'
+                        },
                         node: function (node) {
                             return node && node.parentNode && node.parentNode.tagName === 'HEAD';
                         }
                     },
                     {
-                        fileName: 'simple.css'
+                        to: {
+                            fileName: 'simple.css'
+                        }
                     }
                 ]);
             });

--- a/test/transforms/inlineCriticalCss.js
+++ b/test/transforms/inlineCriticalCss.js
@@ -79,6 +79,31 @@ describe('tranforms/inlineCriticalCss', function () {
             });
     });
 
+    it('should include the <html> node in critical nodes', function () {
+        return new AssetGraph({ root: __dirname + '/../../testdata/transforms/inlineCriticalCss/' })
+            .loadAssets('htmlnode.html')
+            .populate()
+            .inlineCriticalCss()
+            .queue(function (assetGraph) {
+                expect(assetGraph.findRelations({ type: 'HtmlStyle' }), 'to satisfy', [
+                    {
+                        to: {
+                            isInline: true,
+                            text: 'html {\n    color: red\n}'
+                        },
+                        node: function (node) {
+                            return node && node.parentNode && node.parentNode.tagName === 'HEAD';
+                        }
+                    },
+                    {
+                        to: {
+                            fileName: 'htmlnode.css'
+                        }
+                    }
+                ]);
+            });
+    });
+
     it('should handle at-rule block nested CSS rules', function () {
         return new AssetGraph({ root: __dirname + '/../../testdata/transforms/inlineCriticalCss/' })
             .loadAssets('media.html')

--- a/testdata/transforms/inlineCriticalCss/empty.html
+++ b/testdata/transforms/inlineCriticalCss/empty.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/testdata/transforms/inlineCriticalCss/htmlnode.css
+++ b/testdata/transforms/inlineCriticalCss/htmlnode.css
@@ -1,0 +1,3 @@
+html {
+    color:red;
+}

--- a/testdata/transforms/inlineCriticalCss/htmlnode.html
+++ b/testdata/transforms/inlineCriticalCss/htmlnode.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+</head>
+<body>
+
+<link rel="stylesheet" href="htmlnode.css">
+
+</body>
+</html>

--- a/testdata/transforms/inlineCriticalCss/media.css
+++ b/testdata/transforms/inlineCriticalCss/media.css
@@ -1,0 +1,19 @@
+@media screen {
+    h1 {
+        color: red;
+    }
+
+    p {
+        color: green;
+    }
+
+    hr {
+        border: 1px solid hotpink;
+    }
+}
+
+@media print {
+    h1 {
+        background: black;
+    }
+}

--- a/testdata/transforms/inlineCriticalCss/media.html
+++ b/testdata/transforms/inlineCriticalCss/media.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+</head>
+<body>
+    <h1>Hello world</h1>
+
+    <p>lorem ipsum</p>
+
+    <link rel="stylesheet" href="media.css">
+</body>
+</html>

--- a/testdata/transforms/inlineCriticalCss/missing-structure.html
+++ b/testdata/transforms/inlineCriticalCss/missing-structure.html
@@ -1,0 +1,5 @@
+<body>
+    <h1>Hello breakage</h1>
+    <link rel="stylesheet" href="simple.css">
+
+</body>

--- a/testdata/transforms/inlineCriticalCss/simple.css
+++ b/testdata/transforms/inlineCriticalCss/simple.css
@@ -1,3 +1,5 @@
 h1 { color: red; }
 
 p { color: blue; }
+
+a { color: rebeccapurple; }

--- a/testdata/transforms/inlineCriticalCss/simple.css
+++ b/testdata/transforms/inlineCriticalCss/simple.css
@@ -1,0 +1,3 @@
+h1 { color: red; }
+
+p { color: blue; }

--- a/testdata/transforms/inlineCriticalCss/simple.html
+++ b/testdata/transforms/inlineCriticalCss/simple.html
@@ -4,7 +4,7 @@
 </head>
 <body>
 
-    <h1>Red</h1>
+    <h1>Red <a href="#">Rebecca</a></h1>
 
     <link rel="stylesheet" href="simple.css">
 

--- a/testdata/transforms/inlineCriticalCss/simple.html
+++ b/testdata/transforms/inlineCriticalCss/simple.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+</head>
+<body>
+
+    <h1>Red</h1>
+
+    <link rel="stylesheet" href="simple.css">
+
+    <p>Blue</p>
+
+</body>
+</html>


### PR DESCRIPTION
This transform looks for all `Html`-assets that have their first `<link rel="stylesheet">` inside the `<body>`-element.

For each of these pages it collects all DOM-elements that appear on the page before the first `<link rel="stylesheet">`. These are the DOM-elements that are treated as critical to have styled immediately when the brower does its initial render flush.

For each of the critical DOM-nodes it finds the CSS selectors in the pages dependency graph that apply to the node.

CSS selectors matching critical DOM-nodes are then cloned into an inline stylesheet in the pages `<head>`, thus ensuring styling on the critical nodes on the browsers first render flush.

This is particularly useful in Edge and Firefox, but will also yield improved results in Chrome according to [Chromes intent to implement parser blocking for external stylesheets in body](https://groups.google.com/a/chromium.org/forum/#!topic/blink-dev/ZAPP8aTnyn0) and [Jake Archibalds writeup on link in body behavior](https://jakearchibald.com/2016/link-in-body/)

For a developer to trigger critical CSS inlining, all that is needed is to move the first `<link rel="stylesheet">` into the `<body>` at a relevant position, where it will declaratively denote "the fold" with critical content above and less critical content below.

Example output of [mntr.dk](https://mntr.dk) with stylesheets in body and transform applied: http://doubtful-scissors.surge.sh/ (view source)