### PR TITLE
Implement assets/MsApplicationConfig. Refs #636

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -575,6 +575,7 @@ extendWithGettersAndSetters(Html.prototype, {
                         addOutgoingRelation(new AssetGraph.HtmlMsApplicationConfig({
                             from: this,
                             to: {
+                                type: 'MsApplicationConfig',
                                 url: node.getAttribute('content')
                             },
                             node: node

--- a/lib/assets/MsApplicationConfig.js
+++ b/lib/assets/MsApplicationConfig.js
@@ -1,0 +1,179 @@
+var util = require('util'),
+    extendWithGettersAndSetters = require('../util/extendWithGettersAndSetters'),
+    Xml = require('./Xml'),
+    AssetGraph = require('../');
+
+function MsApplicationConfig(config) {
+    Xml.call(this, config);
+}
+
+util.inherits(MsApplicationConfig, Xml);
+
+extendWithGettersAndSetters(MsApplicationConfig.prototype, {
+    contentType: '',
+
+    supportedExtensions: [],
+
+    findOutgoingRelationsInParseTree: function () {
+        var outgoingRelations = Xml.prototype.findOutgoingRelationsInParseTree.call(this),
+            queue = [this.parseTree];
+
+        while (queue.length) {
+            var node = queue.shift();
+
+            if (node.childNodes) {
+                for (var i = node.childNodes.length - 1; i >= 0; i -= 1) {
+                    queue.unshift(node.childNodes[i]);
+                }
+            }
+
+            // Tiles
+            if (node.parentNode &&
+                node.parentNode.nodeType === 1 &&
+                node.parentNode.nodeName.toLowerCase() === 'tile' &&
+                node.parentNode.parentNode.nodeType === 1 &&
+                node.parentNode.parentNode.nodeName.toLowerCase() === 'msapplication' &&
+                node.parentNode.parentNode.parentNode.nodeType === 1 &&
+                node.parentNode.parentNode.parentNode.nodeName.toLowerCase() === 'browserconfig') {
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'tileimage') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'square70x70logo') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'square150x150logo') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'wide310x150logo') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'square310x310logo') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+            }
+
+            // Badge
+            if (node.parentNode &&
+                node.parentNode.nodeType === 1 &&
+                node.parentNode.nodeName.toLowerCase() === 'badge' &&
+                node.parentNode.parentNode.nodeType === 1 &&
+                node.parentNode.parentNode.nodeName.toLowerCase() === 'msapplication' &&
+                node.parentNode.parentNode.parentNode.nodeType === 1 &&
+                node.parentNode.parentNode.parentNode.nodeName.toLowerCase() === 'browserconfig') {
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'polling-uri') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+            }
+
+            // Notification
+            if (node.parentNode &&
+                node.parentNode.nodeType === 1 &&
+                node.parentNode.nodeName.toLowerCase() === 'notification' &&
+                node.parentNode.parentNode.nodeType === 1 &&
+                node.parentNode.parentNode.nodeName.toLowerCase() === 'msapplication' &&
+                node.parentNode.parentNode.parentNode.nodeType === 1 &&
+                node.parentNode.parentNode.parentNode.nodeName.toLowerCase() === 'browserconfig') {
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'polling-uri') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'polling-uri2') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'polling-uri3') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'polling-uri4') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+                if (node.nodeType === 1 && node.nodeName.toLowerCase() === 'polling-uri5') {
+                    outgoingRelations.push(new AssetGraph.Relation({
+                        from: this,
+                        to: {
+                            url: node.getAttribute('src')
+                        },
+                        node: node
+                    }));
+                }
+
+            }
+        }
+
+        return outgoingRelations;
+    }
+});
+
+
+module.exports = MsApplicationConfig;

--- a/test/assets/MsApplicationConfig.js
+++ b/test/assets/MsApplicationConfig.js
@@ -1,0 +1,31 @@
+var expect = require('../unexpected-with-plugins'),
+    AssetGraph = require('../../lib');
+
+describe('assets/MsApplicationConfig', function () {
+    it('should handle a test case with an existing MsApplicationConfig asset', function (done) {
+        new AssetGraph({root: __dirname + '/../../testdata/assets/MsApplicationConfig/'})
+            .loadAssets('index.html')
+            .populate()
+            .queue(function (assetGraph) {
+                expect(assetGraph.findAssets()[1], 'to satisfy', {
+                    text: expect.it('to begin with', '<?xml version="1.0" encoding="utf-8"?>')
+                });
+
+                expect(assetGraph.findRelations({}, true), 'to satisfy', [
+                    { type: 'HtmlMsApplicationConfig' },
+                    { href: 'tile/TileImage.png' },
+                    { href: 'tile/square70x70logo.png' },
+                    { href: 'tile/square150x150logo.png' },
+                    { href: 'tile/wide310x150logo.png' },
+                    { href: 'tile/square310x310logo.png' },
+                    { href: 'badge/polling.xml' },
+                    { href: 'notification/polling-1.xml' },
+                    { href: 'notification/polling-2.xml' },
+                    { href: 'notification/polling-3.xml' },
+                    { href: 'notification/polling-4.xml' },
+                    { href: 'notification/polling-5.xml' }
+                ]);
+            })
+            .run(done);
+    });
+});

--- a/testdata/assets/MsApplicationConfig/IEconfig.xml
+++ b/testdata/assets/MsApplicationConfig/IEconfig.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+   <msapplication>
+     <tile>
+        <TileImage src="/tile/TileImage.png"/>
+        <square70x70logo src="/tile/square70x70logo.png"/>
+        <square150x150logo src="/tile/square150x150logo.png"/>
+        <wide310x150logo src="/tile/wide310x150logo.png"/>
+        <square310x310logo src="/tile/square310x310logo.png"/>
+        <TileColor>#009900</TileColor>
+     </tile>
+     <badge>
+        <polling-uri src="/badge/polling.xml"/>
+        <frequency>30</frequency>
+     </badge>
+     <notification>
+        <polling-uri  src="/notification/polling-1.xml"/>
+        <polling-uri2 src="/notification/polling-2.xml"/>
+        <polling-uri3 src="/notification/polling-3.xml"/>
+        <polling-uri4 src="/notification/polling-4.xml"/>
+        <polling-uri5 src="/notification/polling-5.xml"/>
+        <frequency>30</frequency>
+        <cycle>1</cycle>
+     </notification>
+   </msapplication>
+</browserconfig>

--- a/testdata/assets/MsApplicationConfig/index.html
+++ b/testdata/assets/MsApplicationConfig/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Document</title>
+    <meta name="msapplication-config" content="IEconfig.xml">
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
This one is a bit tricky.

I'd like to set

```js
    contentType: 'text/xml',
    supportedExtensions: ['.xml'],
```

But that is a problem with the current assetgraph architecture.

~~Further more the tests are failing. Seems that the `MsApplicationConfig` instance has an undefined `rawSrcProxy`, meaning it also has no `text`-property, which causes the xmldom parser to throw an error. Can't quite figure out why there is no `rawSrcProxy`~~ **Fixed, I was just a bit tired**

ping @papandreou 