### PR TITLE
Fix relation canonical getter

### DIFF
--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -168,7 +168,7 @@ Relation.prototype = {
                 var hrefObj = urlModule.parse(this.href, false, true);
 
                 canonical = hrefObj.slashes === true
-                    && ['http', 'https', null].indexOf(hrefObj.protocol)
+                    && ['http:', 'https:', null].indexOf(hrefObj.protocol) !== -1
                     && canonicalRootObj.host === hrefObj.host
                     && hrefObj.path.indexOf(canonicalRootObj.path) === 0
                     && (canonicalRootObj.protocol === hrefObj.protocol || canonicalRootObj.protocol === null);

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -167,7 +167,9 @@ Relation.prototype = {
                 var canonicalRootObj = urlModule.parse(this.assetGraph.canonicalRoot, false, true);
                 var hrefObj = urlModule.parse(this.href, false, true);
 
-                canonical = canonicalRootObj.host === hrefObj.host
+                canonical = hrefObj.slashes === true
+                    && ['http', 'https', null].indexOf(hrefObj.protocol)
+                    && canonicalRootObj.host === hrefObj.host
                     && hrefObj.path.indexOf(canonicalRootObj.path) === 0
                     && (canonicalRootObj.protocol === hrefObj.protocol || canonicalRootObj.protocol === null);
             }

--- a/test/relations/Relation.js
+++ b/test/relations/Relation.js
@@ -239,6 +239,24 @@ describe('relations/Relation', function () {
                 });
             });
         });
+
+        it('should handle mailto: protocols where host matches canonicalroot ', function () {
+            return expect(function () {
+                return new AssetGraph({
+                    root: testDataDir,
+                    canonicalRoot: 'http://bar.com/'
+                })
+                .loadAssets('mailto.html')
+                .populate()
+                .queue(function (assetGraph) {
+                    expect(assetGraph.findRelations({}, true), 'to satisfy', [
+                        {
+                            canonical: false
+                        }
+                    ]);
+                });
+            }, 'with http mocked out', [], 'not to error');
+        });
     });
 
     function getTargetFileNames(relations) {

--- a/testdata/relations/Relation/canonicalHref/mailto.html
+++ b/testdata/relations/Relation/canonicalHref/mailto.html
@@ -1,0 +1,1 @@
+<a href="mailto:foo@bar.com">foo@bar.com</a>


### PR DESCRIPTION
`hrefObj.path.indexOf(canonicalRootObj.path)` would throw when a `mailto:`-link had a host name identical to the `canonicalRoot` because `hrefObj.path === null`.

The fix checks that `hrefObj` has `slashes === true` and that the protocol must be either `http`, `https` or `null`(protocol-relative)