### PR TITLE
ES6 support

### DIFF
--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -799,7 +799,10 @@ extendWithGettersAndSetters(Html.prototype, {
                         var javaScriptObjectLiteral = '({' + node.getAttribute(attributeName).replace(/^\s*\{(.*)\}\s*$/, '$1') + '});',
                             parseTree = null; // Must be set to something falsy each time we make it here
                         try {
-                            parseTree = esprima.parse(javaScriptObjectLiteral);
+                            parseTree = esprima.parse(javaScriptObjectLiteral, {
+                                sourceType: 'module',
+                                jsx: true
+                            });
                         } catch (e) {}
 
                         if (parseTree) {

--- a/lib/assets/JavaScript.js
+++ b/lib/assets/JavaScript.js
@@ -146,7 +146,8 @@ extendWithGettersAndSetters(JavaScript.prototype, {
                     loc: !this.assetGraph || this.assetGraph.sourceMaps !== false,
                     attachComment: true,
                     source: sourceUrl,
-                    sourceType: 'module'
+                    sourceType: 'module',
+                    jsx: true
                 });
                 if (this._sourceMap) {
                     this._applySourceMapToParseTree();

--- a/lib/assets/JavaScript.js
+++ b/lib/assets/JavaScript.js
@@ -145,7 +145,8 @@ extendWithGettersAndSetters(JavaScript.prototype, {
                     // Don't incur the penalty of tracking source locations if source maps are disabled globally:
                     loc: !this.assetGraph || this.assetGraph.sourceMaps !== false,
                     attachComment: true,
-                    source: sourceUrl
+                    source: sourceUrl,
+                    sourceType: 'module'
                 });
                 if (this._sourceMap) {
                     this._applySourceMapToParseTree();

--- a/lib/parseExpression.js
+++ b/lib/parseExpression.js
@@ -1,5 +1,8 @@
 var esprima = require('esprima');
 
 module.exports = function parseExpression(str) {
-    return esprima.parse('(' + String(str) + ')').body[0].expression;
+    return esprima.parse('(' + String(str) + ')', {
+        sourceType: 'module',
+        jsx: true
+    }).body[0].expression;
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cssnano": "^3.7.4",
     "esanimate": "^1.1.0",
     "escodegen": "^1.8.0",
-    "esprima": "^3.0.0",
+    "esprima": "^3.1.3",
     "espurify": "^1.7.0",
     "estraverse": "^4.2.0",
     "gettemporaryfilepath": "0.0.1",

--- a/test/assets/JavaScript.js
+++ b/test/assets/JavaScript.js
@@ -217,6 +217,21 @@ describe('assets/JavaScript', function () {
         expect(javaScript.text, 'to equal', es6Text);
     });
 
+    it.skip('should tolerate Object spread syntax', function () {
+        var text = 'const foo = { ...bar };';
+        var javaScript = new AssetGraph.JavaScript({
+            text: text
+        });
+        expect(javaScript.parseTree, 'to satisfy', {
+            type: 'Program',
+            body: [
+            ],
+            sourceType: 'module'
+        });
+        javaScript.markDirty();
+        expect(javaScript.text, 'to equal', text);
+    });
+
     it('should tolerate JSX syntax', function () {
         var jsxText = 'function render() { return (<MyComponent />); }';
         var javaScript = new AssetGraph.JavaScript({

--- a/test/assets/JavaScript.js
+++ b/test/assets/JavaScript.js
@@ -199,4 +199,18 @@ describe('assets/JavaScript', function () {
             })
             .run(done);
     });
+
+    it('should tolerate ES6 syntax', function () {
+        var javaScript = new AssetGraph.JavaScript({
+            text: 'import gql from \'graphql-tag\';\nlet a = 123;'
+        });
+        expect(javaScript.parseTree, 'to satisfy', {
+            type: 'Program',
+            body: [
+                { type: 'ImportDeclaration' },
+                { type: 'VariableDeclaration', kind: 'let' }
+            ],
+            sourceType: 'module'
+        });
+    });
 });

--- a/test/assets/JavaScript.js
+++ b/test/assets/JavaScript.js
@@ -201,8 +201,9 @@ describe('assets/JavaScript', function () {
     });
 
     it('should tolerate ES6 syntax', function () {
+        var es6Text = 'import gql from \'graphql-tag\';\nlet a = 123;';
         var javaScript = new AssetGraph.JavaScript({
-            text: 'import gql from \'graphql-tag\';\nlet a = 123;'
+            text: es6Text
         });
         expect(javaScript.parseTree, 'to satisfy', {
             type: 'Program',
@@ -212,5 +213,46 @@ describe('assets/JavaScript', function () {
             ],
             sourceType: 'module'
         });
+        javaScript.markDirty();
+        expect(javaScript.text, 'to equal', es6Text);
+    });
+
+    it('should tolerate JSX syntax', function () {
+        var jsxText = 'function render() { return (<MyComponent />); }';
+        var javaScript = new AssetGraph.JavaScript({
+            text: jsxText
+        });
+        expect(javaScript.parseTree, 'to satisfy', {
+            type: 'Program',
+            body: [
+                {
+                    type: 'FunctionDeclaration',
+                    body: {
+                        type: 'BlockStatement',
+                        body: [
+                            {
+                                type: 'ReturnStatement',
+                                argument: {
+                                    type: 'JSXElement',
+                                    openingElement: {
+                                        type: 'JSXOpeningElement',
+                                        name: {
+                                            type: 'JSXIdentifier',
+                                            name: 'MyComponent'
+                                        }
+                                    },
+                                    children: [],
+                                    closingElement: null
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            sourceType: 'module'
+        });
+        javaScript.markDirty();
+        // This doesn't work because escodegen doesn't support JSX:
+        // expect(javaScript.text, 'to equal', jsxText);
     });
 });


### PR DESCRIPTION
Seems like it's quite easy to allow ES6 syntax in JavaScript assets by switching esprima into "module" mode. I hope there are no downsides :)

It's also able to parse JSX, although escodegen doesn't support serializing it. Still, better than nothing.