### PR TITLE
Update to jsdom 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "4"
   - "6"
   - "7"
 

--- a/lib/assets/Css.js
+++ b/lib/assets/Css.js
@@ -115,8 +115,6 @@ extendWithGettersAndSetters(Css.prototype, {
             var sourceUrl = this.sourceUrl || (nonInlineAncestor && nonInlineAncestor.url) || this.url || 'standalone-' + this.id + '.css';
             try {
                 this._parseTree = postcss.parse(this.text, {
-                    // TODO: jsdom 6.4.0+ supports jsdom.nodeLocation, which might help us map this
-                    // inline stylesheets correctly to the .html source in the generated source map.
                     source: sourceUrl,
                     from: sourceUrl,
                     map: this._sourceMap && { prev: this._sourceMap }

--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -2,7 +2,7 @@
 var util = require('util'),
     _ = require('lodash'),
     esprima = require('esprima'),
-    jsdom = require('jsdom'),
+    JSDOM = require('jsdom').JSDOM,
     htmlMinifier = require('html-minifier'),
     extendWithGettersAndSetters = require('../util/extendWithGettersAndSetters'),
     errors = require('../errors'),
@@ -126,7 +126,7 @@ extendWithGettersAndSetters(Html.prototype, {
     get text() {
         if (typeof this._text !== 'string') {
             if (this._parseTree) {
-                this._text = this.isFragment ? this._parseTree.innerHTML : jsdom.serializeDocument(this._parseTree);
+                this._text = this.isFragment ? this._parseTree.innerHTML : this._serialize();
                 var templateReplacements = this._templateReplacements;
                 this._text = Object.keys(templateReplacements).reduce(function (text, key) {
                     return text.replace(key, templateReplacements[key]);
@@ -186,13 +186,15 @@ extendWithGettersAndSetters(Html.prototype, {
             var isFragment = this.isFragment;
             var document;
             try {
-                document = jsdom.jsdom(isFragment ? '<body>' + text + '</body>' : text, {
+                var jsdom = new JSDOM(isFragment ? '<body>' + text + '</body>' : text, {
                     features: {
                         ProcessExternalResources: [],
                         FetchExternalResources: [],
                         QuerySelector: true
                     }
                 });
+                document = jsdom.window.document;
+                this._serialize = jsdom.serialize.bind(jsdom);
             } catch (e) {
                 var err = new errors.ParseError({message: 'Parse error in ' + this.urlOrDescription + '\n' + e.message, asset: this});
                 if (this.assetGraph) {

--- a/lib/assets/Html.js
+++ b/lib/assets/Html.js
@@ -8,6 +8,7 @@ var util = require('util'),
     errors = require('../errors'),
     Text = require('./Text'),
     JavaScript = require('./JavaScript'),
+    mozilla = require('source-map'),
     AssetGraph = require('../');
 
 function Html(config) {
@@ -187,6 +188,7 @@ extendWithGettersAndSetters(Html.prototype, {
             var document;
             try {
                 var jsdom = new JSDOM(isFragment ? '<body>' + text + '</body>' : text, {
+                    includeNodeLocations: true,
                     features: {
                         ProcessExternalResources: [],
                         FetchExternalResources: [],
@@ -195,6 +197,7 @@ extendWithGettersAndSetters(Html.prototype, {
                 });
                 document = jsdom.window.document;
                 this._serialize = jsdom.serialize.bind(jsdom);
+                this._nodeLocation = jsdom.nodeLocation.bind(jsdom);
             } catch (e) {
                 var err = new errors.ParseError({message: 'Parse error in ' + this.urlOrDescription + '\n' + e.message, asset: this});
                 if (this.assetGraph) {
@@ -243,6 +246,69 @@ extendWithGettersAndSetters(Html.prototype, {
 
     set isFragment(isFragment) {
         this._isFragment = isFragment;
+    },
+
+    _createSourceMapForInlineScriptOrStylesheet: function (element) {
+        var nonInlineAncestor = this.nonInlineAncestor;
+        var sourceUrl = this.sourceUrl || (nonInlineAncestor ? nonInlineAncestor.url : this.url);
+        var location;
+        if (element.firstChild) {
+            location = this._nodeLocation(element.firstChild);
+        } else {
+            // Empty script or stylesheet
+            location = this._nodeLocation(element).endTag;
+        }
+        var sourceMapGenerator = new mozilla.SourceMapGenerator({file: this.nonInlineAncestor.url});
+        var text = element.firstChild ? element.firstChild.nodeValue : '';
+        var generatedLineNumber = 1;
+        var generatedColumnNumber = 0;
+        var previousChar;
+        var originalLineNumber = location.line;
+        var originalColumnNumber = location.col;
+        var hasAddedMappingForTheCurrentLine = false;
+        function addMapping() {
+            sourceMapGenerator.addMapping({
+                generated: {
+                    line: generatedLineNumber,
+                    column: generatedColumnNumber
+                },
+                original: {
+                    line: originalLineNumber,
+                    column: originalColumnNumber
+                },
+                source: sourceUrl
+            });
+        }
+        addMapping();
+        for (var i = 0 ; i < text.length ; i += 1) {
+            var ch = text.charAt(i);
+            if (ch === '\n') {
+                if (previousChar !== '\r') {
+                    originalLineNumber += 1;
+                    generatedLineNumber += 1;
+                    generatedColumnNumber = 0;
+                    originalColumnNumber = 0;
+                    hasAddedMappingForTheCurrentLine = false;
+                }
+            } else if (ch === '\r') {
+                if (previousChar !== '\n') {
+                    originalLineNumber += 1;
+                    generatedLineNumber += 1;
+                    generatedColumnNumber = 0;
+                    originalColumnNumber = 0;
+                    hasAddedMappingForTheCurrentLine = false;
+                }
+            } else {
+                if (!hasAddedMappingForTheCurrentLine && !/\s/.test(ch)) {
+                    addMapping();
+                }
+                originalColumnNumber += 1;
+                generatedColumnNumber += 1;
+            }
+            previousChar = ch;
+        }
+        addMapping();
+        return sourceMapGenerator.toJSON();
     },
 
     findOutgoingRelationsInParseTree: function () {
@@ -309,7 +375,7 @@ extendWithGettersAndSetters(Html.prototype, {
                             addOutgoingRelation(new AssetGraph.HtmlScript({
                                 from: this,
                                 to: new (require('./JavaScript'))({
-                                    sourceUrl: this.sourceUrl || this.url,
+                                    sourceMap: this._createSourceMapForInlineScriptOrStylesheet(node),
                                     text: node.firstChild ? node.firstChild.nodeValue : ''
                                 }),
                                 node: node
@@ -340,7 +406,7 @@ extendWithGettersAndSetters(Html.prototype, {
                     addOutgoingRelation(new AssetGraph.HtmlStyle({
                         from: this,
                         to: new (require('./Css'))({
-                            sourceUrl: this.sourceUrl || this.url,
+                            sourceMap: this._createSourceMapForInlineScriptOrStylesheet(node),
                             text: node.firstChild ? node.firstChild.nodeValue : ''
                         }),
                         node: node

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "svgo": "^0.7.2",
     "systemjs-asset-plugin": "^3.0.0",
     "systemjs-builder": "^0.16.3",
-    "unexpected": "^10.26.0",
+    "unexpected": "^10.27.0",
     "unexpected-dom": "papandreou/unexpected-dom#7acee57d1f21e03831d466da97daf4cc205d3b20",
     "unexpected-sinon": "^10.7.0",
     "webpack": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "glob": "^7.0.5",
     "html-minifier": "^3.4.0",
     "imageinfo": "1.0.4",
-    "jsdom": "9.12.0",
+    "jsdom": "11.0.0",
     "lodash": "^4.11.2",
     "mkdirp": "^0.5.1",
     "normalizeurl": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "systemjs-asset-plugin": "^3.0.0",
     "systemjs-builder": "^0.16.3",
     "unexpected": "^10.26.0",
-    "unexpected-dom": "^3.0.2",
+    "unexpected-dom": "papandreou/unexpected-dom#7acee57d1f21e03831d466da97daf4cc205d3b20",
     "unexpected-sinon": "^10.7.0",
     "webpack": "^2.3.1",
     "yui-compressor": "^0.1.3"

--- a/test/assets/Html.js
+++ b/test/assets/Html.js
@@ -1,7 +1,8 @@
 /*global describe, it*/
-var unexpected = require('../unexpected-with-plugins'),
-    AssetGraph = require('../../lib'),
-    Promise = require('bluebird');
+var unexpected = require('../unexpected-with-plugins');
+var AssetGraph = require('../../lib');
+var Promise = require('bluebird');
+var mozilla = require('source-map');
 
 describe('assets/Html', function () {
     var expect = unexpected.clone().addAssertion('to minify to', function (expect, subject, value, manipulator) {
@@ -554,5 +555,76 @@ describe('assets/Html', function () {
         htmlAsset.parseTree;
         htmlAsset.markDirty();
         expect(htmlAsset.text, 'not to contain', '<foo></foo>');
+    });
+
+    it('should register the source location of inline scripts and stylesheets', function () {
+        return new AssetGraph({root: __dirname + '../../../testdata/assets/Html/sourceMapInlineAssets/'})
+            .loadAssets('index.html')
+            .populate()
+            .applySourceMaps()
+            .queue(function (assetGraph) {
+                // FIXME: Make sure that it's sufficient to mark the containing asset dirty:
+                assetGraph.findAssets({type: 'JavaScript'})[0].markDirty();
+                assetGraph.findAssets({type: 'Css'})[0].markDirty();
+            })
+            .externalizeRelations({type: ['HtmlStyle', 'HtmlScript']})
+            .minifyAssets({type: ['Css', 'JavaScript']})
+            .serializeSourceMaps()
+            .queue(function (assetGraph) {
+                expect(assetGraph, 'to contain asset', 'JavaScript');
+                expect(assetGraph, 'to contain asset', 'Css');
+                expect(assetGraph, 'to contain assets', 'SourceMap', 2);
+                var cssSourceMap = assetGraph.findRelations({type: 'CssSourceMappingUrl'})[0].to;
+                expect(cssSourceMap.parseTree, 'to satisfy', {
+                    sources: [ assetGraph.root + 'index.html' ]
+                });
+                var cssSourceMapConsumer = new mozilla.SourceMapConsumer(cssSourceMap.parseTree);
+
+                expect(cssSourceMapConsumer.generatedPositionFor({
+                    source: assetGraph.root + 'index.html',
+                    line: 6,
+                    column: 17
+                }), 'to equal', {
+                    line: 1,
+                    column: 5,
+                    lastColumn: null
+                });
+
+                expect(cssSourceMapConsumer.originalPositionFor({
+                    line: 1,
+                    column: 12
+                }), 'to equal', {
+                    source: assetGraph.root + 'index.html',
+                    line: 6,
+                    column: 16,
+                    name: null
+                });
+
+                var javaScriptSourceMap = assetGraph.findRelations({type: 'JavaScriptSourceMappingUrl'})[0].to;
+                expect(javaScriptSourceMap.parseTree, 'to satisfy', {
+                    sources: [ assetGraph.root + 'index.html' ]
+                });
+
+                var javaScriptSourceMapConsumer = new mozilla.SourceMapConsumer(javaScriptSourceMap.parseTree);
+                expect(javaScriptSourceMapConsumer.generatedPositionFor({
+                    source: assetGraph.root + 'index.html',
+                    line: 13,
+                    column: 16
+                }), 'to equal', {
+                    line: 1,
+                    column: 8,
+                    lastColumn: null
+                });
+
+                expect(javaScriptSourceMapConsumer.originalPositionFor({
+                    line: 1,
+                    column: 12
+                }), 'to equal', {
+                    source: assetGraph.root + 'index.html',
+                    line: 13,
+                    column: 16,
+                    name: 'alert'
+                });
+            });
     });
 });

--- a/testdata/assets/Html/sourceMapInlineAssets/index.html
+++ b/testdata/assets/Html/sourceMapInlineAssets/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <style>
+            body {
+                color: red;
+            }
+        </style>
+    </head>
+    <body>
+        <script>
+            if (foo) {
+                alert("foo");
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
... and use the updated `jsdom.nodeLocation` API to map inline scripts and stylesheets back to their location in the HTML.