### PR TITLE
es6/2017-ify transforms

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,9 @@ module.exports = {
     extends: [
         'onelint'
     ],
+    rules: {
+        'no-const-assign': 2
+    },
     env: {
         es6: true
     },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,5 +5,7 @@ module.exports = {
     env: {
         es6: true
     },
-    parserOptions: null
+    parserOptions: {
+        ecmaVersion: 2017
+    }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /coverage/
 .DS_Store
+/.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   directories:
   - node_modules
 node_js:
-  - "6"
   - "7"
   - "8"
 

--- a/lib/transforms/addCacheManifest.js
+++ b/lib/transforms/addCacheManifest.js
@@ -1,10 +1,9 @@
-const _ = require('lodash');
 const AssetGraph = require('../AssetGraph');
 const query = AssetGraph.query;
 
 module.exports = queryObj => {
     return function addCacheManifest(assetGraph) {
-        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html', isInline: false}, queryObj))) {
             // Look for an existing manifests for htmlAsset:
             let manifest;
             const existingManifestRelations = assetGraph.findRelations({

--- a/lib/transforms/addCacheManifest.js
+++ b/lib/transforms/addCacheManifest.js
@@ -1,19 +1,16 @@
-var _ = require('lodash'),
-    AssetGraph = require('../AssetGraph'),
-    query = AssetGraph.query;
+const _ = require('lodash');
+const AssetGraph = require('../AssetGraph');
+const query = AssetGraph.query;
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function addCacheManifest(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'Html'}, queryObj)).forEach(function (htmlAsset) {
-            if (htmlAsset.isInline) {
-                throw new Error('addCacheManifestSinglePage: Cannot generate a CacheManifest for an inline Html asset');
-            }
+        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false}, queryObj))) {
             // Look for an existing manifests for htmlAsset:
-            var manifest,
-                existingManifestRelations = assetGraph.findRelations({
-                    from: htmlAsset,
-                    type: 'HtmlCacheManifest'
-                });
+            let manifest;
+            const existingManifestRelations = assetGraph.findRelations({
+                from: htmlAsset,
+                type: 'HtmlCacheManifest'
+            });
             if (existingManifestRelations.length === 1) {
                 manifest = existingManifestRelations[0].to;
             } else if (existingManifestRelations.length > 1) {
@@ -37,12 +34,12 @@ module.exports = function (queryObj) {
 
             // Find all assets that can be reached from the Html file and add relations to them from the manifest:
 
-            assetGraph.eachAssetPostOrder(htmlAsset, {type: query.not(['HtmlAnchor', 'HtmlMetaRefresh', 'HtmlCacheManifest', 'HtmlConditionalComment', 'JavaScriptSourceUrl', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceMap'])}, function (asset) {
+            assetGraph.eachAssetPostOrder(htmlAsset, {type: query.not(['HtmlAnchor', 'HtmlMetaRefresh', 'HtmlCacheManifest', 'HtmlConditionalComment', 'JavaScriptSourceUrl', 'JavaScriptSourceMappingUrl', 'JavaScriptSourceMap'])}, asset => {
                 // But only if the asset isn't inline, has been loaded, and isn't already in the manifest:
                 if (!asset.isInline && asset.isLoaded && asset !== htmlAsset && asset !== manifest && !assetGraph.findRelations({from: manifest, to: asset}).length) {
-                    var existingManifestEntriesInCacheSection = assetGraph.findRelations({from: manifest, sectionName: 'CACHE'}),
-                        position,
-                        adjacentRelation;
+                    const existingManifestEntriesInCacheSection = assetGraph.findRelations({from: manifest, sectionName: 'CACHE'});
+                    let position;
+                    let adjacentRelation;
 
                     if (existingManifestEntriesInCacheSection.length === 0) {
                         position = 'first';
@@ -56,6 +53,6 @@ module.exports = function (queryObj) {
                     }).attach(manifest, position, adjacentRelation);
                 }
             });
-        });
+        }
     };
 };

--- a/lib/transforms/addDataVersionAttributeToHtmlElement.js
+++ b/lib/transforms/addDataVersionAttributeToHtmlElement.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const childProcess = require('child_process');
 const Promise = require('bluebird');
 
@@ -15,7 +14,7 @@ module.exports = (queryObj, version) => {
             } catch (e) {}
         }
         if (version) {
-            for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+            for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html'}, queryObj))) {
                 const documentElement = htmlAsset.parseTree.documentElement;
                 if (documentElement) {
                     documentElement.setAttribute('data-version', version.replace(/\{0\}/g, documentElement.getAttribute('data-version') || ''));

--- a/lib/transforms/addDataVersionAttributeToHtmlElement.js
+++ b/lib/transforms/addDataVersionAttributeToHtmlElement.js
@@ -1,31 +1,27 @@
-var _ = require('lodash'),
-    childProcess = require('child_process');
+const _ = require('lodash');
+const childProcess = require('child_process');
+const Promise = require('bluebird');
 
-module.exports = function (queryObj, version) {
-    return function addDataVersionAttributeToHtmlElement(assetGraph, cb) {
-        function proceed() {
-            if (version) {
-                assetGraph.findAssets(_.extend({type: 'Html'}, queryObj)).forEach(function (htmlAsset) {
-                    var documentElement = htmlAsset.parseTree.documentElement;
-                    if (documentElement) {
-                        documentElement.setAttribute('data-version', version.replace(/\{0\}/g, documentElement.getAttribute('data-version') || ''));
-                        htmlAsset.markDirty();
-                    }
-                });
-            }
-            cb();
-        }
-
+module.exports = (queryObj, version) => {
+    return async function addDataVersionAttributeToHtmlElement(assetGraph) {
         if (typeof version === 'undefined') {
             // Try to derive a version tag from git:
-            childProcess.exec('git describe --long --tags --always --dirty', function (err, stdout, stderr) {
-                if (!err) {
-                    version = stdout.replace(/^[\s\n\r]+|[\s\r\n]+$/g, '');
+            try {
+                const [ stdout ] = await Promise.fromNode(
+                    cb => childProcess.exec('git describe --long --tags --always --dirty', cb),
+                    { multiArgs: true }
+                );
+                version = stdout.replace(/^[\s\n\r]+|[\s\r\n]+$/g, '');
+            } catch (e) {}
+        }
+        if (version) {
+            for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+                const documentElement = htmlAsset.parseTree.documentElement;
+                if (documentElement) {
+                    documentElement.setAttribute('data-version', version.replace(/\{0\}/g, documentElement.getAttribute('data-version') || ''));
+                    htmlAsset.markDirty();
                 }
-                proceed();
-            });
-        } else {
-            proceed();
+            }
         }
     };
 };

--- a/lib/transforms/addJavaScriptSourceUrl.js
+++ b/lib/transforms/addJavaScriptSourceUrl.js
@@ -1,9 +1,8 @@
-const _ = require('lodash');
 const AssetGraph = require('../AssetGraph');
 
 module.exports = queryObj => {
     return function addJavaScriptSourceUrl(assetGraph) {
-        for (const javaScript of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
+        for (const javaScript of assetGraph.findAssets(Object.assign({type: 'JavaScript'}, queryObj))) {
             new AssetGraph.JavaScriptSourceUrl({
                 to: javaScript,
                 hrefType: 'rootRelative'

--- a/lib/transforms/addJavaScriptSourceUrl.js
+++ b/lib/transforms/addJavaScriptSourceUrl.js
@@ -1,13 +1,13 @@
-var _ = require('lodash'),
-    AssetGraph = require('../AssetGraph');
+const _ = require('lodash');
+const AssetGraph = require('../AssetGraph');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function addJavaScriptSourceUrl(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj)).forEach(function (javaScript) {
+        for (const javaScript of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
             new AssetGraph.JavaScriptSourceUrl({
                 to: javaScript,
                 hrefType: 'rootRelative'
             }).attach(javaScript, 'last');
-        });
+        }
     };
 };

--- a/lib/transforms/addPrecacheServiceWorker.js
+++ b/lib/transforms/addPrecacheServiceWorker.js
@@ -6,7 +6,7 @@ const swPrecache = require('sw-precache');
 const commonPathPrefix = require('common-path-prefix');
 const Promise = require('bluebird');
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
     return function addPrecacheServiceWorker(assetGraph) {
         function generateAndAttachPrecacheServiceWorkerAsync(entryPointHtmlAssets) {
@@ -70,7 +70,7 @@ module.exports = function (queryObj, options) {
                 }
                 assetGraph.addAsset(serviceWorker);
                 for (const htmlAsset of entryPointHtmlAssets) {
-                    var serviceWorkerRegistrationScript = new assetGraph.JavaScript({
+                    const serviceWorkerRegistrationScript = new assetGraph.JavaScript({
                         text:
                             'if (\'serviceWorker\' in navigator) {\n' +
                             '    window.addEventListener(\'load\', function () {\n' +

--- a/lib/transforms/addPrecacheServiceWorker.js
+++ b/lib/transforms/addPrecacheServiceWorker.js
@@ -95,7 +95,7 @@ module.exports = (queryObj, options) => {
             });
         }
 
-        const entryPointHtmlAssets = assetGraph.findAssets(_.extend({type: 'Html', isInline: false}, queryObj));
+        const entryPointHtmlAssets = assetGraph.findAssets(Object.assign({type: 'Html', isInline: false}, queryObj));
 
         let batches;
         if (options.single) {

--- a/lib/transforms/addRelNoopenerToBlankTargetAnchors.js
+++ b/lib/transforms/addRelNoopenerToBlankTargetAnchors.js
@@ -12,32 +12,23 @@
  * See https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/
  */
 
-module.exports = function () {
+module.exports = () => {
     return function addRelNoopenerToBlankTargetAnchors(assetGraph) {
-        var externalAnchors = assetGraph.findRelations({
+        const externalAnchors = assetGraph.findRelations({
             type: 'HtmlAnchor',
             crossorigin: true,
-            node: function (node) {
-                return node.getAttribute('target') === '_blank';
-            }
+            node: node => node.getAttribute('target') === '_blank'
         }, true);
 
-        externalAnchors.forEach(function (relation) {
-            var node = relation.node;
-            var currentRel = node.getAttribute('rel');
+        for (const relation of externalAnchors) {
+            const node = relation.node;
+            const currentRel = node.getAttribute('rel');
 
             if (typeof currentRel === 'string') {
-                var rels = currentRel.split(' ').map(function (str) {
-                    return str.toLowerCase();
-                });
+                const rels = currentRel.split(' ').map(str => str.toLowerCase());
 
-                // Bail out if 'noopener' is already set
-                if (rels.indexOf('noopener') !== -1) {
-                    return;
-                }
-
-                // bail out if 'opener' is explicitly set
-                if (rels.indexOf('opener') !== -1) {
+                // Bail out if 'noopener' or 'opener' is already set
+                if (rels.includes('noopener') || rels.includes('opener')) {
                     return;
                 }
 
@@ -47,6 +38,6 @@ module.exports = function () {
             }
 
             relation.from.markDirty();
-        });
+        }
     };
 };

--- a/lib/transforms/applySourceMaps.js
+++ b/lib/transforms/applySourceMaps.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 module.exports = queryObj => {
     return function applySourceMaps(assetGraph) {
         for (const asset of assetGraph.findAssets(queryObj || { type: [ 'JavaScript', 'Css' ] })) {
@@ -7,7 +5,7 @@ module.exports = queryObj => {
             if (sourceMappingUrl) {
                 if (asset.parseTree) {
                     // Absolutify urls in sources array before applying:
-                    const shallowCopy = _.extend({}, sourceMappingUrl.to.parseTree);
+                    const shallowCopy = Object.assign({}, sourceMappingUrl.to.parseTree);
                     if (Array.isArray(shallowCopy.sources)) {
                         const nonInlineAncestorUrl = sourceMappingUrl.to.nonInlineAncestor.url;
                         shallowCopy.sources = shallowCopy.sources.map(

--- a/lib/transforms/applySourceMaps.js
+++ b/lib/transforms/applySourceMaps.js
@@ -1,22 +1,22 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function applySourceMaps(assetGraph) {
-        assetGraph.findAssets(queryObj || { type: [ 'JavaScript', 'Css' ] }).forEach(function (asset) {
-            var sourceMappingUrl = assetGraph.findRelations({ from: asset, type: /SourceMappingUrl$/, to: { type: 'SourceMap', isLoaded: true } })[0];
+        for (const asset of assetGraph.findAssets(queryObj || { type: [ 'JavaScript', 'Css' ] })) {
+            const sourceMappingUrl = assetGraph.findRelations({ from: asset, type: /SourceMappingUrl$/, to: { type: 'SourceMap', isLoaded: true } })[0];
             if (sourceMappingUrl) {
                 if (asset.parseTree) {
                     // Absolutify urls in sources array before applying:
-                    var shallowCopy = _.extend({}, sourceMappingUrl.to.parseTree);
+                    const shallowCopy = _.extend({}, sourceMappingUrl.to.parseTree);
                     if (Array.isArray(shallowCopy.sources)) {
-                        var nonInlineAncestorUrl = sourceMappingUrl.to.nonInlineAncestor.url;
-                        shallowCopy.sources = shallowCopy.sources.map(function (sourceUrl) {
-                            return assetGraph.resolveUrl(nonInlineAncestorUrl, sourceUrl);
-                        });
+                        const nonInlineAncestorUrl = sourceMappingUrl.to.nonInlineAncestor.url;
+                        shallowCopy.sources = shallowCopy.sources.map(
+                            sourceUrl => assetGraph.resolveUrl(nonInlineAncestorUrl, sourceUrl)
+                        );
                     }
                     asset.sourceMap = shallowCopy;
                 }
             }
-        });
+        }
     };
 };

--- a/lib/transforms/autoprefixer.js
+++ b/lib/transforms/autoprefixer.js
@@ -4,15 +4,15 @@
  * - Runs autoprefixer with the supplied options on each css asset
  */
 
-var semver = require('semver');
+const semver = require('semver');
 
-module.exports = function (browsers, options) {
+module.exports = (browsers, options) => {
     options = options || {};
     return function autoprefixer_(assetGraph) {
-        var cssAssets = assetGraph.findAssets({type: 'Css'});
+        const cssAssets = assetGraph.findAssets({type: 'Css'});
 
         if (cssAssets.length > 0) {
-            var autoprefixerVersionStr;
+            let autoprefixerVersionStr;
             try {
                 autoprefixerVersionStr = require('autoprefixer/package.json').version;
             } catch (e) {
@@ -23,15 +23,15 @@ module.exports = function (browsers, options) {
                 throw e;
             }
 
-            var autoprefixer;
+            let autoprefixer;
             if (semver.satisfies(autoprefixerVersionStr, '>= 3.0.0')) {
                 autoprefixer = require('autoprefixer')(browsers ? {browsers: browsers} : {});
             } else {
                 autoprefixer = require('autoprefixer')(browsers);
             }
 
-            var isAtLeastVersion5 = semver.satisfies(autoprefixerVersionStr, '>= 5.0.0');
-            var postcss;
+            const isAtLeastVersion5 = semver.satisfies(autoprefixerVersionStr, '>= 5.0.0');
+            let postcss;
             if (isAtLeastVersion5) {
                 try {
                     postcss = require('postcss');
@@ -39,23 +39,23 @@ module.exports = function (browsers, options) {
                     postcss = require('autoprefixer/node_modules/postcss');
                 }
             }
-            cssAssets.forEach(function (cssAsset) {
+            for (const cssAsset of cssAssets) {
                 try {
                     if (isAtLeastVersion5) {
-                        var existingSourceMap = cssAsset.sourceMap;
+                        let existingSourceMap = cssAsset.sourceMap;
                         if (existingSourceMap && !existingSourceMap.mappings) {
                             existingSourceMap = undefined;
                         }
 
-                        var result = postcss(autoprefixer).process(cssAsset.parseTree, { map: options.sourceMaps && { inline: false, annotation: false, sourcesContent: options.sourcesContent } }).stringify();
+                        const result = postcss(autoprefixer).process(cssAsset.parseTree, { map: options.sourceMaps && { inline: false, annotation: false, sourcesContent: options.sourcesContent } }).stringify();
                         cssAsset.text = result.css;
-                        var sourceMap;
+                        let sourceMap;
                         if (options.sourceMaps && result.map) {
                             sourceMap = result.map.toJSON();
                             if (Array.isArray(sourceMap.sources)) {
-                                sourceMap.sources = sourceMap.sources.map(function (sourceUrl) {
-                                    return sourceUrl.replace(/^http:\/+/, 'http://').replace(/^file:\/*/, 'file:///');
-                                });
+                                sourceMap.sources = sourceMap.sources.map(
+                                    sourceUrl => sourceUrl.replace(/^http:\/+/, 'http://').replace(/^file:\/*/, 'file:///')
+                                );
                             }
                             cssAsset.sourceMap = sourceMap;
                         }
@@ -67,7 +67,7 @@ module.exports = function (browsers, options) {
 
                     assetGraph.emit('warn', err);
                 }
-            });
+            }
         }
     };
 };

--- a/lib/transforms/bundleRelations.js
+++ b/lib/transforms/bundleRelations.js
@@ -1,24 +1,23 @@
-var _ = require('lodash'),
-    urlTools = require('urltools'),
-    postcss = require('postcss'),
-    AssetGraph = require('../AssetGraph'),
-    assetGraphConditions = require('../assetGraphConditions');
+const _ = require('lodash');
+const urlTools = require('urltools');
+const postcss = require('postcss');
+const AssetGraph = require('../AssetGraph');
+const assetGraphConditions = require('../assetGraphConditions');
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
-    var bundleStrategyName = options.strategyName || 'oneBundlePerIncludingAsset';
+    const bundleStrategyName = options.strategyName || 'oneBundlePerIncludingAsset';
 
     return function bundleRelations(assetGraph) {
         function getDiscriminatorForRelation(relation) {
-            var discriminatorFragments = [],
-                i,
-                attribute;
+            const discriminatorFragments = [];
+            let attribute;
             discriminatorFragments.push(relation.type); // HtmlScript vs. JavaScriptImportScripts
             if (relation.to.isLoaded) {
                 discriminatorFragments.push('isLoaded');
             }
-            var isInsideHead = false,
-                parentNode = relation.node.parentNode;
+            let isInsideHead = false;
+            let parentNode = relation.node.parentNode;
             while (parentNode) {
                 if (parentNode.nodeName.toLowerCase() === 'head') {
                     isInsideHead = true;
@@ -32,14 +31,14 @@ module.exports = function (queryObj, options) {
                 discriminatorFragments.push('body');
             }
             if (relation.conditionalComments) {
-                Array.prototype.push.apply(discriminatorFragments, _.map(relation.conditionalComments, 'nodeValue'));
+                discriminatorFragments.push(..._.map(relation.conditionalComments, 'nodeValue'));
             }
             if (relation.node && relation.node.hasAttribute && relation.node.hasAttribute('bundle')) {
                 discriminatorFragments.push(relation.node.getAttribute('bundle'));
             }
             if (relation.type === 'HtmlStyle') {
                 discriminatorFragments.push(relation.node.getAttribute('media') || 'all');
-                for (i = 0 ; i < relation.node.attributes.length ; i += 1) {
+                for (let i = 0 ; i < relation.node.attributes.length ; i += 1) {
                     attribute = relation.node.attributes[i];
                     if (attribute.name !== 'charset' &&
                         attribute.name !== 'media' &&
@@ -55,7 +54,7 @@ module.exports = function (queryObj, options) {
             } else if (relation.type === 'HtmlScript') {
                 if (relation.to.strict) {
                     discriminatorFragments.push('strict');
-                    var warning = new Error('Global "use strict"-directive. Splitting into multiple bundles to avoid side effects.');
+                    const warning = new Error('Global "use strict"-directive. Splitting into multiple bundles to avoid side effects.');
                     warning.asset = relation.to;
                     assetGraph.emit('info', warning);
                 }
@@ -65,7 +64,7 @@ module.exports = function (queryObj, options) {
                 if (relation.node.getAttribute('async') === 'async') {
                     discriminatorFragments.push('async');
                 }
-                for (i = 0 ; i < relation.node.attributes.length ; i += 1) {
+                for (let i = 0 ; i < relation.node.attributes.length ; i += 1) {
                     attribute = relation.node.attributes[i];
                     if (attribute.name !== 'charset' &&
                         attribute.name !== 'src' &&
@@ -92,41 +91,37 @@ module.exports = function (queryObj, options) {
                 return [assetsToBundle[0]];
             }
 
-            var type = assetsToBundle[0].type,
-                constructorOptions = {
-                    lastKnownByteLength: assetsToBundle.reduce(function (sumOfLastKnownByteLengths, asset) {
-                        return sumOfLastKnownByteLengths + asset.lastKnownByteLength;
-                    }, 0),
-                    isMinified: assetsToBundle.every(function (asset) {
-                        return asset.isMinified;
-                    }),
-                    isPretty: assetsToBundle.every(function (asset) {
-                        return asset.isPretty;
-                    })
-                };
+            const type = assetsToBundle[0].type;
+            const constructorOptions = {
+                lastKnownByteLength: assetsToBundle.reduce((sumOfLastKnownByteLengths, asset) => {
+                    return sumOfLastKnownByteLengths + asset.lastKnownByteLength;
+                }, 0),
+                isMinified: assetsToBundle.every(asset => asset.isMinified),
+                isPretty: assetsToBundle.every(asset => asset.isPretty)
+            };
 
             if (type === 'JavaScript') {
                 constructorOptions.parseTree = { type: 'Program', body: [] };
-                assetsToBundle.forEach(function (asset, i) {
-                    assetGraph.findRelations({from: asset, type: 'JavaScriptSourceMappingUrl'}, true).forEach(function (relation) {
+                for (const asset of assetsToBundle)  {
+                    for (const relation of assetGraph.findRelations({from: asset, type: 'JavaScriptSourceMappingUrl'}, true)) {
                         if (relation.to.isAsset) {
                             assetGraph.removeAsset(relation.to);
                         }
                         relation.detach();
-                    });
+                    }
 
                     // Append asset to new bundle
-                    Array.prototype.push.apply(constructorOptions.parseTree.body, asset.parseTree.body);
-                });
+                    constructorOptions.parseTree.body.push(...asset.parseTree.body);
+                }
             } else {
                 // type === 'Css'
                 constructorOptions.parseTree = postcss.parse('');
                 // Make sure that all @import rules go at the top of the bundle:
-                var importRules = [];
-                assetsToBundle.forEach(function (asset) {
-                    var topLevelNodes = asset.parseTree.nodes;
-                    for (var i = 0 ; i < topLevelNodes.length ; i += 1) {
-                        var topLevelNode = topLevelNodes[i];
+                const importRules = [];
+                for (const asset of assetsToBundle) {
+                    const topLevelNodes = asset.parseTree.nodes;
+                    for (let i = 0 ; i < topLevelNodes.length ; i += 1) {
+                        const topLevelNode = topLevelNodes[i];
                         topLevelNode.parent = constructorOptions.parseTree;
                         if (topLevelNode.type === 'atrule' && topLevelNode.name === 'import') {
                             importRules.push(topLevelNode);
@@ -134,46 +129,47 @@ module.exports = function (queryObj, options) {
                             i -= 1;
                         }
                     }
-                    Array.prototype.push.apply(constructorOptions.parseTree.nodes, topLevelNodes);
-                });
+                    constructorOptions.parseTree.nodes.push(...topLevelNodes);
+                }
                 if (importRules.length > 0) {
-                    Array.prototype.unshift.apply(constructorOptions.parseTree.nodes, importRules);
+                    constructorOptions.parseTree.nodes.unshift(...importRules);
                 }
             }
 
-            var bundleAsset = new AssetGraph[type](constructorOptions);
+            const bundleAsset = new AssetGraph[type](constructorOptions);
 
             bundleAsset.url = urlTools.resolveUrl(assetGraph.root, 'bundle-' + bundleAsset.id + bundleAsset.extension);
             bundleAsset.outgoingRelations = assetGraph.findRelations({from: assetsToBundle}, true);
-            bundleAsset.outgoingRelations.forEach(function (outgoingRelation) {
+            for (const outgoingRelation of bundleAsset.outgoingRelations) {
                 outgoingRelation.remove();
                 outgoingRelation.from = bundleAsset;
-            });
+            }
 
-            var seenReferringAssets = {},
-                incomingRelations = assetGraph.findRelations({type: incomingType, to: assetsToBundle}),
-                // Point at the bundled asset with a root-relative href if at least one of the relations
-                // being bundled have a more specific hrefType than 'relative':
-                bundleRelationHrefType = incomingRelations.some(function (incomingRelation) {
-                    return incomingRelation.hrefType !== 'relative';
-                }) ? 'rootRelative' : 'relative';
+            const seenReferringAssets = {};
+            const incomingRelations = assetGraph.findRelations({type: incomingType, to: assetsToBundle});
 
-            var combinedAssetGraphConditions = {};
+            // Point at the bundled asset with a root-relative href if at least one of the relations
+            // being bundled have a more specific hrefType than 'relative':
+            const bundleRelationHrefType = incomingRelations.some(
+                incomingRelation => incomingRelation.hrefType !== 'relative'
+            ) ? 'rootRelative' : 'relative';
+
+            const combinedAssetGraphConditions = {};
             // Reverse iteration for HtmlScript relations to ensure bundle insertion at tail end
-            (incomingType === 'HtmlScript' ? incomingRelations.slice().reverse() : incomingRelations).forEach(function (incomingRelation) {
+            for (const incomingRelation of (incomingType === 'HtmlScript' ? incomingRelations.slice().reverse() : incomingRelations)) {
                 if (!seenReferringAssets[incomingRelation.from.id]) {
-                    var bundleRelation = new AssetGraph[incomingType]({
+                    const bundleRelation = new AssetGraph[incomingType]({
                         hrefType: bundleRelationHrefType,
                         to: bundleAsset
                     });
                     bundleRelation.attach(incomingRelation.from, 'before', incomingRelation);
                     if (incomingRelation.from.type === 'Html') {
-                        var commonNonce;
-                        var nonceIsUnique = true;
-                        incomingRelations.forEach(function (relation) {
+                        let commonNonce;
+                        let nonceIsUnique = true;
+                        for (const relation of incomingRelations) {
                             if (relation.from === incomingRelation.from) {
                                 if (relation.node.hasAttribute('nonce')) {
-                                    var nonce = relation.node.getAttribute('nonce');
+                                    const nonce = relation.node.getAttribute('nonce');
                                     if (typeof commonNonce === 'undefined') {
                                         commonNonce = nonce;
                                     } else if (commonNonce !== nonce) {
@@ -181,36 +177,36 @@ module.exports = function (queryObj, options) {
                                     }
                                 }
                             }
-                            var conditions = assetGraphConditions.parse(relation.node);
+                            const conditions = assetGraphConditions.parse(relation.node);
                             if (conditions) {
-                                Object.keys(conditions).forEach(function (conditionName) {
+                                for (const conditionName of Object.keys(conditions)) {
                                     if (Array.isArray(combinedAssetGraphConditions[conditionName])) {
                                         combinedAssetGraphConditions[conditionName].push(conditions[conditionName]);
                                     } else {
                                         combinedAssetGraphConditions[conditionName] = [conditions[conditionName]];
                                     }
-                                });
+                                }
                             }
-                        });
+                        }
                         if (typeof commonNonce !== 'undefined' && nonceIsUnique) {
                             bundleRelation.node.setAttribute('nonce', commonNonce);
                             bundleRelation.from.markDirty();
                         }
-                        var conditionNames = Object.keys(combinedAssetGraphConditions);
+                        const conditionNames = Object.keys(combinedAssetGraphConditions);
                         if (conditionNames.length > 0) {
-                            conditionNames.forEach(function (conditionName) {
-                                var uniqueValues = _.uniq(combinedAssetGraphConditions[conditionName]);
+                            for (const conditionName of conditionNames) {
+                                const uniqueValues = _.uniq(combinedAssetGraphConditions[conditionName]);
                                 if (uniqueValues.length === 1) {
                                     combinedAssetGraphConditions[conditionName] = uniqueValues[0];
                                 } else {
                                     combinedAssetGraphConditions[conditionName] = uniqueValues;
                                 }
-                            });
+                            }
                             bundleRelation.node.setAttribute('data-assetgraph-conditions', assetGraphConditions.stringify(combinedAssetGraphConditions));
                         }
                     }
                     if (incomingType === 'HtmlStyle') {
-                        var media = incomingRelation.node.getAttribute('media');
+                        const media = incomingRelation.node.getAttribute('media');
                         if (media && media !== 'all') {
                             bundleRelation.node.setAttribute('media', media);
                             bundleRelation.from.markDirty();
@@ -228,60 +224,60 @@ module.exports = function (queryObj, options) {
                     seenReferringAssets[incomingRelation.from.id] = true;
                 }
                 incomingRelation.detach();
-            });
+            }
 
             assetGraph.addAsset(bundleAsset);
 
-            assetGraph.findRelations({from: bundleAsset}, true).forEach(function (outgoingRelation) {
+            for (const outgoingRelation of assetGraph.findRelations({from: bundleAsset}, true)) {
                 outgoingRelation.refreshHref();
-            });
+            }
 
-            assetsToBundle.forEach(function (asset) {
+            for (const asset of assetsToBundle) {
                 if (assetGraph.findRelations({to: asset}).length === 0) {
                     assetGraph.removeAsset(asset);
                 }
-            });
+            }
             return bundleAsset;
         }
 
-        var bundleStrategyByName = {};
+        const bundleStrategyByName = {};
 
         // Quick and dirty bundling strategy that gets you down to one <script> and one <link rel='stylesheet'>
         // per document, but doesn't do any cross-page optimization.
-        bundleStrategyByName.oneBundlePerIncludingAsset = function () {
-            var assetsToBundleById = {},
-                bundleAssets = [],
-                relationsByIncludingAsset = {};
+        bundleStrategyByName.oneBundlePerIncludingAsset = () => {
+            const assetsToBundleById = {};
+            const bundleAssets = [];
+            const relationsByIncludingAsset = {};
 
-            assetGraph.findRelations(queryObj).forEach(function (relation) {
+            for (const relation of assetGraph.findRelations(queryObj)) {
                 assetsToBundleById[relation.to.id] = relation.to; // Means not in a bundle yet
                 (relationsByIncludingAsset[relation.from.id] = relationsByIncludingAsset[relation.from.id] || []).push(relation);
-            });
+            }
 
-            Object.keys(relationsByIncludingAsset).forEach(function (includingAssetId) {
-                var relationsToBundle = relationsByIncludingAsset[includingAssetId];
+            for (const includingAssetId of Object.keys(relationsByIncludingAsset)) {
+                const relationsToBundle = relationsByIncludingAsset[includingAssetId];
 
-                _.uniq(_.map(relationsToBundle, 'type')).forEach(function (relationType) {
-                    var currentBundle = [],
-                        bundleDiscriminator,
-                        relationsOfTypeToBundle = relationsToBundle.filter(function (relation) {
-                            return relation.type === relationType;
-                        });
+                for (const relationType of _.uniq(_.map(relationsToBundle, 'type'))) {
+                    let currentBundle = [];
+                    let bundleDiscriminator;
+                    const relationsOfTypeToBundle = relationsToBundle.filter(
+                        relation => relation.type === relationType
+                    );
 
                     function flushBundle() {
                         if (currentBundle.length > 0) {
-                            bundleAssets.push(makeBundle(currentBundle, relationType)); // FIXME
+                            bundleAssets.push(makeBundle(currentBundle, relationType));
                             currentBundle = [];
                         }
                     }
-                    assetGraph.findRelations(assetGraph.constructor.query.or({type: relationType}, {type: 'HtmlConditionalComment'}), true).forEach(function (outgoingRelation) {
+                    for (const outgoingRelation of assetGraph.findRelations(assetGraph.constructor.query.or({type: relationType}, {type: 'HtmlConditionalComment'}), true)) {
                         if (outgoingRelation.type === 'HtmlConditionalComment') {
                             if (assetGraph.findRelations({from: outgoingRelation.to, type: relationType}, true).length > 0) {
                                 flushBundle();
                             }
-                        } else if (relationsOfTypeToBundle.indexOf(outgoingRelation) !== -1) {
+                        } else if (relationsOfTypeToBundle.includes(outgoingRelation)) {
                             // Make sure that we don't bundle HtmlStyles with different media attributes together etc.:
-                            var discriminator = getDiscriminatorForRelation(outgoingRelation);
+                            const discriminator = getDiscriminatorForRelation(outgoingRelation);
                             if (bundleDiscriminator && (discriminator === 'nobundle' || bundleDiscriminator === 'nobundle' || discriminator !== bundleDiscriminator)) {
                                 flushBundle();
                             }
@@ -294,65 +290,65 @@ module.exports = function (queryObj, options) {
                         } else {
                             flushBundle();
                         }
-                    });
+                    }
                     flushBundle();
-                });
-            });
+                }
+            }
             return bundleAssets;
         };
 
         // Cross-page optimizing bundling strategy that never puts the same chunk in multiple bundles, but still tries
         // to create as few bundles as possible. Also preserves inclusion order.
-        bundleStrategyByName.sharedBundles = function () {
-            var assetIndex = {},
-                seenIncludingAssets = {},
-                bundles = [],
-                relationsByIncludingAsset = {};
+        bundleStrategyByName.sharedBundles = () => {
+            const assetIndex = {};
+            const seenIncludingAssets = {};
+            const bundles = [];
+            const relationsByIncludingAsset = {};
 
-            assetGraph.findRelations(queryObj).forEach(function (relation) {
+            for (const relation of assetGraph.findRelations(queryObj)) {
                 assetIndex[relation.to.id] = null; // Means not in a bundle yet
                 seenIncludingAssets[relation.from.id] = relation.from;
                 (relationsByIncludingAsset[relation.from.id] = relationsByIncludingAsset[relation.from.id] || []).push(relation);
-            });
+            }
 
             function splitBundle(bundle, index) {
-                var newBundle = bundle.splice(index);
+                const newBundle = bundle.splice(index);
                 newBundle._relationType = bundle._relationType;
-                newBundle.forEach(function (asset) {
+                for (const asset of newBundle) {
                     assetIndex[asset.id] = newBundle;
-                });
+                }
                 if (newBundle.length > 0) {
                     bundles.push(newBundle);
                 }
                 return newBundle;
             }
 
-            _.values(seenIncludingAssets).forEach(function (includingAsset) {
-                var relationsToBundle = relationsByIncludingAsset[includingAsset.id];
+            for (const includingAsset of _.values(seenIncludingAssets)) {
+                const relationsToBundle = relationsByIncludingAsset[includingAsset.id];
 
-                _.uniq(_.map(relationsToBundle, 'type')).forEach(function (relationType) {
-                    var outgoingRelations = assetGraph.findRelations({from: includingAsset, type: [relationType, 'HtmlConditionalComment']}, true), // includeUnresolved
-                        previousBundle,
-                        bundleDiscriminator,
-                        canAppendToPreviousBundle = false,
-                        previousBundleIndex;
+                for (const relationType of _.uniq(_.map(relationsToBundle, 'type'))) {
+                    const outgoingRelations = assetGraph.findRelations({from: includingAsset, type: [relationType, 'HtmlConditionalComment']}, true); // includeUnresolved
+                    let previousBundle;
+                    let bundleDiscriminator;
+                    let canAppendToPreviousBundle = false;
+                    let previousBundleIndex;
 
-                    outgoingRelations.forEach(function (outgoingRelation) {
+                    for (const outgoingRelation of outgoingRelations) {
                         if (outgoingRelation.type === 'HtmlConditionalComment') {
                             if (assetGraph.findRelations({from: outgoingRelation.to, type: relationType}).length > 0) {
                                 canAppendToPreviousBundle = false;
                             }
-                            return;
+                            continue;
                         }
 
                         // Make sure that we don't bundle HtmlStyles with different media attributes together etc.:
-                        var discriminator = getDiscriminatorForRelation(outgoingRelation);
+                        const discriminator = getDiscriminatorForRelation(outgoingRelation);
                         if (bundleDiscriminator && (discriminator === 'nobundle' || bundleDiscriminator === 'nobundle' || discriminator !== bundleDiscriminator)) {
                             canAppendToPreviousBundle = false;
                         }
                         bundleDiscriminator = discriminator;
 
-                        var existingBundle = assetIndex[outgoingRelation.to.id];
+                        let existingBundle = assetIndex[outgoingRelation.to.id];
                         if (existingBundle === null) {
                             // Not bundled yet, append to previousBundle if possible, else create a new one
                             if (canAppendToPreviousBundle) {
@@ -372,7 +368,7 @@ module.exports = function (queryObj, options) {
                         } else if (existingBundle) {
                             // Already in another bundle
                             canAppendToPreviousBundle = false;
-                            var indexInExistingBundle = existingBundle.indexOf(outgoingRelation.to);
+                            let indexInExistingBundle = existingBundle.indexOf(outgoingRelation.to);
                             if (previousBundle && existingBundle === previousBundle) {
                                 if (indexInExistingBundle === previousBundleIndex + 1) {
                                     previousBundleIndex = indexInExistingBundle;
@@ -401,29 +397,26 @@ module.exports = function (queryObj, options) {
                             previousBundle = null;
                             canAppendToPreviousBundle = false;
                         }
-                    });
+                    }
                     // No more outgoing relations for this asset, make sure that the asset that was bundled
                     // last is at the last position in its bundle:
                     if (previousBundle && previousBundleIndex !== previousBundle.length - 1) {
                         splitBundle(previousBundle, previousBundleIndex + 1);
                     }
 
-                });
-            });
+                }
+            }
 
-            return bundles.map(function (bundle) {
-                makeBundle(bundle, bundle._relationType);
-            });
+            return bundles.map(bundle => makeBundle(bundle, bundle._relationType));
         };
 
-        var bundleAssets = bundleStrategyByName[bundleStrategyName]();
-        bundleAssets.forEach(function (bundleAsset) {
-            assetGraph.findRelations({to: bundleAsset}).forEach(function (incomingRelation) {
+        for (const bundleAsset of bundleStrategyByName[bundleStrategyName]()) {
+            for (const incomingRelation of assetGraph.findRelations({to: bundleAsset})) {
                 incomingRelation.refreshHref();
-            });
-            assetGraph.findRelations({from: bundleAsset}).forEach(function (outgoingRelation) {
+            }
+            for (const outgoingRelation of assetGraph.findRelations({from: bundleAsset})) {
                 outgoingRelation.refreshHref();
-            });
-        });
+            }
+        }
     };
 };

--- a/lib/transforms/bundleRequireJs.js
+++ b/lib/transforms/bundleRequireJs.js
@@ -1,18 +1,18 @@
 /*jshint unused:false*/
-var _ = require('lodash');
-var pathModule = require('path');
-var urlTools = require('urltools');
-var getTemporaryFilePath = require('gettemporaryfilepath');
-var AssetGraph = require('../../lib/AssetGraph');
-var estraverse = require('estraverse');
-var esanimate = require('esanimate');
-var Promise = require('bluebird');
-var fs = Promise.promisifyAll(require('fs'));
+const _ = require('lodash');
+const pathModule = require('path');
+const urlTools = require('urltools');
+const getTemporaryFilePath = require('gettemporaryfilepath');
+const AssetGraph = require('../../lib/AssetGraph');
+const estraverse = require('estraverse');
+const esanimate = require('esanimate');
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
 
 function extractRequireJsConfigFragments(parseTree, htmlAsset) {
-    var requireJsConfigFragments = [];
+    const requireJsConfigFragments = [];
     estraverse.traverse(parseTree, {
-        enter: function (node) {
+        enter: node => {
             if (node.type === 'ExpressionStatement' &&
                 node.expression.type === 'CallExpression' &&
                 node.expression.callee.type === 'MemberExpression' &&
@@ -25,13 +25,13 @@ function extractRequireJsConfigFragments(parseTree, htmlAsset) {
                 // require.config({})
                 requireJsConfigFragments.push(esanimate.objectify(node.expression.arguments[0]));
             } else if (node.type === 'VariableDeclaration') {
-                node.declarations.forEach(function (declarator) {
+                for (const declarator of node.declarations) {
                     if ((declarator.id.type === 'Identifier' && (declarator.id.name === 'require' || declarator.id.name === 'requirejs')) && declarator.init && declarator.init.type === 'ObjectExpression') {
                         // var require = {}
                         // var requirejs = {}
                         requireJsConfigFragments.push(esanimate.objectify(declarator.init));
                     }
-                });
+                }
             } else if (node.type === 'AssignmentExpression' &&
                        node.left.type === 'Identifier' &&
                        node.operator === '=' &&
@@ -60,157 +60,157 @@ function extractRequireJsConfigFragments(parseTree, htmlAsset) {
                        node.right.type === 'Literal' &&
                        typeof node.right.value === 'string') {
                 // require.config.baseUrl = '...'
-                requireJsConfigFragments.push({baseUrl: htmlAsset.assetGraph.resolveUrl(htmlAsset.Url.replace(/[^\/]+([\?#].*)?$/, ''), node.right.value.replace(/\/?$/, '/'))});
+                requireJsConfigFragments.push({
+                    baseUrl: htmlAsset.assetGraph.resolveUrl(
+                        htmlAsset.url.replace(/[^\/]+([\?#].*)?$/, ''),
+                        node.right.value.replace(/\/?$/, '/')
+                    )
+                });
             }
         }
     });
     return requireJsConfigFragments;
 }
 
-module.exports = function (options) {
+module.exports = options => {
     options = options || {};
-    return function bundleRequireJs(assetGraph) {
-        var requireJs;
-        var entryPoints = [];
-        assetGraph.findAssets({type: 'Html', isFragment: false, isLoaded: true}).forEach(function (htmlAsset) {
-            assetGraph.findRelations({from: htmlAsset, type: 'HtmlScript'}).forEach(function (htmlScript, i, htmlScripts) {
-                var dataMain = htmlScript.node.getAttribute('data-main');
+    return async function bundleRequireJs(assetGraph) {
+        let requireJs;
+        const entryPoints = [];
+        for (const htmlAsset of assetGraph.findAssets({type: 'Html', isFragment: false, isLoaded: true})) {
+            const htmlScripts = assetGraph.findRelations({from: htmlAsset, type: 'HtmlScript'});
+            for (let i = 0 ; i < htmlScripts.length ; i += 1) {
+                const htmlScript = htmlScripts[i];
+                const dataMain = htmlScript.node.getAttribute('data-main');
                 if (dataMain) {
-                    var requireJsConfigFragments = [];
-                    htmlScripts.slice(0, i).forEach(function (preceedingHtmlScript) {
+                    const requireJsConfigFragments = [];
+                    for (const preceedingHtmlScript of htmlScripts.slice(0, i)) {
                         if (preceedingHtmlScript.to && preceedingHtmlScript.to.isLoaded) {
-                            Array.prototype.push.apply(requireJsConfigFragments, extractRequireJsConfigFragments(preceedingHtmlScript.to.parseTree, htmlAsset));
+                            requireJsConfigFragments.push(...extractRequireJsConfigFragments(preceedingHtmlScript.to.parseTree, htmlAsset));
                         }
-                    });
+                    }
                     entryPoints.push({
-                        htmlScript: htmlScript,
-                        requireJsConfig: _.merge.apply(_, [{}].concat(requireJsConfigFragments))
+                        htmlScript,
+                        requireJsConfig: _.merge({}, ...requireJsConfigFragments)
                     });
                 }
-            });
-        });
+            }
+        }
         if (entryPoints.length > 0) {
-            var globalSnapshot = _.extend({}, global);
+            const globalSnapshot = _.extend({}, global);
             try {
                 requireJs = require('requirejs');
             } catch (e) {
-                throw new Error(
-                    'The graph contains ' + entryPoints.length + ' top-level data-main attribute' + (entryPoints.length === 1 ? '' : 's') +
+                assetGraph.emit('error', new Error(
+                    `The graph contains ${entryPoints.length} top-level data-main attribute ${entryPoints.length === 1 ? '' : 's'}` +
                     ', but the requirejs package is not available. Please install requirejs in the the containing project.'
-                );
+                ));
             }
 
-            var potentiallyOrphanedAssetsById = {};
+            const potentiallyOrphanedAssetsById = {};
 
-            return Promise.map(entryPoints, function (entryPoint) {
-                var requireJsConfig = entryPoint.requireJsConfig;
-                var node = entryPoint.htmlScript.node;
-                var dataMain = node.getAttribute('data-main');
-                node.removeAttribute('data-main');
-                var baseUrl = requireJsConfig.baseUrl;
-                if (baseUrl) {
-                    baseUrl = assetGraph.resolveUrl(entryPoint.htmlScript.from.nonInlineAncestor.url, baseUrl).replace(/^file:\/\//, '');
-                } else {
-                    baseUrl = urlTools.fileUrlToFsPath(assetGraph.root);
-                    var lastIndexOfSlash = dataMain.lastIndexOf('/');
-                    if (lastIndexOfSlash !== -1) {
-                        baseUrl = assetGraph.resolveUrl(baseUrl, dataMain.slice(0, lastIndexOfSlash));
-                        dataMain = dataMain.slice(lastIndexOfSlash + 1, dataMain.length);
+            try {
+                for (const entryPoint of entryPoints) {
+                    const { requireJsConfig, htmlScript } = entryPoint;
+                    let dataMain = htmlScript.node.getAttribute('data-main');
+                    htmlScript.node.removeAttribute('data-main');
+                    let baseUrl = requireJsConfig.baseUrl;
+                    if (baseUrl) {
+                        baseUrl = assetGraph.resolveUrl(htmlScript.from.nonInlineAncestor.url, baseUrl)
+                            .replace(/^file:\/\//, '');
+                    } else {
+                        baseUrl = urlTools.fileUrlToFsPath(assetGraph.root);
+                        const lastIndexOfSlash = dataMain.lastIndexOf('/');
+                        if (lastIndexOfSlash !== -1) {
+                            baseUrl = assetGraph.resolveUrl(baseUrl, dataMain.slice(0, lastIndexOfSlash));
+                            dataMain = dataMain.slice(lastIndexOfSlash + 1, dataMain.length);
+                        }
                     }
-                }
-                baseUrl = baseUrl.replace(/\/?$/, '/'); // Ensure trailing slash
-                var outBundleFile = getTemporaryFilePath({suffix: '.js'});
-                var outCssFileName = outBundleFile.replace(/\.js$/, '.css');
-                var requireJsOptimizeOptions = _.defaults({
-                    siteRoot: urlTools.fileUrlToFsPath(assetGraph.root), // https://github.com/guybedford/require-css#siteroot-configuration
-                    baseUrl: baseUrl,
-                    name: dataMain,
-                    out: outBundleFile,
-                    optimize: 'none',
-                    generateSourceMaps: true,
-                    preserveLicenseComments: true
-                }, requireJsConfig);
-                var dataAlmond = node.getAttribute('data-almond');
-                if (dataAlmond) {
-                    potentiallyOrphanedAssetsById[entryPoint.htmlScript.to.id] = entryPoint.htmlScript.to;
-                    entryPoint.htmlScript.href = dataAlmond;
-                    entryPoint.htmlScript.to = { url: dataAlmond };
-                    node.removeAttribute('data-almond');
-                }
+                    baseUrl = baseUrl.replace(/\/?$/, '/'); // Ensure trailing slash
+                    const outBundleFile = getTemporaryFilePath({suffix: '.js'});
+                    const outCssFileName = outBundleFile.replace(/\.js$/, '.css');
+                    const requireJsOptimizeOptions = _.defaults({
+                        siteRoot: urlTools.fileUrlToFsPath(assetGraph.root), // https://github.com/guybedford/require-css#siteroot-configuration
+                        baseUrl,
+                        name: dataMain,
+                        out: outBundleFile,
+                        optimize: 'none',
+                        generateSourceMaps: true,
+                        preserveLicenseComments: true
+                    }, requireJsConfig);
+                    const dataAlmond = htmlScript.node.getAttribute('data-almond');
+                    if (dataAlmond) {
+                        potentiallyOrphanedAssetsById[htmlScript.to.id] = htmlScript.to;
+                        htmlScript.href = dataAlmond;
+                        htmlScript.to = { url: dataAlmond };
+                        htmlScript.node.removeAttribute('data-almond');
+                    }
 
-                return new Promise(function (resolve) {
-                    requireJs.optimize(requireJsOptimizeOptions, resolve); // Does not pass err as the first parameter
-                }).then(function (buildResponse) {
-                    //buildResponse is just a text output of the modules
-                    //included. Load the built file for the contents.
-                    //Use config.out to get the optimized file contents.
-                    return fs.readFileAsync(outBundleFile, 'utf-8');
-                }).then(function (contents) {
-                    var sourceMapFileName;
-                    contents = contents.replace(/\/\/[@#]\s*sourceMappingURL=([\w-\.]+)\s*$/, function ($0, sourceMapUrl) {
+                    await new Promise(resolve => requireJs.optimize(requireJsOptimizeOptions, resolve)); // Does not pass err as the first parameter
+
+                    let contents = await fs.readFileAsync(outBundleFile, 'utf-8');
+                    await fs.unlinkAsync(outBundleFile);
+
+                    let sourceMapFileName;
+                    contents = contents.replace(/\/\/[@#]\s*sourceMappingURL=([\w-\.]+)\s*$/, ($0, sourceMapUrl) => {
                         sourceMapFileName = pathModule.resolve(pathModule.dirname(outBundleFile), decodeURIComponent(sourceMapUrl));
                         return '';
                     });
-                    var bundleAsset = new AssetGraph.JavaScript({
+                    const bundleAsset = new AssetGraph.JavaScript({
                         text: contents,
                         url: 'file://' + baseUrl + (dataMain ? dataMain + '-' : '') + 'bundle.js',
                         sourceMap: undefined
                     });
                     new AssetGraph.HtmlScript({
                         to: bundleAsset
-                    }).attach(entryPoint.htmlScript.from, 'after', entryPoint.htmlScript);
+                    }).attach(htmlScript.from, 'after', htmlScript);
                     assetGraph.addAsset(bundleAsset);
                     if (sourceMapFileName) {
-                        return fs.readFileAsync(sourceMapFileName, 'utf-8').then(function (sourceMapContents) {
-                            var sourceMap = JSON.parse(sourceMapContents);
-                            sourceMap.file = '/' + urlTools.buildRelativeUrl(assetGraph.root, bundleAsset.url);
-                            sourceMap.sources = sourceMap.sources.map(function (sourceFileName) {
-                                return '/' + urlTools.buildRelativeUrl(assetGraph.root, 'file://' + baseUrl + sourceFileName);
-                            });
-                            bundleAsset.sourceMap = sourceMap;
-                        }).finally(function () {
-                            return fs.unlinkAsync(sourceMapFileName);
-                        });
+                        const sourceMapContents = await fs.readFileAsync(sourceMapFileName, 'utf-8');
+                        await fs.unlinkAsync(sourceMapFileName);
+                        const sourceMap = JSON.parse(sourceMapContents);
+                        sourceMap.file = '/' + urlTools.buildRelativeUrl(assetGraph.root, bundleAsset.url);
+                        sourceMap.sources = sourceMap.sources.map(
+                            sourceFileName => '/' + urlTools.buildRelativeUrl(assetGraph.root, 'file://' + baseUrl + sourceFileName)
+                        );
+                        bundleAsset.sourceMap = sourceMap;
                     }
-                }).then(function () {
-                    return fs.statAsync(outCssFileName).catch(function () {}).then(function (stats) {
-                        if (stats && stats.isFile()) {
-                            return fs.readFileAsync(outCssFileName, 'utf-8').then(function (cssContents) {
-                                if (cssContents) {
-                                    var cssBundleAsset = new AssetGraph.Css({
-                                        text: cssContents,
-                                        url: 'file://' + baseUrl + (dataMain ? dataMain + '-' : '') + 'bundle.css',
-                                        sourceMap: undefined
-                                    });
-                                    var htmlStyle = new AssetGraph.HtmlStyle({to: cssBundleAsset});
-                                    var existingHtmlStyles = assetGraph.findRelations({from: entryPoint.htmlScript.from, type: 'HtmlStyle'});
-                                    var lastExistingHtmlStyle = existingHtmlStyles[existingHtmlStyles.length - 1];
-                                    htmlStyle.attach(entryPoint.htmlScript.from, lastExistingHtmlStyle ? 'after' : 'first', lastExistingHtmlStyle);
-                                    assetGraph.addAsset(cssBundleAsset);
-                                }
-                            }).finally(function () {
-                                fs.unlinkAsync(outCssFileName);
+
+                    let stats;
+                    try {
+                        stats = await fs.statAsync(outCssFileName);
+                    } catch (e) {}
+                    if (stats && stats.isFile()) {
+                        const cssContents = await fs.readFileAsync(outCssFileName, 'utf-8');
+                        if (cssContents) {
+                            const cssBundleAsset = new AssetGraph.Css({
+                                text: cssContents,
+                                url: 'file://' + baseUrl + (dataMain ? dataMain + '-' : '') + 'bundle.css',
+                                sourceMap: undefined
                             });
+                            const htmlStyle = new AssetGraph.HtmlStyle({to: cssBundleAsset});
+                            const existingHtmlStyles = assetGraph.findRelations({from: htmlScript.from, type: 'HtmlStyle'});
+                            const lastExistingHtmlStyle = existingHtmlStyles[existingHtmlStyles.length - 1];
+                            htmlStyle.attach(htmlScript.from, lastExistingHtmlStyle ? 'after' : 'first', lastExistingHtmlStyle);
+                            assetGraph.addAsset(cssBundleAsset);
                         }
-                    });
-                }).finally(function () {
-                    fs.unlinkAsync(outBundleFile);
-                });
-            }).then(function () {
+                        await fs.unlinkAsync(outCssFileName);
+                    }
+                }
                 // Clean up require.js assets if nothing is referring to them any more
-                Object.keys(potentiallyOrphanedAssetsById).forEach(function (assetId) {
-                    var asset = potentiallyOrphanedAssetsById[assetId];
+                for (const assetId of Object.keys(potentiallyOrphanedAssetsById)) {
+                    const asset = potentiallyOrphanedAssetsById[assetId];
                     if (assetGraph.findRelations({to: asset}).length === 0) {
                         assetGraph.removeAsset(asset);
                     }
-                });
-            }).finally(function () {
-                Object.keys(global).forEach(function (key) {
+                }
+            } finally {
+                for (const key of Object.keys(global)) {
                     if (!(key in globalSnapshot)) {
                         delete global[key];
                     }
-                });
-            });
+                }
+            }
         }
     };
 };

--- a/lib/transforms/bundleRequireJs.js
+++ b/lib/transforms/bundleRequireJs.js
@@ -97,7 +97,7 @@ module.exports = options => {
             }
         }
         if (entryPoints.length > 0) {
-            const globalSnapshot = _.extend({}, global);
+            const globalSnapshot = Object.assign({}, global);
             try {
                 requireJs = require('requirejs');
             } catch (e) {

--- a/lib/transforms/bundleSystemJs.js
+++ b/lib/transforms/bundleSystemJs.js
@@ -1,22 +1,22 @@
 /*jshint unused:false*/
-var _ = require('lodash'),
-    Promise = require('bluebird'),
-    esanimate = require('esanimate'),
-    estraverse = require('estraverse'),
-    urlTools = require('urltools'),
-    AssetGraph = require('../AssetGraph'),
-    assetGraphConditions = require('../assetGraphConditions');
+const _ = require('lodash');
+const Promise = require('bluebird');
+const esanimate = require('esanimate');
+const estraverse = require('estraverse');
+const urlTools = require('urltools');
+const AssetGraph = require('../AssetGraph');
+const assetGraphConditions = require('../assetGraphConditions');
 
 function extractSystemJsConfig(incomingRelations) { // HtmlScript, HtmlServiceWorkerRegistration, JavaScriptServiceWorkerRegistration, JavaScriptWebWorker, and JavaScriptImportScripts
-    var systemJsConfig = {
+    const systemJsConfig = {
         configStatements: [],
         topLevelSystemImportCalls: []
     };
-    incomingRelations.forEach(function (relation) {
-        var seenConfig = false;
-        var seenImport = false;
+    for (const relation of incomingRelations) {
+        let seenConfig = false;
+        let seenImport = false;
         estraverse.traverse(relation.to.parseTree, {
-            enter: function (node, parentNode) {
+            enter(node, parentNode) {
                 if (node.type === 'CallExpression' &&
                     node.callee.type === 'MemberExpression' &&
                     !node.callee.computed &&
@@ -27,10 +27,10 @@ function extractSystemJsConfig(incomingRelations) { // HtmlScript, HtmlServiceWo
 
                     if (node.callee.property.name === 'config') {
                         seenConfig = true;
-                        var parentNodes = this.parents();
+                        const parentNodes = this.parents();
                         systemJsConfig.configStatements.push({
                             asset: relation.to,
-                            node: node,
+                            node,
                             parentNode: parentNode.type === 'SequenceExpression' ? parentNodes[parentNodes.length - 1] : parentNodes[parentNodes.length - 2],
                             detachableNode: parentNode.type === 'SequenceExpression' ? node : parentNodes[parentNodes.length - 1]
                         });
@@ -39,7 +39,7 @@ function extractSystemJsConfig(incomingRelations) { // HtmlScript, HtmlServiceWo
                         systemJsConfig.topLevelSystemImportCalls.push({
                             argumentString: node.arguments[0].value,
                             asset: relation.to,
-                            node: node
+                            node
                         });
                     }
                 }
@@ -48,16 +48,14 @@ function extractSystemJsConfig(incomingRelations) { // HtmlScript, HtmlServiceWo
         if (seenConfig && seenImport) {
             throw new Error('Please do not use both System.config and System.import in the same script as it will cause the generated bundle to be injected in the wrong place.');
         }
-    });
+    }
     return systemJsConfig;
 }
 
 // meta, packages deep
 function getSharedProperties(configA, configB) {
-    var bKeys = Object.keys(configB);
-    return Object.keys(configA).filter(function (p) {
-        return bKeys.indexOf(p) !== -1;
-    });
+    const bKeys = Object.keys(configB);
+    return Object.keys(configA).filter(p => bKeys.includes(p));
 }
 
 function arrayEquals(arrayA, arrayB) {
@@ -69,9 +67,9 @@ function detectObjectConflict(objA, objB) {
     if (!objA || !objB) {
         return false;
     }
-    return getSharedProperties(objA, objB).some(function (prop) {
-        var valueA = objA[prop];
-        var valueB = objB[prop];
+    return getSharedProperties(objA, objB).some(prop => {
+        const valueA = objA[prop];
+        const valueB = objB[prop];
         if (valueA instanceof Array && valueB instanceof Array) {
             return !arrayEquals(valueA, valueB);
         } else if (typeof valueA === 'object' || typeof valueB === 'object') {
@@ -87,13 +85,13 @@ function detectMetaConflict(metaA, metaB) {
     if (!metaA || !metaB) {
         return false;
     }
-    return getSharedProperties(metaA, metaB).some(function (prop) {
-        var valueA = metaA[prop];
-        var valueB = metaB[prop];
+    return getSharedProperties(metaA, metaB).some(prop => {
+        const valueA = metaA[prop];
+        const valueB = metaB[prop];
 
         // ensure both arrays (which would concat in conflict scenario)
-        if (valueA instanceof Array || valueB instanceof Array) {
-            return !(valueA instanceof Array && valueB instanceof Array) || !arrayEquals(valueA, valueB);
+        if (Array.isArray(valueA) || Array.isArray(valueB)) {
+            return !(Array.isArray(valueA) && Array.isArray(valueB)) || !arrayEquals(valueA, valueB);
         } else if (typeof valueA === 'object' || typeof valueB === 'object') {
             // ensure objects don't conflict
             return !(typeof valueA === 'object' && typeof valueB === 'object') || detectObjectConflict(valueA, valueB);
@@ -104,7 +102,7 @@ function detectMetaConflict(metaA, metaB) {
 }
 
 function detectSystemJSConflict(configA, configB) {
-    if (['pluginFirst', 'defaultJSExtensions'].some(function (value) {
+    if (['pluginFirst', 'defaultJSExtensions'].some(value => {
         if (typeof configA[value] !== 'undefined' && typeof configB[value] !== 'undefined') {
             return configA[value] !== configB[value];
         }
@@ -115,29 +113,29 @@ function detectSystemJSConflict(configA, configB) {
         return !arrayEquals(configA.packageConfigPaths, configB.packageConfigPaths);
     }
 
-    if (['map', 'paths', 'bundles', 'depCache'].some(function (value) {
+    if (['map', 'paths', 'bundles', 'depCache'].some(value => {
         return detectObjectConflict(configA[value], configB[value]);
     })) {
         return true;
     }
 
-    if (['meta', 'babelOptions', 'traceurOptions'].some(function (value) {
+    if (['meta', 'babelOptions', 'traceurOptions'].some(value => {
         return detectMetaConflict(configA[value], configB[value]);
     })) {
         return true;
     }
 
     if (configA.packages && configB.packages) {
-        if (getSharedProperties(configA.packages, configB.packages).some(function (pkgName) {
-            var packageA = configA.packages[pkgName];
-            var packageB = configB.packages[pkgName];
-            if (['main', 'format', 'defaultExtension', 'basePath'].some(function (value) {
+        if (getSharedProperties(configA.packages, configB.packages).some(pkgName => {
+            const packageA = configA.packages[pkgName];
+            const packageB = configB.packages[pkgName];
+            if (['main', 'format', 'defaultExtension', 'basePath'].some(value => {
                 return packageA[value] !== packageB[value];
             })) {
                 return true;
             }
 
-            if (['map', 'depCache'].some(function (value) {
+            if (['map', 'depCache'].some(value => {
                 return detectObjectConflict(packageA[value], packageB[value]);
             })) {
                 return true;
@@ -176,21 +174,21 @@ function detectSystemJSConflict(configA, configB) {
  * Any remaining conditional variation will then be iterated through all conditional combinations
  * per individual entry point providing the entry point "conditions" variations of the output
  */
-function bundleStrategy(builder, entryPoints, options) {
+async function bundleStrategy(builder, entryPoints, options) {
     // output
-    var bundles = {};
+    const bundles = {};
 
     // we inline conditions that are singular in passed options
-    var inlineConditions = {};
+    const inlineConditions = {};
     if (options.conditions) {
-        Object.keys(options.conditions).forEach(function (condition) {
-            var val = options.conditions[condition];
+        for (const condition of Object.keys(options.conditions)) {
+            const val = options.conditions[condition];
             if (typeof val === 'string') {
                 inlineConditions[condition] = val;
-            } else if (val instanceof Array && val.length === 1) {
+            } else if (Array.isArray(val) && val.length === 1) {
                 inlineConditions[condition] = options.conditions[condition][0];
             }
-        });
+        }
     }
 
     entryPoints = entryPoints.concat([]);
@@ -207,36 +205,36 @@ function bundleStrategy(builder, entryPoints, options) {
     // with duplication avoidance
     function generateBundleName(name, modules, conditionValueOrVariationObject) {
         // first check if the given modules already matches an existing bundle
-        var existingBundleName;
-        Object.keys(bundles).forEach(function (bundleName) {
-            var bundleModules = bundles[bundleName].modules;
+        let existingBundleName;
+        for (const bundleName of Object.keys(bundles)) {
+            const bundleModules = bundles[bundleName].modules;
 
             if (containsModules(modules, bundleModules) && containsModules(bundleModules, modules)) {
                 existingBundleName = bundleName;
             }
-        });
+        }
         if (existingBundleName) {
             return existingBundleName;
         }
 
-        var shortName = name.split('/').pop();
-        var dotIndex = shortName.lastIndexOf('.');
+        let shortName = name.split('/').pop();
+        const dotIndex = shortName.lastIndexOf('.');
         if (dotIndex > 0) {
             shortName = shortName.substr(0, dotIndex);
         }
 
-        var bundleName = shortName.replace(/[ \.]/g, '').toLowerCase();
+        let bundleName = shortName.replace(/[ \.]/g, '').toLowerCase();
         if (conditionValueOrVariationObject) {
             if (typeof conditionValueOrVariationObject === 'string') {
                 bundleName += '-' + conditionValueOrVariationObject;
             } else {
-                Object.keys(conditionValueOrVariationObject).forEach(function (condition) {
+                for (const condition of Object.keys(conditionValueOrVariationObject)) {
                     bundleName += '-' + conditionValueOrVariationObject[condition];
-                });
+                }
             }
         }
 
-        var i;
+        let i;
         if (bundles[bundleName]) {
             i = 1;
             while (bundles[bundleName + '-' + i]) {
@@ -248,159 +246,126 @@ function bundleStrategy(builder, entryPoints, options) {
 
     // intersect two arrays
     function intersectModules(modulesA, modulesB) {
-        var intersection = [];
-        modulesA.forEach(function (module) {
-            if (modulesB.indexOf(module) !== -1) {
+        const intersection = [];
+        for (const module of modulesA) {
+            if (modulesB.includes(module)) {
                 intersection.push(module);
             }
-        });
+        }
         return intersection;
     }
 
     // remove elements of arrayB from arrayA
     function subtractModules(modulesA, modulesB) {
-        var subtracted = [];
-        modulesA.forEach(function (module) {
-            if (modulesB.indexOf(module) === -1) {
+        const subtracted = [];
+        for (const module of modulesA) {
+            if (!modulesB.includes(module)) {
                 subtracted.push(module);
             }
-        });
+        }
         return subtracted;
     }
 
     // returns true if modulesA contains all the modules in modulesB
     function containsModules(modulesA, modulesB) {
-        return !modulesB.some(function (module) {
-            return modulesA.indexOf(module) === -1;
-        });
+        return !modulesB.some(module => !modulesA.includes(module));
     }
 
-    function getModuleTrace(entryPointName, options) {
-        return builder.trace(entryPointName, options)
-        .then(function (tree) {
-            return Object.keys(tree).filter(function (module) {
-                return tree[module] && !tree[module].conditional;
-            });
-        });
+    async function getModuleTrace(entryPointName, options) {
+        const tree = await builder.trace(entryPointName, options);
+        return Object.keys(tree).filter(module => tree[module] && !tree[module].conditional);
     }
 
     // intermediate data
-    var manualBundles = options.manualBundles || {};
-    var entryPointModules = [/*{ name, deferredParent, modules / conditionalVariations: [{ modules, conditions }]*/];
-    var allEntryPoints = [].concat(entryPoints);
-    var conditionalEnv;
+    const manualBundles = options.manualBundles || {};
+    const entryPointModules = [/*{ name, deferredParent, modules / conditionalVariations: [{ modules, conditions }]*/];
+    let allEntryPoints = [].concat(entryPoints);
+    let conditionalEnv;
 
     // Trace the deferred entry points to get all entry points
-    return Promise.resolve()
-    .then(function () {
-        if (!options.deferredImports) {
+    if (options.deferredImports) {
+        await Promise.map(entryPoints, async entryPoint => {
+            const tree = await builder.trace(entryPoint.name, options);
+            const deferredImports = await builder.getDeferredImports(tree);
+            allEntryPoints = allEntryPoints.concat(deferredImports.map(deferredImport => ({
+                name: deferredImport.name,
+                deferredParent: entryPoint.name
+            })));
+        });
+    }
+
+    // populate entryPointModules from allEntryPoints
+    // based on determining conditional variations and associated modules
+    // { name, deferredParent, conditions, modules }
+    await Promise.map(allEntryPoints, async entryPoint => {
+        conditionalEnv = await builder.traceConditionalEnv(entryPoint.name, Object.assign({ inlineConditions }, options));
+
+        // remove set conditions from conditionalEnv
+        for (const condition of Object.keys(options.conditions || {})) {
+            delete conditionalEnv[condition];
+        }
+
+        // generate conditional combinations recursively (for general case of arbitrarily many conditional combinations)
+        function generateVariationsOverConditions(conditionList) {
+            let curCondition = conditionList[0];
+
+            if (!curCondition) {
+                return [];
+            }
+
+            // get combinations from the n - 1th dimension
+            const nextVariations = generateVariationsOverConditions(conditionList.slice(1));
+            const variations = [];
+
+            if (!nextVariations.length) {
+                for (const curConditionValue of conditionalEnv[curCondition]) {
+                    const variationConditions = {};
+                    variationConditions[curCondition] = curConditionValue;
+                    variations.push(variationConditions);
+                }
+            }
+
+            // multiply the combinations of the n - 1 dimension by the cominations of this nth dimension
+            for (const nextVariation of nextVariations) {
+                for (const curConditionValue of conditionalEnv[curCondition]) {
+                    const variationConditions = Object.assign({}, nextVariation);
+                    variationConditions[curCondition] = curConditionValue;
+                    variations.push(variationConditions);
+                }
+            }
+
+            return variations;
+        }
+
+        const conditionsCombinations = generateVariationsOverConditions(Object.keys(conditionalEnv));
+
+        if (conditionsCombinations.length === 0) {
+            const modules = await getModuleTrace(entryPoint.name, Object.assign({ inlineConditions }, options));
+            entryPointModules.push({
+                name: entryPoint.name,
+                deferredParent: entryPoint.deferredParent,
+                modules: modules
+            });
             return;
         }
 
-        return Promise.all(entryPoints.map(function (entryPoint) {
-            return builder.trace(entryPoint.name, options)
-            .then(function (tree) {
-                return builder.getDeferredImports(tree).then(function (deferredImports) {
-                    allEntryPoints = allEntryPoints.concat(deferredImports.map(function (deferredImport) {
-                        return {
-                            name: deferredImport.name,
-                            deferredParent: entryPoint.name
-                        };
-                    }));
-                });
-            });
-        }));
-    })
+        // trace conditional variations
+        const conditionalVariations = [];
+        entryPointModules.push({
+            name: entryPoint.name,
+            deferredParent: entryPoint.deferredParent,
+            conditionalVariations
+        });
 
-    .then(function () {
-        // populate entryPointModules from allEntryPoints
-        // based on determining conditional variations and associated modules
-        // { name, deferredParent, conditions, modules }
-        return Promise.all(allEntryPoints.map(function (entryPoint) {
-            return builder.traceConditionalEnv(entryPoint.name, Object.assign({ inlineConditions: inlineConditions }, options))
-            .then(function (_conditionalEnv) {
-                conditionalEnv = _conditionalEnv;
-
-                // remove set conditions from conditionalEnv
-                Object.keys(options.conditions || {}).forEach(function (condition) {
-                    delete conditionalEnv[condition];
-                });
-
-                // generate conditional combinations recursively (for general case of arbitrarily many conditional combinations)
-                function generateVariationsOverConditions(conditionList) {
-                    var curCondition = conditionList[0];
-
-                    if (!curCondition) {
-                        return [];
-                    }
-
-                    // get combinations from the n - 1th dimension
-                    var nextVariations = generateVariationsOverConditions(conditionList.slice(1));
-
-                    var variations = [];
-
-                    if (!nextVariations.length) {
-                        conditionalEnv[curCondition].forEach(function (curConditionValue) {
-                            var variationConditions = {};
-                            variationConditions[curCondition] = curConditionValue;
-                            variations.push(variationConditions);
-                        });
-                    }
-
-                    // multiply the combinations of the n - 1 dimention by the cominations of this nth dimension
-                    nextVariations.forEach(function (nextVariation) {
-                        conditionalEnv[curCondition].forEach(function (curConditionValue) {
-                            var variationConditions = Object.assign({}, nextVariation);
-                            variationConditions[curCondition] = curConditionValue;
-                            variations.push(variationConditions);
-                        });
-                    });
-
-                    return variations;
-                }
-
-                var conditionsCombinations = generateVariationsOverConditions(Object.keys(conditionalEnv));
-
-                if (!conditionsCombinations.length) {
-                    return getModuleTrace(entryPoint.name, Object.assign({ inlineConditions: inlineConditions }, options))
-                    .then(function (modules) {
-                        entryPointModules.push({
-                            name: entryPoint.name,
-                            deferredParent: entryPoint.deferredParent,
-                            modules: modules
-                        });
-                    });
-                }
-
-                // trace conditional variations
-                var conditionalVariations = [];
-                entryPointModules.push({
-                    name: entryPoint.name,
-                    deferredParent: entryPoint.deferredParent,
-                    conditionalVariations: conditionalVariations
-                });
-
-                var variationsPromise = Promise.resolve();
-
-                conditionsCombinations.forEach(function (conditions, index) {
-                    variationsPromise = variationsPromise.then(function () {
-                        return getModuleTrace(entryPoint.name, Object.assign(Object.assign({}, options), {
-                            inlineConditions: inlineConditions,
-                            conditions: Object.assign({}, conditions)
-                        }))
-                        .then(function (modules) {
-                            conditionalVariations[index] = {
-                                modules: modules,
-                                conditions: conditions
-                            };
-                        });
-                    });
-                });
-
-                return variationsPromise;
-            });
-        }));
-    })
+        for (let i = 0 ; i < conditionsCombinations.length ; i += 1) {
+            const conditions = conditionsCombinations[i];
+            const modules = await getModuleTrace(entryPoint.name, Object.assign(Object.assign({}, options), {
+                inlineConditions,
+                conditions: Object.assign({}, conditions)
+            }));
+            conditionalVariations[i] = { modules, conditions };
+        }
+    });
 
     // We now have a four-layer optimization:
     // - common bundle
@@ -410,96 +375,268 @@ function bundleStrategy(builder, entryPoints, options) {
     // for each entry point, we remove the layers from the above
     // what we are left with is the entry point-specific bundle (if any)
     // we then populate entryPointBundles and bundles with this derivation
-    .then(function () {
-        // first we determine the common bundle
-        var commonModules;
-        var commonBundleName;
 
-        // determine common modules
-        entryPointModules.forEach(function (entryPoint) {
-            // deferredParent modules not included in base-level common bundle
-            if (entryPoint.deferredParent) {
-                return;
-            }
+    // first we determine the common bundle
+    let commonModules;
+    let commonBundleName;
 
-            if (entryPoint.modules) {
-                if (!commonModules) {
-                    commonModules = entryPoint.modules.concat([]);
-                } else {
-                    commonModules = intersectModules(commonModules, entryPoint.modules);
-                }
+    // determine common modules
+    for (const entryPoint of entryPointModules) {
+        // deferredParent modules not included in base-level common bundle
+        if (entryPoint.deferredParent) {
+            continue;
+        }
+
+        if (entryPoint.modules) {
+            if (!commonModules) {
+                commonModules = entryPoint.modules.concat([]);
             } else {
-                entryPoint.conditionalVariations.forEach(function (variation) {
-                    if (!commonModules) {
-                        commonModules = variation.modules.concat([]);
-                    } else {
-                        commonModules = intersectModules(commonModules, variation.modules);
-                    }
-                });
+                commonModules = intersectModules(commonModules, entryPoint.modules);
             }
-        });
-
-        // subtract manual bundles from the common bundle
-        if (commonModules && commonModules.length) {
-            Object.keys(manualBundles).forEach(function (manualBundleName) {
-                var manualBundleModules = manualBundles[manualBundleName];
-                if (containsModules(commonModules, manualBundleModules)) {
-                    commonModules = subtractModules(commonModules, manualBundleModules);
+        } else {
+            for (const variation of entryPoint.conditionalVariations) {
+                if (!commonModules) {
+                    commonModules = variation.modules.concat([]);
+                } else {
+                    commonModules = intersectModules(commonModules, variation.modules);
                 }
-            });
+            }
         }
+    }
 
-        /*
-         * Populate bundles and entryPointBundles
-         */
-        if (commonModules && commonModules.length) {
-            bundles[commonBundleName = generateBundleName('common-bundle', commonModules)] = {
-                entryPoints: [],
-                modules: commonModules,
-                source: undefined,
-                sourceMap: undefined,
-                assetList: undefined
-            };
+    // subtract manual bundles from the common bundle
+    if (commonModules && commonModules.length) {
+        for (const manualBundleName of Object.keys(manualBundles)) {
+            const manualBundleModules = manualBundles[manualBundleName];
+            if (containsModules(commonModules, manualBundleModules)) {
+                commonModules = subtractModules(commonModules, manualBundleModules);
+            }
         }
+    }
 
-        Object.keys(manualBundles).forEach(function (manualBundleName) {
-            bundles[manualBundleName] = {
-                entryPoints: [],
-                modules: manualBundles[manualBundleName],
-                source: undefined,
-                sourceMap: undefined,
-                assetList: undefined
-            };
-        });
+    /*
+     * Populate bundles and entryPointBundles
+     */
+    if (commonModules && commonModules.length > 0) {
+        bundles[commonBundleName = generateBundleName('common-bundle', commonModules)] = {
+            entryPoints: [],
+            modules: commonModules,
+            source: undefined,
+            sourceMap: undefined,
+            assetList: undefined
+        };
+    }
 
-        entryPointModules.forEach(function (entryPoint) {
-            var entryPointItem = {
-                name: entryPoint.name,
-                deferredParent: entryPoint.deferredParent,
-                conditions: {}
-            };
+    for (const manualBundleName of Object.keys(manualBundles)) {
+        bundles[manualBundleName] = {
+            entryPoints: [],
+            modules: manualBundles[manualBundleName],
+            source: undefined,
+            sourceMap: undefined,
+            assetList: undefined
+        };
+    }
 
-            if (entryPoint.modules) {
-                var entryPointBundleModules = entryPoint.modules;
+    for (const entryPoint of entryPointModules) {
+        const entryPointItem = {
+            name: entryPoint.name,
+            deferredParent: entryPoint.deferredParent,
+            conditions: {}
+        };
+
+        if (entryPoint.modules) {
+            let entryPointBundleModules = entryPoint.modules;
+
+            // subtract common layer
+            if (commonModules && commonModules.length && containsModules(entryPointBundleModules, commonModules)) {
+                entryPointBundleModules = subtractModules(entryPointBundleModules, commonModules);
+                bundles[commonBundleName].entryPoints.push(entryPointItem);
+            }
+
+            // subtract manual bundles
+            for (const manualBundle of Object.keys(manualBundles)) {
+                const manualBundleModules = manualBundles[manualBundle];
+                if (containsModules(entryPointBundleModules, manualBundleModules)) {
+                    entryPointBundleModules = subtractModules(entryPointBundleModules, manualBundleModules);
+                    bundles[manualBundle].entryPoints.push(entryPointItem);
+                }
+            }
+
+            // if there is anything left over then we create the entry-point-specific bundle
+            if (entryPointBundleModules.length > 0) {
+                const bundleName = generateBundleName('bundle-' + entryPoint.name, entryPointBundleModules);
+                bundles[bundleName] = bundles[bundleName] || {
+                    entryPoints: [],
+                    modules: entryPointBundleModules,
+                    source: undefined,
+                    sourceMap: undefined,
+                    assetList: undefined
+                };
+                bundles[bundleName].entryPoints.push(entryPointItem);
+            }
+
+        // entry point has conditionals
+        } else {
+            let commonVariationModules;
+            let commonVariationBundleName;
+
+            // determine common variation modules
+            for (const variation of entryPoint.conditionalVariations) {
+                if (commonVariationModules) {
+                    commonVariationModules = intersectModules(commonVariationModules, variation.modules);
+                } else {
+                    commonVariationModules = variation.modules.concat([]);
+                }
+            }
+
+            // subtract common modules from common variation bundle
+            if (commonVariationModules && commonVariationModules.length > 0 && commonModules && commonModules.length) {
+                if (containsModules(commonVariationModules, commonModules)) {
+                    commonVariationModules = subtractModules(commonVariationModules, commonModules);
+                }
+            }
+
+            if (commonBundleName) {
+                bundles[commonBundleName].entryPoints.push(entryPointItem);
+            }
+
+            // subtract manual bundles from the common variation bundle
+            if (commonVariationModules && commonVariationModules.length) {
+                for (const manualBundleName of Object.keys(manualBundles)) {
+                    const manualBundleModules = manualBundles[manualBundleName];
+                    if (containsModules(commonVariationModules, manualBundleModules)) {
+                        commonVariationModules = subtractModules(commonVariationModules, manualBundleModules);
+                    }
+                }
+            }
+
+            // save the common variation bundle
+            if (commonVariationModules && commonVariationModules.length) {
+                commonVariationBundleName = generateBundleName('common-' + entryPoint.name, commonVariationModules);
+                bundles[commonVariationBundleName] = bundles[commonVariationBundleName] || {
+                    entryPoints: [],
+                    modules: commonVariationModules,
+                    source: undefined,
+                    sourceMap: undefined,
+                    assetList: undefined
+                };
+                bundles[commonVariationBundleName].entryPoints.push(entryPointItem);
+            }
+
+            // for each independent condition value, generate a common layer
+            const independentConditionBundles = [];
+
+            for (const condition of Object.keys(conditionalEnv)) {
+                for (const conditionValue of conditionalEnv[condition]) {
+
+                    const independentEntryPoint = {
+                        name: entryPoint.name,
+                        deferredParent: entryPoint.deferredParent,
+                        conditions: {}
+                    };
+                    independentEntryPoint.conditions[condition] = conditionValue;
+
+                    let curModules;
+
+                    // for this condition and conditionValue, determine the common bundle over all other conditional variations
+                    for (const variation of entryPoint.conditionalVariations) {
+                        if (variation.conditions[condition] !== conditionValue) {
+                            continue;
+                        }
+                        if (!curModules) {
+                            curModules = variation.modules.concat([]);
+                            continue;
+                        }
+                        curModules = intersectModules(curModules, variation.modules);
+                    }
+
+                    // subtract common modules from common variation bundle
+                    if (curModules && curModules.length > 0 && commonModules && commonModules.length > 0) {
+                        if (containsModules(curModules, commonModules)) {
+                            curModules = subtractModules(curModules, commonModules);
+                        }
+                    }
+
+                    // subtract common variation modules from common variation bundle
+                    if (curModules && curModules.length > 0 && commonVariationModules && commonVariationModules.length > 0) {
+                        if (containsModules(curModules, commonVariationModules)) {
+                            curModules = subtractModules(curModules, commonVariationModules);
+                        }
+                    }
+
+                    // subtract previous independent conditional layers
+                    for (const independentConditionBundle of independentConditionBundles) {
+                        const independentConditionModules = bundles[independentConditionBundle].modules;
+                        if (containsModules(curModules, independentConditionModules)) {
+                            curModules = subtractModules(curModules, independentConditionModules);
+                        }
+                    }
+
+                    // subtract manual bundles from the independent condition bundle
+                    if (curModules && curModules.length) {
+                        for (const manualBundleName of Object.keys(manualBundles)) {
+                            const manualBundleModules = manualBundles[manualBundleName];
+                            if (containsModules(curModules, manualBundleModules)) {
+                                curModules = subtractModules(curModules, manualBundleModules);
+                            }
+                        }
+                    }
+                    // save the independent condition bundle if it has any modules
+                    if (curModules && curModules.length > 0) {
+                        independentConditionBundles.push(generateBundleName('bundle-' + entryPoint.name, curModules, conditionValue));
+                        const independentConditionBundleName = independentConditionBundles[independentConditionBundles.length - 1];
+                        bundles[independentConditionBundleName] = bundles[independentConditionBundleName] || {
+                            entryPoints: [],
+                            modules: curModules,
+                            source: undefined,
+                            sourceMap: undefined,
+                            assetList: undefined
+                        };
+                        bundles[independentConditionBundleName].entryPoints.push(independentEntryPoint);
+                    }
+                }
+            }
+
+            // create each variation bundle
+            for (const variation of entryPoint.conditionalVariations) {
+                let entryPointBundleModules = variation.modules;
+
+                const entryPointVariation = {
+                    name: entryPoint.name,
+                    deferredParent: entryPoint.deferredParent,
+                    conditions: variation.conditions
+                };
 
                 // subtract common layer
-                if (commonModules && commonModules.length && containsModules(entryPointBundleModules, commonModules)) {
+                if (commonModules && commonModules.length > 0 && containsModules(entryPointBundleModules, commonModules)) {
                     entryPointBundleModules = subtractModules(entryPointBundleModules, commonModules);
-                    bundles[commonBundleName].entryPoints.push(entryPointItem);
+                }
+
+                // subtract common variation layer
+                if (commonVariationModules && commonVariationModules.length > 0 && containsModules(entryPointBundleModules, commonVariationModules)) {
+                    entryPointBundleModules = subtractModules(entryPointBundleModules, commonVariationModules);
+                }
+
+                // subtract all independent condition layers
+                for (const independentConditionBundle of independentConditionBundles) {
+                    const independentConditionModules = bundles[independentConditionBundle].modules;
+                    if (containsModules(entryPointBundleModules, independentConditionModules)) {
+                        entryPointBundleModules = subtractModules(entryPointBundleModules, independentConditionModules);
+                    }
                 }
 
                 // subtract manual bundles
-                Object.keys(manualBundles).forEach(function (manualBundle) {
-                    var manualBundleModules = manualBundles[manualBundle];
+                for (const manualBundle of Object.keys(manualBundles)) {
+                    const manualBundleModules = manualBundles[manualBundle];
                     if (containsModules(entryPointBundleModules, manualBundleModules)) {
                         entryPointBundleModules = subtractModules(entryPointBundleModules, manualBundleModules);
-                        bundles[manualBundle].entryPoints.push(entryPointItem);
+                        bundles[manualBundle].entryPoints.push(entryPointVariation);
                     }
-                });
+                }
 
-                // if there is anything left over then we create the entry-point-specific bundle
-                if (entryPointBundleModules.length) {
-                    var bundleName = generateBundleName('bundle-' + entryPoint.name, entryPointBundleModules);
+                // if there is anything left over then we create the entry-point-variation-specific bundle
+                if (entryPointBundleModules.length > 0) {
+                    const bundleName = generateBundleName('bundle-' + entryPoint.name, entryPointBundleModules, variation.conditions);
                     bundles[bundleName] = bundles[bundleName] || {
                         entryPoints: [],
                         modules: entryPointBundleModules,
@@ -507,223 +644,46 @@ function bundleStrategy(builder, entryPoints, options) {
                         sourceMap: undefined,
                         assetList: undefined
                     };
-                    bundles[bundleName].entryPoints.push(entryPointItem);
+                    bundles[bundleName].entryPoints.push(entryPointVariation);
                 }
-
-            // entry point has conditionals
-            } else {
-                var commonVariationModules;
-                var commonVariationBundleName;
-
-                // determine common variation modules
-                entryPoint.conditionalVariations.forEach(function (variation) {
-                    if (!commonVariationModules) {
-                        commonVariationModules = variation.modules.concat([]);
-                        return;
-                    }
-                    commonVariationModules = intersectModules(commonVariationModules, variation.modules);
-                });
-
-                // subtract common modules from common variation bundle
-                if (commonVariationModules && commonVariationModules.length && commonModules && commonModules.length) {
-                    if (containsModules(commonVariationModules, commonModules)) {
-                        commonVariationModules = subtractModules(commonVariationModules, commonModules);
-                    }
-                }
-
-                if (commonBundleName) {
-                    bundles[commonBundleName].entryPoints.push(entryPointItem);
-                }
-
-                // subtract manual bundles from the common variation bundle
-                if (commonVariationModules && commonVariationModules.length) {
-                    Object.keys(manualBundles).forEach(function (manualBundleName) {
-                        var manualBundleModules = manualBundles[manualBundleName];
-                        if (containsModules(commonVariationModules, manualBundleModules)) {
-                            commonVariationModules = subtractModules(commonVariationModules, manualBundleModules);
-                        }
-                    });
-                }
-
-                // save the common variation bundle
-                if (commonVariationModules && commonVariationModules.length) {
-                    commonVariationBundleName = generateBundleName('common-' + entryPoint.name, commonVariationModules);
-                    bundles[commonVariationBundleName] = bundles[commonVariationBundleName] || {
-                        entryPoints: [],
-                        modules: commonVariationModules,
-                        source: undefined,
-                        sourceMap: undefined,
-                        assetList: undefined
-                    };
-                    bundles[commonVariationBundleName].entryPoints.push(entryPointItem);
-                }
-
-                // for each independent condition value, generate a common layer
-                var independentConditionBundles = [];
-
-                Object.keys(conditionalEnv).forEach(function (condition) {
-                    conditionalEnv[condition].forEach(function (conditionValue) {
-
-                        var independentEntryPoint = {
-                            name: entryPoint.name,
-                            deferredParent: entryPoint.deferredParent,
-                            conditions: {}
-                        };
-                        independentEntryPoint.conditions[condition] = conditionValue;
-
-                        var curModules;
-
-                        // for this condition and conditionValue, determine the common bundle over all other conditional variations
-                        entryPoint.conditionalVariations.forEach(function (variation) {
-                            if (variation.conditions[condition] !== conditionValue) {
-                                return;
-                            }
-                            if (!curModules) {
-                                curModules = variation.modules.concat([]);
-                                return;
-                            }
-                            curModules = intersectModules(curModules, variation.modules);
-                        });
-
-                        // subtract common modules from common variation bundle
-                        if (curModules && curModules.length && commonModules && commonModules.length) {
-                            if (containsModules(curModules, commonModules)) {
-                                curModules = subtractModules(curModules, commonModules);
-                            }
-                        }
-
-                        // subtract common variation modules from common variation bundle
-                        if (curModules && curModules.length && commonVariationModules && commonVariationModules.length) {
-                            if (containsModules(curModules, commonVariationModules)) {
-                                curModules = subtractModules(curModules, commonVariationModules);
-                            }
-                        }
-
-                        // subtract previous independent conditional layers
-                        independentConditionBundles.forEach(function (independentConditionBundle) {
-                            var independentConditionModules = bundles[independentConditionBundle].modules;
-                            if (containsModules(curModules, independentConditionModules)) {
-                                curModules = subtractModules(curModules, independentConditionModules);
-                            }
-                        });
-
-                        // subtract manual bundles from the independent condition bundle
-                        if (curModules && curModules.length) {
-                            Object.keys(manualBundles).forEach(function (manualBundleName) {
-                                var manualBundleModules = manualBundles[manualBundleName];
-                                if (containsModules(curModules, manualBundleModules)) {
-                                    curModules = subtractModules(curModules, manualBundleModules);
-                                }
-                            });
-                        }
-                        // save the independent condition bundle if it has any modules
-                        if (curModules && curModules.length) {
-                            independentConditionBundles.push(generateBundleName('bundle-' + entryPoint.name, curModules, conditionValue));
-                            var independentConditionBundleName = independentConditionBundles[independentConditionBundles.length - 1];
-                            bundles[independentConditionBundleName] = bundles[independentConditionBundleName] || {
-                                entryPoints: [],
-                                modules: curModules,
-                                source: undefined,
-                                sourceMap: undefined,
-                                assetList: undefined
-                            };
-                            bundles[independentConditionBundleName].entryPoints.push(independentEntryPoint);
-                        }
-                    });
-                });
-
-                // create each variation bundle
-                entryPoint.conditionalVariations.forEach(function (variation) {
-                    var entryPointBundleModules = variation.modules;
-
-                    var entryPointVariation = {
-                        name: entryPoint.name,
-                        deferredParent: entryPoint.deferredParent,
-                        conditions: variation.conditions
-                    };
-
-                    // subtract common layer
-                    if (commonModules && commonModules.length && containsModules(entryPointBundleModules, commonModules)) {
-                        entryPointBundleModules = subtractModules(entryPointBundleModules, commonModules);
-                    }
-
-                    // subtract common variation layer
-                    if (commonVariationModules && commonVariationModules.length && containsModules(entryPointBundleModules, commonVariationModules)) {
-                        entryPointBundleModules = subtractModules(entryPointBundleModules, commonVariationModules);
-                    }
-
-                    // subtract all independent condition layers
-                    independentConditionBundles.forEach(function (independentConditionBundle) {
-                        var independentConditionModules = bundles[independentConditionBundle].modules;
-                        if (containsModules(entryPointBundleModules, independentConditionModules)) {
-                            entryPointBundleModules = subtractModules(entryPointBundleModules, independentConditionModules);
-                        }
-                    });
-
-                    // subtract manual bundles
-                    Object.keys(manualBundles).forEach(function (manualBundle) {
-                        var manualBundleModules = manualBundles[manualBundle];
-                        if (containsModules(entryPointBundleModules, manualBundleModules)) {
-                            entryPointBundleModules = subtractModules(entryPointBundleModules, manualBundleModules);
-                            bundles[manualBundle].entryPoints.push(entryPointVariation);
-                        }
-                    });
-
-                    // if there is anything left over then we create the entry-point-variation-specific bundle
-                    if (entryPointBundleModules.length) {
-                        var bundleName = generateBundleName('bundle-' + entryPoint.name, entryPointBundleModules, variation.conditions);
-                        bundles[bundleName] = bundles[bundleName] || {
-                            entryPoints: [],
-                            modules: entryPointBundleModules,
-                            source: undefined,
-                            sourceMap: undefined,
-                            assetList: undefined
-                        };
-                        bundles[bundleName].entryPoints.push(entryPointVariation);
-                    }
-                });
             }
-        });
-    })
-    // finally, now that we have all bundles calculated, generate the bundle sources
-    .then(function () {
-        return Promise.all(Object.keys(bundles).map(function (bundleName) {
-            var bundle = bundles[bundleName];
+        }
+    }
 
-            return builder.bundle(bundle.modules, Object.assign({ inlineConditions: inlineConditions }, options))
-            .then(function (output) {
-                bundle.source = output.source;
-                bundle.sourceMap = output.sourceMap;
-                bundle.assetList = output.assetList;
-            });
-        }));
-    })
-    .then(function () {
-        return bundles;
+    // finally, now that we have all bundles calculated, generate the bundle sources
+
+    await Promise.map(Object.keys(bundles), async bundleName => {
+        const bundle = bundles[bundleName];
+        const output = await builder.bundle(bundle.modules, Object.assign({ inlineConditions }, options));
+        bundle.source = output.source;
+        bundle.sourceMap = output.sourceMap;
+        bundle.assetList = output.assetList;
     });
+
+    return bundles;
 }
 
-var systemJsGlobals = {};
+const systemJsGlobals = {};
 
-module.exports = function (options) {
+module.exports = options => {
     options = options || {};
-    return function bundleSystemJs(assetGraph) {
-        var potentiallyOrphanedAssetsById = {};
-        var htmlScriptsToRemove = [];
+    return async function bundleSystemJs(assetGraph) {
+        const potentiallyOrphanedAssetsById = {};
+        const htmlScriptsToRemove = [];
         function cleanUp() {
-            htmlScriptsToRemove.forEach(function (htmlScript) {
-                var htmlAsset = htmlScript.from;
+            for (const htmlScript of htmlScriptsToRemove) {
+                const htmlAsset = htmlScript.from;
                 htmlScript.detach();
                 htmlAsset.markDirty();
-            });
+            }
 
             // Clean up system.js assets if nothing is referring to them any more
-            Object.keys(potentiallyOrphanedAssetsById).forEach(function (assetId) {
-                var asset = potentiallyOrphanedAssetsById[assetId];
+            for (const assetId of Object.keys(potentiallyOrphanedAssetsById)) {
+                const asset = potentiallyOrphanedAssetsById[assetId];
                 if (assetGraph.findRelations({to: asset}).length === 0) {
                     assetGraph.removeAsset(asset);
                 }
-            });
+            }
         }
 
         // Parse a source map (if given as a string) and absolutify the urls in the sources array:
@@ -732,37 +692,39 @@ module.exports = function (options) {
                 sourceMap = JSON.parse(sourceMap);
             }
             if (sourceMap && Array.isArray(sourceMap.sources)) {
-                sourceMap.sources = sourceMap.sources.map(function (sourceUrl) {
-                    return urlTools.resolveUrl(assetGraph.root, sourceUrl.replace(/^\//, ''));
-                });
+                sourceMap.sources = sourceMap.sources.map(
+                    sourceUrl => urlTools.resolveUrl(assetGraph.root, sourceUrl.replace(/^\//, ''))
+                );
             }
             return sourceMap;
         }
 
-        var systemJsConfig = extractSystemJsConfig(assetGraph.findRelations({type: ['HtmlScript', 'HtmlServiceWorkerRegistration', 'JavaScriptServiceWorkerRegistration', 'JavaScriptWebWorker', 'JavaScriptImportScripts'], to: {isLoaded: true}}));
-        var doneFirstConfigCall = false;
-        var configStatements = systemJsConfig.configStatements.sort(function (a, b) {
-            var aRelationsByPageId = {};
-            var bRelationsByPageId = {};
-            assetGraph.findRelations({to: a.asset}).forEach(function (incomingRelation) {
-                (aRelationsByPageId[incomingRelation.from.id] = aRelationsByPageId[incomingRelation.from.id] || []).push(incomingRelation);
-            });
-            assetGraph.findRelations({to: b.asset}).forEach(function (incomingRelation) {
-                (bRelationsByPageId[incomingRelation.from.id] = bRelationsByPageId[incomingRelation.from.id] || []).push(incomingRelation);
-            });
+        const systemJsConfig = extractSystemJsConfig(assetGraph.findRelations({type: ['HtmlScript', 'HtmlServiceWorkerRegistration', 'JavaScriptServiceWorkerRegistration', 'JavaScriptWebWorker', 'JavaScriptImportScripts'], to: {isLoaded: true}}));
+        let doneFirstConfigCall = false;
+        const configStatements = systemJsConfig.configStatements.sort((a, b) => {
+            const aRelationsByPageId = {};
+            const bRelationsByPageId = {};
+            for (const incomingRelation of assetGraph.findRelations({to: a.asset})) {
+                (aRelationsByPageId[incomingRelation.from.id] = aRelationsByPageId[incomingRelation.from.id] || [])
+                    .push(incomingRelation);
+            }
+            for (const incomingRelation of assetGraph.findRelations({to: b.asset})) {
+                (bRelationsByPageId[incomingRelation.from.id] = bRelationsByPageId[incomingRelation.from.id] || [])
+                    .push(incomingRelation);
+            }
 
-            var pageIds = _.uniq(Object.keys(aRelationsByPageId).concat(Object.keys(bRelationsByPageId)));
-            if (pageIds.every(function (pageId) {
-                return ((aRelationsByPageId[pageId] || []).every(function (aRelation) {
-                    return (bRelationsByPageId[pageId] || []).every(function (bRelation) {
+            const pageIds = _.uniq(Object.keys(aRelationsByPageId).concat(Object.keys(bRelationsByPageId)));
+            if (pageIds.every(pageId => {
+                return ((aRelationsByPageId[pageId] || []).every(aRelation => {
+                    return (bRelationsByPageId[pageId] || []).every(bRelation => {
                         return aRelation.from.outgoingRelations.indexOf(aRelation) <= bRelation.from.outgoingRelations.indexOf(bRelation);
                     });
                 }));
             })) {
                 return -1;
-            } else if (pageIds.every(function (pageId) {
-                return ((bRelationsByPageId[pageId] || []).every(function (bRelation) {
-                    return (aRelationsByPageId[pageId] || []).every(function (aRelation) {
+            } else if (pageIds.every(pageId => {
+                return ((bRelationsByPageId[pageId] || []).every(bRelation => {
+                    return (aRelationsByPageId[pageId] || []).every(aRelation => {
                         return bRelation.from.outgoingRelations.indexOf(bRelation) <= aRelation.from.outgoingRelations.indexOf(aRelation);
                     });
                 }));
@@ -772,14 +734,14 @@ module.exports = function (options) {
             throw new Error('System.config calls come in conflicting order across pages');
         });
 
-        var topLevelSystemImportCalls = systemJsConfig.topLevelSystemImportCalls;
-        var canonicalNames = _.uniq(topLevelSystemImportCalls.map(function (topLevelSystemImportCall) {
+        const topLevelSystemImportCalls = systemJsConfig.topLevelSystemImportCalls;
+        const canonicalNames = _.uniq(topLevelSystemImportCalls.map(topLevelSystemImportCall => {
             return topLevelSystemImportCall.argumentString;
         }));
 
-        assetGraph.findRelations({ type: 'HtmlScript' }, true).forEach(function (htmlScript) {
-            var htmlAsset = htmlScript.from;
-            var markDirty = false;
+        for (const htmlScript of assetGraph.findRelations({ type: 'HtmlScript' }, true)) {
+            const htmlAsset = htmlScript.from;
+            let markDirty = false;
             if (htmlScript.node.hasAttribute('data-systemjs-polyfill')) {
                 if (options.polyfill) {
                     new assetGraph.HtmlScript({
@@ -795,9 +757,9 @@ module.exports = function (options) {
             }
 
             if (htmlScript.node.hasAttribute('data-systemjs-csp-production')) {
-                var dataSystemJsCspProduction = htmlScript.node.getAttribute('data-systemjs-csp-production');
+                const dataSystemJsCspProduction = htmlScript.node.getAttribute('data-systemjs-csp-production');
                 potentiallyOrphanedAssetsById[htmlScript.to.id] = htmlScript.to;
-                var href = dataSystemJsCspProduction || (htmlScript.href || '').replace(/[^\/]*$/, 'system-csp-production.js');
+                const href = dataSystemJsCspProduction || (htmlScript.href || '').replace(/[^\/]*$/, 'system-csp-production.js');
                 htmlScript.to = { url: href };
                 htmlScript.href = href;
                 htmlScript.node.removeAttribute('data-systemjs-csp-production');
@@ -811,39 +773,38 @@ module.exports = function (options) {
                 potentiallyOrphanedAssetsById[htmlScript.to.id] = htmlScript.to;
                 htmlScriptsToRemove.push(htmlScript);
             }
-        });
+        }
 
         if (canonicalNames.length === 0) {
             cleanUp();
             return;
         }
 
-        var entryPointInfosByPageId = {};
-        var occurrences = [];
+        const entryPointInfosByPageId = {};
+        const occurrences = [];
 
-        topLevelSystemImportCalls.forEach(function (topLevelSystemImportCall) {
-            var asset = topLevelSystemImportCall.asset;
-            assetGraph.findRelations({ type: ['HtmlScript', 'HtmlServiceWorkerRegistration', 'JavaScriptServiceWorkerRegistration', 'JavaScriptWebWorker'], to: asset }).forEach(function (incomingRelation) {
-                var page = incomingRelation.from;
-                var occurrence = _.defaults({
-                    page: page,
-                    incomingRelation: incomingRelation
-                }, topLevelSystemImportCall);
+        for (const topLevelSystemImportCall of topLevelSystemImportCalls) {
+            const incomingRelations = assetGraph.findRelations({
+                type: ['HtmlScript', 'HtmlServiceWorkerRegistration', 'JavaScriptServiceWorkerRegistration', 'JavaScriptWebWorker'],
+                to: topLevelSystemImportCall.asset
+            });
+            for (const incomingRelation of incomingRelations) {
+                const page = incomingRelation.from;
+                const occurrence = _.defaults({ page, incomingRelation }, topLevelSystemImportCall);
                 occurrences.push(occurrence);
                 (entryPointInfosByPageId[page.id] = entryPointInfosByPageId[page.id] || []).push(occurrence);
-            });
-        });
+            }
+        }
 
-        var pagesWithEntryPoints = Object.keys(entryPointInfosByPageId).map(function (pageId) {
-            return assetGraph.findAssets({ id: pageId })[0];
-        });
+        const pagesWithEntryPoints = Object.keys(entryPointInfosByPageId)
+            .map(pageId => assetGraph.findAssets({ id: pageId })[0]);
 
-        var manualBundles = {};
+        const manualBundles = {};
 
-        configStatements.forEach(function (configStatement, i) {
+        for (const configStatement of configStatements) {
             configStatement.obj = esanimate.objectify(configStatement.node.arguments[0]);
             if (configStatement.obj.manualBundles) {
-                Object.keys(configStatement.obj.manualBundles).forEach(function (bundleId) {
+                for (const bundleId of Object.keys(configStatement.obj.manualBundles)) {
                     if (manualBundles[bundleId]) {
                         if (!_.isEqual([].concat(manualBundles[bundleId]).sort(), [].concat(configStatement.obj.manualBundles[bundleId]).sort())) {
                             throw new Error('Conflicting definitions of the manual bundle ' + bundleId);
@@ -851,12 +812,12 @@ module.exports = function (options) {
                     } else {
                         manualBundles[bundleId] = configStatement.obj.manualBundles[bundleId];
                     }
-                });
+                }
             }
 
-            var dirty = false;
-            var objectLiteralNode = configStatement.node.arguments[0];
-            objectLiteralNode.properties = objectLiteralNode.properties.filter(function (propertyNode) {
+            let dirty = false;
+            const objectLiteralNode = configStatement.node.arguments[0];
+            objectLiteralNode.properties = objectLiteralNode.properties.filter(propertyNode => {
                 if (propertyNode.key.type === 'Identifier' && (propertyNode.key.name === 'buildConfig' || propertyNode.key.name === 'testConfig')) {
                     dirty = true;
                     return false;
@@ -865,33 +826,33 @@ module.exports = function (options) {
                 }
             });
             if (objectLiteralNode.properties.length === 0) {
-                var parentBody = configStatement.parentNode.body || configStatement.parentNode.expressions;
+                const parentBody = configStatement.parentNode.body || configStatement.parentNode.expressions;
                 parentBody.splice(parentBody.indexOf(configStatement.detachableNode), 1);
                 dirty = true;
             }
             if (dirty) {
                 configStatement.asset.markDirty();
             }
-        });
+        }
 
         function isConfigIncludedOnEveryPage(configStatement) {
-            return pagesWithEntryPoints.every(function (pageWithEntryPoint) {
+            return pagesWithEntryPoints.every(pageWithEntryPoint => {
                 return assetGraph.findRelations({from: pageWithEntryPoint, to: configStatement.asset}).length > 0;
             });
         }
 
-        configStatements.forEach(function (configStatement, i) {
-            if (!isConfigIncludedOnEveryPage(configStatement) && configStatements.some(function (otherConfigStatement, j) {
+        for (const configStatement of configStatements) {
+            if (!isConfigIncludedOnEveryPage(configStatement) && configStatements.some(otherConfigStatement => {
                 return detectSystemJSConflict(configStatement.obj, otherConfigStatement.obj);
             })) {
                 throw new Error('Configs conflict');
             }
-        });
+        }
 
         // For cleaning up global leaks:
-        var globalSnapshotBeforeRequire = Object.assign({}, global);
+        const globalSnapshotBeforeRequire = Object.assign({}, global);
 
-        var SystemJsBuilder;
+        let SystemJsBuilder;
         try {
             // Will leak globals when required the first time: __curScript, URLPolyfill, SystemJS, System
             SystemJsBuilder = require('systemjs-builder');
@@ -903,12 +864,12 @@ module.exports = function (options) {
         }
 
         // Will leak globals: $traceurRuntime, traceur
-        var builder = new SystemJsBuilder();
-        _.difference(Object.keys(global), Object.keys(globalSnapshotBeforeRequire)).forEach(function (leakedKey) {
+        const builder = new SystemJsBuilder();
+        for (const leakedKey of _.difference(Object.keys(global), Object.keys(globalSnapshotBeforeRequire))) {
             systemJsGlobals[leakedKey] = global[leakedKey];
-        });
+        }
 
-        configStatements.forEach(function (configStatement) {
+        for (const configStatement of configStatements) {
             if (configStatement.obj.baseURL) {
                 if (!/^\//.test(configStatement.obj.baseURL)) {
                     throw new Error('the System.js baseURL must be absolute');
@@ -919,17 +880,17 @@ module.exports = function (options) {
             }
             builder.config(_.clone(configStatement.obj, true));
             doneFirstConfigCall = true;
-        });
-        var entryPointNames = _.uniq(topLevelSystemImportCalls.map(function (topLevelSystemImportCall) {
+        }
+        const entryPointNames = _.uniq(topLevelSystemImportCalls.map(topLevelSystemImportCall => {
             return topLevelSystemImportCall.argumentString;
         }));
 
-        var bundleStrategyOptions = {
+        const bundleStrategyOptions = {
             production: true,
             normalize: true,
             traceConditionModules: !options.conditions,
             deferredImports: options.deferredImports,
-            manualBundles: manualBundles,
+            manualBundles,
             sourceMaps: true,
             assetRoot: assetGraph.root,
             inlinePlugins: false // Skip inlining resources like css, handled through the asset list
@@ -939,22 +900,22 @@ module.exports = function (options) {
             bundleStrategyOptions.conditions = options.conditions;
         }
 
-        var globalSnapshotBeforeBundling = Object.assign({}, global);
+        const globalSnapshotBeforeBundling = Object.assign({}, global);
         _.defaults(global, systemJsGlobals);
-        return bundleStrategy(builder, entryPointNames.map(function (entryPointName) {
-            return { name: entryPointName };
-        }), bundleStrategyOptions).then(function (bundles) {
-            var isSeenByPageIdAndBundleId = {};
-            var assetListEntryByUrl = {};
-            var attachAssetsPromises = [];
-            var assetByBundleId = {};
+
+        try {
+            const bundles = await bundleStrategy(builder, entryPointNames.map(entryPointName => ({ name: entryPointName })), bundleStrategyOptions);
+            const isSeenByPageIdAndBundleId = {};
+            const assetListEntryByUrl = {};
+            const attachAssetsPromises = [];
+            const assetByBundleId = {};
 
             function addBundle(bundleId, incomingRelation, conditions) {
-                var bundle = bundles[bundleId];
-                var bundleAsset = assetByBundleId[bundleId];
+                const bundle = bundles[bundleId];
+                let bundleAsset = assetByBundleId[bundleId];
                 if (!bundleAsset) {
-                    var nextSuffixToTry = 0;
-                    var bundleUrl;
+                    let nextSuffixToTry = 0;
+                    let bundleUrl;
                     do {
                         bundleUrl = assetGraph.root + bundleId + (nextSuffixToTry ? '-' + nextSuffixToTry : '') + '.js';
                         nextSuffixToTry += 1;
@@ -965,10 +926,10 @@ module.exports = function (options) {
                         sourceMap: preprocessSourceMap(bundle.sourceMap)
                     });
                 }
-                var addBundleToGraph = true;
+                let addBundleToGraph = true;
                 if (incomingRelation.type === 'HtmlServiceWorkerRegistration' || incomingRelation.type === 'JavaScriptServiceWorkerRegistration' || incomingRelation.type === 'JavaScriptWebWorker') {
-                    var currentImportScripts = assetGraph.findRelations({type: 'JavaScriptImportScripts', from: incomingRelation.to});
-                    var importScriptsRelation = new AssetGraph.JavaScriptImportScripts({to: bundleAsset, hrefType: 'rootRelative'});
+                    const currentImportScripts = assetGraph.findRelations({type: 'JavaScriptImportScripts', from: incomingRelation.to});
+                    const importScriptsRelation = new AssetGraph.JavaScriptImportScripts({to: bundleAsset, hrefType: 'rootRelative'});
                     if (currentImportScripts.length > 0) {
                         importScriptsRelation.attach(incomingRelation.to, 'after', currentImportScripts[currentImportScripts.length - 1]);
                     } else {
@@ -977,7 +938,7 @@ module.exports = function (options) {
                 } else {
                     // assume 'HtmlScript'
                     if (htmlScriptsToRemove.indexOf(incomingRelation) === -1) {
-                        var htmlScript = new AssetGraph.HtmlScript({
+                        const htmlScript = new AssetGraph.HtmlScript({
                             hrefType: 'rootRelative',
                             to: bundleAsset
                         });
@@ -996,19 +957,15 @@ module.exports = function (options) {
                     assetGraph.addAsset(bundleAsset);
                 }
 
-                (bundle.assetList || []).forEach(function (assetListEntry) {
-                    var url = assetListEntry.url;
-                    var asset = assetListEntryByUrl[url];
+                for (const { source, type, url, sourceMap } of (bundle.assetList || [])) {
+                    let asset = assetListEntryByUrl[url];
                     if (!asset) {
-                        var assetConfig = {
-                            url: url,
-                            sourceMap: assetListEntry.sourceMap
-                        };
-                        if (assetListEntry.type === 'css') {
+                        const assetConfig = { url, sourceMap };
+                        if (type === 'css') {
                             assetConfig.type = 'Css';
                         }
-                        if (typeof assetListEntry.source === 'string') {
-                            assetConfig.text = assetListEntry.source;
+                        if (typeof source === 'string') {
+                            assetConfig.text = source;
                         }
                         asset = assetGraph.createAsset(assetGraph.resolveAssetConfig(assetConfig, assetGraph.root));
                         assetListEntryByUrl[url] = asset;
@@ -1017,7 +974,7 @@ module.exports = function (options) {
                     }
 
                     if (asset.type === 'Css') {
-                        var htmlStyle = new AssetGraph.HtmlStyle({
+                        const htmlStyle = new AssetGraph.HtmlStyle({
                             hrefType: 'rootRelative',
                             to: asset
                         });
@@ -1034,43 +991,42 @@ module.exports = function (options) {
                     } else {
                         assetGraph.emit('warn', new Error('Cannot attach relation to ' + asset.urlOrDescription + ' when the <script> containing the entry point has the data-systemjs-remove property'));
                     }
-                });
+                }
             }
 
-            Object.keys(entryPointInfosByPageId).forEach(function (pageId) {
+            for (const pageId of Object.keys(entryPointInfosByPageId)) {
                 isSeenByPageIdAndBundleId[pageId] = {};
-                entryPointInfosByPageId[pageId].forEach(function (occurrence, i) {
-                    Object.keys(bundles).forEach(function (bundleId) {
-                        bundles[bundleId].entryPoints.forEach(function (entryPoint) {
+                for (const occurrence of entryPointInfosByPageId[pageId]) {
+                    for (const bundleId of Object.keys(bundles)) {
+                        for (const entryPoint of bundles[bundleId].entryPoints) {
                             if (entryPoint.name === occurrence.argumentString && !entryPoint.deferredParent) {
                                 addBundle(bundleId, occurrence.incomingRelation, entryPoint.conditions);
                             }
-                        });
-                    });
-                });
-            });
-            Object.keys(bundles).forEach(function (bundleId) {
-                var bundle = bundles[bundleId];
-                bundle.entryPoints.forEach(function (entryPoint) {
-                    var deferredParent = entryPoint.deferredParent;
+                        }
+                    }
+                }
+            }
+            for (const bundleId of Object.keys(bundles)) {
+                const bundle = bundles[bundleId];
+                for (const { deferredParent } of bundle.entryPoints) {
                     if (deferredParent) {
                         // Find the occurrence object corresponding to the parent
                         // entry point of the deferred System.import:
-                        var parentOccurrence;
-                        occurrences.some(function (occurrence) {
+                        let parentOccurrence;
+                        for (const occurrence of occurrences) {
                             if (occurrence.argumentString === deferredParent) {
                                 parentOccurrence = occurrence;
-                                return true;
+                                break;
                             }
-                        });
+                        }
                         if (!parentOccurrence) {
                             throw new Error('No parent occurrence found for deferredParent: ' + deferredParent);
                         }
-                        var configBundleArgument = {};
+                        const configBundleArgument = {};
                         configBundleArgument[bundleId] = bundle.modules;
-                        var configBundleArgumentAst = esanimate.astify({ bundles: configBundleArgument });
+                        const configBundleArgumentAst = esanimate.astify({ bundles: configBundleArgument });
 
-                        var configScript = new AssetGraph.JavaScript({
+                        const configScript = new AssetGraph.JavaScript({
                             parseTree: {
                                 type: 'Program',
                                 body: [
@@ -1102,19 +1058,19 @@ module.exports = function (options) {
                         }).attach(parentOccurrence.incomingRelation.from, 'before', parentOccurrence.incomingRelation);
                         if (!isSeenByPageIdAndBundleId[parentOccurrence.page.id][bundleId]) {
                             isSeenByPageIdAndBundleId[parentOccurrence.page.id][bundleId] = true;
-                            var bundleAsset = new AssetGraph.JavaScript({
+                            const bundleAsset = new AssetGraph.JavaScript({
                                 text: bundle.source,
                                 url: bundleId + '.js',
                                 sourceMap: preprocessSourceMap(bundle.sourceMap)
                             });
                             assetGraph.addAsset(bundleAsset);
-                            var node;
-                            configBundleArgumentAst.properties[0].value.properties.some(function (propertyNode) {
+                            let node;
+                            for (const propertyNode of configBundleArgumentAst.properties[0].value.properties) {
                                 if ((propertyNode.key.name || propertyNode.key.value) === bundleId) {
                                     node = propertyNode;
-                                    return true;
+                                    break;
                                 }
-                            });
+                            }
                             new AssetGraph.SystemJsLazyBundle({
                                 from: configScript,
                                 to: bundleAsset,
@@ -1122,15 +1078,15 @@ module.exports = function (options) {
                             }).attach(configScript, 'last');
                         }
                     }
-                });
-            });
-            return Promise.all(attachAssetsPromises);
-        })
-        .then(cleanUp)
-        .finally(function () {
-            Object.keys(systemJsGlobals).concat(_.difference(Object.keys(global), Object.keys(globalSnapshotBeforeBundling))).forEach(function (key) {
+                }
+            }
+            await Promise.all(attachAssetsPromises);
+
+            cleanUp();
+        } finally {
+            for (const key of Object.keys(systemJsGlobals).concat(_.difference(Object.keys(global), Object.keys(globalSnapshotBeforeBundling)))) {
                 delete global[key];
-            });
-        });
+            }
+        }
     };
 };

--- a/lib/transforms/bundleWebpack.js
+++ b/lib/transforms/bundleWebpack.js
@@ -1,13 +1,13 @@
-var pathModule = require('path');
-var Promise = require('bluebird');
-var urlTools = require('urltools');
-var estraverse = require('estraverse');
-var readPkgUp = require('read-pkg-up');
+const pathModule = require('path');
+const Promise = require('bluebird');
+const urlTools = require('urltools');
+const estraverse = require('estraverse');
+const readPkgUp = require('read-pkg-up');
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
-    return function bundleWebpack(assetGraph) {
-        var webpack;
+    return async function bundleWebpack(assetGraph) {
+        let webpack;
         try {
             webpack = require('webpack');
         } catch (e) {
@@ -17,477 +17,470 @@ module.exports = function (queryObj, options) {
             }
         }
 
-        var triedConfigPaths = [];
+        const triedConfigPaths = [];
 
-        function loadWebpackConfig() {
-            return Promise.resolve().then(function () {
-                // First try to look for the config in the assetGraph root:
-                var configPath = options.configPath || pathModule.resolve(urlTools.fileUrlToFsPath(assetGraph.root), 'webpack.config.js');
-                triedConfigPaths.push(configPath);
-                try {
-                    return require.main.require(configPath);
-                } catch (err) {
-                    if (err.code !== 'MODULE_NOT_FOUND' || options.configPath) {
-                        throw err;
-                    }
-                    // webpack.config.js was not found in the assetgraph's root.
-                    // Look for it in the directory that contains the nearest package.json:
-                    return readPkgUp()
-                    .then(function (readPkgUpResult) {
-                        if (readPkgUpResult.path) {
-                            var alternativeConfigPath = pathModule.resolve(pathModule.dirname(readPkgUpResult.path), 'webpack.config.js');
-                            if (alternativeConfigPath !== configPath) {
-                                configPath = alternativeConfigPath;
-                                triedConfigPaths.push(configPath);
-                                return require.main.require(configPath);
-                            }
-                        }
-                        throw new Error('Could not load webpack config');
-                    });
+        async function loadWebpackConfig() {
+            // First try to look for the config in the assetGraph root:
+            let configPath = options.configPath || pathModule.resolve(urlTools.fileUrlToFsPath(assetGraph.root), 'webpack.config.js');
+            triedConfigPaths.push(configPath);
+            try {
+                return require.main.require(configPath);
+            } catch (err) {
+                if (err.code !== 'MODULE_NOT_FOUND' || options.configPath) {
+                    throw err;
                 }
-            });
+                // webpack.config.js was not found in the assetgraph's root.
+                // Look for it in the directory that contains the nearest package.json:
+                const readPkgUpResult = await readPkgUp();
+                if (readPkgUpResult.path) {
+                    const alternativeConfigPath = pathModule.resolve(pathModule.dirname(readPkgUpResult.path), 'webpack.config.js');
+                    if (alternativeConfigPath !== configPath) {
+                        configPath = alternativeConfigPath;
+                        triedConfigPaths.push(configPath);
+                        return require.main.require(configPath);
+                    }
+                }
+                throw new Error('Could not load webpack config');
+            }
         }
-        return loadWebpackConfig().then(function (config) {
-            config.context = config.context || urlTools.fileUrlToFsPath(assetGraph.root);
-            config.output = config.output || {};
-            if (typeof config.output.path === 'string') {
-                config.output.path = pathModule.resolve(config.context, config.output.path);
-            }
-            config.devtool = config.devtool || 'source-map';
-            config.output.devtoolModuleFilenameTemplate = config.output.devtoolModuleFilenameTemplate || '/[resource-path]';
 
-            var basePath = config.output.path;
-            if (config.output.publicPath) {
-                basePath = pathModule.resolve(config.context, config.output.publicPath.replace(/^\//, ''));
-            }
-
-            var plugins = Array.isArray(config.plugins) ? config.plugins : [];
-
-            plugins.forEach(function (plugin) {
-                if (plugin.constructor.name === 'UglifyJsPlugin' && (plugin.options.mangle || plugin.options.compress)) {
-                    plugin.options.mangle = plugin.options.compress = false;
-                    assetGraph.emit('info', new Error('UglifyJsPlugin detected, turning off mangling and compression so outgoing relations can be detected. This is fine for assetgraph-builder, which will run UglifyJs later anyway'));
-                }
-            });
-
-            var hasHtmlWebpackPlugin = plugins.some(function (plugin) {
-                return plugin.constructor.name === 'HtmlWebpackPlugin';
-            });
-
-            if (!hasHtmlWebpackPlugin) {
-                // HtmlWebpackPlugin is not in the picture, so we can assume that the
-                // relevant entry points are referenced by assets that we have
-                // in the graph. Only build the actually referenced entry points:
-                var seenReferencedEntryPoints = false;
-                var potentialBundlePaths = assetGraph.findRelations({
-                    to: {
-                        url: /\.js(?:\?|$)/
-                    }
-                }, true).map(function (relation) {
-                    return urlTools.fileUrlToFsPath(assetGraph.resolveUrl(relation.from.nonInlineAncestor.url, relation.to.url));
-                });
-
-                var createAbsolutePath = function (name) {
-                    return pathModule.resolve(
-                        basePath,
-                        name ? config.output.filename.replace(/\[name]/g, name) : config.output.filename
-                    );
-                };
-
-                if (config.entry && typeof config.entry === 'object' && !Array.isArray(config.entry)) {
-                    config.entry = Object.keys(config.entry).reduce(function (entryPointsToBeBuilt, entryPointName) {
-                        if (potentialBundlePaths.indexOf(createAbsolutePath(entryPointName)) !== -1) {
-                            entryPointsToBeBuilt[entryPointName] = config.entry[entryPointName];
-                        }
-                        return entryPointsToBeBuilt;
-                    }, {});
-
-                    seenReferencedEntryPoints = Object.keys(config.entry).length > 0;
-                } else {
-                    // array or string
-                    if (potentialBundlePaths.indexOf(createAbsolutePath()) !== -1) {
-                        seenReferencedEntryPoints = true;
-                    }
-                }
-
-                if (!seenReferencedEntryPoints) {
-                    assetGraph.emit('info', new Error('No matching webpack bundles found, skipping'));
-                    return;
-                }
-            }
-
-            var compiler = webpack(config);
-            var outputFileSystem = new webpack.MemoryOutputFileSystem();
-            compiler.outputFileSystem = outputFileSystem;
-            return Promise.fromNode(function (cb) {
-                compiler.run(cb);
-            }).then(function (stats) {
-                var statsObj = stats.toJson({assets: true});
-                var existingAssetsWereReplaced;
-                var assetInfos = [];
-                var urlByAssetName = {};
-                statsObj.assets.forEach(function (asset) {
-                    var url = urlTools.fsFilePathToFileUrl(pathModule.resolve(basePath, asset.name));
-                    var outputPath = urlTools.fsFilePathToFileUrl(pathModule.resolve(config.output.path, asset.name));
-                    assetInfos.push({
-                        url: url,
-                        output: outputPath,
-                        name: asset.name
-                    });
-                    urlByAssetName[asset.name] = url;
-                    var existingAsset = assetGraph.findAssets({url: url})[0];
-                    if (existingAsset) {
-                        assetGraph.emit('info', new Error('Replacing previously built artifact: ' + url));
-                        existingAssetsWereReplaced = true;
-                        existingAsset.incomingRelations.forEach(function (relation) {
-                            relation.to = {url: url};
-                        });
-                        assetGraph.removeAsset(existingAsset);
-                    }
-                });
-                assetGraph.emit('info', stats.toString({colors: true}));
-                if (existingAssetsWereReplaced) {
-                    assetGraph.emit('info', new Error('Please remove ' + config.output.path + ' before building with assetgraph to speed up the process'));
-                }
-                return assetGraph.loadAssets(assetInfos.map(function (url) {
-                    return {
-                        isInitial: /\.html$/.test(url.url),
-                        url: url.url,
-                        rawSrc: outputFileSystem.readFileSync(urlTools.fileUrlToFsPath(url.output))
-                    };
-                })).then(function () {
-                    // Pick up CSS assets and attach them to each entry point
-                    Object.keys(statsObj.assetsByChunkName).forEach(function (chunkName) {
-                        var assets = statsObj.assetsByChunkName[chunkName];
-                        var javaScriptAssets = assets.filter(function (asset) { return /\.js$/.test(asset); });
-                        var cssAssets = assets.filter(function (asset) { return /\.css$/.test(asset); });
-                        if (javaScriptAssets.length === 1 && cssAssets.length > 0) {
-                            var entryPointRelations = assetGraph.findRelations(function (relation) {
-                                if (relation.type !== 'HtmlScript' || !relation.to || !relation.to.url) {
-                                    return;
-                                }
-                                var absoluteUrl = assetGraph.resolveUrl(relation.from.nonInlineAncestor.url, relation.to.url);
-                                return absoluteUrl === urlByAssetName[javaScriptAssets[0]];
-                            }, true);
-                            entryPointRelations.forEach(function (entryPointRelation) {
-                                cssAssets.forEach(function (cssAsset) {
-                                    var htmlStyle = new assetGraph.HtmlStyle({
-                                        hrefType: 'rootRelative',
-                                        to: assetGraph.findAssets({url: urlByAssetName[cssAsset]})[0]
-                                    });
-                                    htmlStyle.attach(entryPointRelation.from, 'last');
-                                });
-                            });
-                        }
-                    });
-
-                    assetGraph.findAssets({
-                        type: 'JavaScript',
-                        url: assetInfos.map(function (url) { return url.url; })
-                    }).forEach(function (asset) {
-                        var replacementsMade = false;
-                        var requireEnsureAstTemplate;
-                        estraverse.traverse(asset.parseTree, {
-                            enter: function (node) {
-                                // Detect the __webpack_require__.e = function requireEnsure(chunkId, callback) { ... declaration at the top of a bundle
-                                if (node.type === 'AssignmentExpression' &&
-                                    node.operator === '=' &&
-                                    node.left.type === 'MemberExpression' &&
-                                    node.left.object.type === 'Identifier' &&
-                                    node.left.object.name === '__webpack_require__' &&
-                                    node.left.property.type === 'Identifier' &&
-                                    node.left.property.name === 'e' &&
-                                    node.right.type === 'FunctionExpression' &&
-                                    node.right.id &&
-                                    node.right.id.type === 'Identifier' &&
-                                    node.right.id.name === 'requireEnsure'
-                                ) {
-                                    node.right.params.push({ type: 'Identifier', name: '_assetgraph_url' });
-                                    // Replace script.src = ... in the function body:
-                                    estraverse.traverse(node.right.body, {
-                                        enter: function (node) {
-                                            if (node.type === 'ExpressionStatement' &&
-                                                node.expression.type === 'AssignmentExpression' &&
-                                                node.expression.left.type === 'MemberExpression' &&
-                                                node.expression.left.object.type === 'Identifier' &&
-                                                node.expression.left.object.name === 'script' &&
-                                                node.expression.left.property.type === 'Identifier' &&
-                                                node.expression.left.property.name === 'src'
-                                            ) {
-                                                var templateAst = node.expression.right;
-                                                // Quick and dirty evaluator
-                                                requireEnsureAstTemplate = function (chunkId) {
-                                                    var result = '';
-                                                    (function visit(node) {
-                                                        if (
-                                                            node.type === 'MemberExpression' &&
-                                                            node.object.type === 'Identifier' &&
-                                                            node.object.name === '__webpack_require__' &&
-                                                            node.property.type === 'Identifier' &&
-                                                            node.property.name === 'p'
-                                                        ) {
-                                                            // FIXME: Fall back to config.output.path instead of hardcoding /dist/:
-                                                            result += (config.output.publicPath || '/dist/');
-                                                        } else if (node.type === 'BinaryExpression' && node.operator === '+') {
-                                                            visit(node.left);
-                                                            visit(node.right);
-                                                        } else if (node.type === 'LogicalExpression' && node.operator === '||') {
-                                                            var resultBeforeLeft = result;
-                                                            visit(node.left);
-                                                            if (result === resultBeforeLeft) {
-                                                                visit(node.right);
-                                                            }
-                                                        } else if (
-                                                            node.type === 'MemberExpression' &&
-                                                            node.computed &&
-                                                            node.property.type === 'Identifier' &&
-                                                            node.property.name === 'chunkId' &&
-                                                            node.object.type === 'ObjectExpression'
-                                                        ) {
-                                                            node.object.properties.forEach(function (propertyNode) {
-                                                                if (propertyNode.key.type === 'Literal' && String(propertyNode.key.value) === String(chunkId)) {
-                                                                    visit(propertyNode.value);
-                                                                }
-                                                            });
-                                                        } else if (node.type === 'Literal') {
-                                                            result += String(node.value);
-                                                        } else if (node.type === 'Identifier' && node.name === 'chunkId') {
-                                                            result += chunkId;
-                                                        } else {
-                                                            throw new Error('unsupported ' + node.type + ': ' + require('escodegen').generate(node));
-                                                        }
-                                                    }(templateAst));
-                                                    return result;
-                                                };
-                                                node.expression.right = {
-                                                    type: 'BinaryExpression',
-                                                    operator: '||',
-                                                    left: {
-                                                        type: 'Identifier',
-                                                        name: '_assetgraph_url'
-                                                    },
-                                                    right: node.expression.right
-                                                };
-                                            }
-                                        }
-                                    });
-                                    replacementsMade = true;
-                                } else if (
-                                    node.type === 'VariableDeclaration' &&
-                                    node.declarations.length === 1 &&
-                                    node.declarations[0].type === 'VariableDeclarator' &&
-                                    node.declarations[0].id.type === 'Identifier' &&
-                                    node.declarations[0].id.name === 'map' &&
-                                    node.declarations[0].init &&
-                                    node.declarations[0].init.type === 'ObjectExpression' &&
-                                    node.declarations[0].init.properties.length > 0 &&
-                                    node.declarations[0].init.properties.every(propertyNode =>
-                                        propertyNode.value.type === 'ArrayExpression' &&
-                                        propertyNode.value.elements.length < 3
-                                    )
-                                ) {
-                                    // var map = {
-                                    //     './splita': [
-                                    //         1,
-                                    //         1
-                                    //     ],
-                                    //     './splita.js': [
-                                    //         1,
-                                    //         1
-                                    //     ],
-                                    //     './splitb': [
-                                    //         2,
-                                    //         0
-                                    //     ],
-                                    //     './splitb.js': [
-                                    //         2,
-                                    //         0
-                                    //     ]
-                                    // };
-                                    // Add a 3rd element to each value that uses .toString('url')
-                                    node.declarations[0].init.properties.forEach(function (propertyNode) {
-                                        // Not sure this is necessary yet, but pad with undefined so we always
-                                        // add to the 3rd position
-                                        while (propertyNode.value.elements.length < 2) {
-                                            propertyNode.value.elements.push({
-                                                type: 'Identifier',
-                                                value: 'undefined'
-                                            });
-                                        }
-                                        propertyNode.value.elements.push({
-                                            type: 'CallExpression',
-                                            callee: {
-                                                type: 'MemberExpression',
-                                                computed: false,
-                                                object: {
-                                                    type: 'Literal',
-                                                    value: requireEnsureAstTemplate(String(propertyNode.value.elements[1].value))
-                                                },
-                                                property: {
-                                                    type: 'Identifier',
-                                                    name: 'toString'
-                                                }
-                                            },
-                                            arguments: [
-                                                {
-                                                    type: 'Literal',
-                                                    value: 'url'
-                                                }
-                                            ]
-                                        });
-                                    });
-                                    replacementsMade = true;
-                                } else if (
-                                    node.type === 'FunctionDeclaration' &&
-                                    node.id.type === 'Identifier' &&
-                                    node.id.name === 'webpackAsyncContext'
-                                ) {
-                                    // function webpackAsyncContext(req) {
-                                    //     var ids = map[req];
-                                    //     if (!ids)
-                                    //         return Promise.reject(new Error('Cannot find module \'' + req + '\'.'));
-                                    //     return __webpack_require__.e(ids[1]).then(function () {
-                                    //         return __webpack_require__(ids[0]);
-                                    //     });
-                                    // }
-                                    // Add ids[2] to the argument list in the __webpack_require__.e call so that the JavaScriptStaticUrl is passed on
-                                    var lastStatement = node.body.body[node.body.body.length - 1];
-                                    if (lastStatement &&
-                                        lastStatement.type === 'ReturnStatement' &&
-                                        lastStatement.argument.type === 'CallExpression' &&
-                                        lastStatement.argument.callee.type === 'MemberExpression' &&
-                                        lastStatement.argument.callee.object.type === 'CallExpression' &&
-                                        lastStatement.argument.callee.object.callee.type === 'MemberExpression' &&
-                                        lastStatement.argument.callee.object.callee.object.type === 'Identifier' &&
-                                        lastStatement.argument.callee.object.callee.object.name === '__webpack_require__' &&
-                                        lastStatement.argument.callee.object.callee.property.type === 'Identifier' &&
-                                        lastStatement.argument.callee.object.callee.property.name === 'e' &&
-                                        lastStatement.argument.callee.object.arguments.length === 1 &&
-                                        lastStatement.argument.callee.object.arguments[0].type === 'MemberExpression' &&
-                                        lastStatement.argument.callee.object.arguments[0].computed &&
-                                        lastStatement.argument.callee.object.arguments[0].object.type === 'Identifier' &&
-                                        lastStatement.argument.callee.object.arguments[0].object.name === 'ids' &&
-                                        lastStatement.argument.callee.object.arguments[0].property.type === 'Literal'
-                                    ) {
-                                        lastStatement.argument.callee.object.arguments.push({
-                                            type: 'MemberExpression',
-                                            computed: true,
-                                            object: {
-                                                type: 'Identifier',
-                                                name: 'ids'
-                                            },
-                                            property: {
-                                                type: 'Literal',
-                                                value: 2
-                                            }
-                                        });
-                                        replacementsMade = true;
-                                    }
-                                } else if (
-                                    node.type === 'CallExpression' &&
-                                    node.callee.type === 'MemberExpression' &&
-                                    node.callee.object.type === 'Identifier' &&
-                                    node.callee.object.name === '__webpack_require__' &&
-                                    node.callee.property.type === 'Identifier' &&
-                                    node.callee.property.name === 'e' &&
-                                    node.arguments.length >= 1 &&
-                                    node.arguments[0].type === 'Literal' &&
-                                    typeof node.arguments[0].value === 'number' &&
-                                    requireEnsureAstTemplate
-                                ) {
-                                    node.arguments.push({
-                                        type: 'CallExpression',
-                                        callee: {
-                                            type: 'MemberExpression',
-                                            computed: false,
-                                            object: {
-                                                type: 'Literal',
-                                                value: requireEnsureAstTemplate(node.arguments[0].value)
-                                            },
-                                            property: {
-                                                type: 'Identifier',
-                                                name: 'toString'
-                                            }
-                                        },
-                                        arguments: [
-                                            {
-                                                type: 'Literal',
-                                                value: 'url'
-                                            }
-                                        ]
-                                    });
-                                    replacementsMade = true;
-                                } else if (
-                                    node.type === 'FunctionExpression' &&
-                                    node.params.length === 3 &&
-                                    node.params[0].type === 'Identifier' && node.params[0].name === 'module' &&
-                                    node.params[1].type === 'Identifier' && node.params[1].name === 'exports' &&
-                                    node.params[2].type === 'Identifier' && node.params[2].name === '__webpack_require__' &&
-                                    node.leadingComments && (node.leadingComments.length === 2 || node.leadingComments.length === 3) &&
-                                    /^ \d+ $/.test(node.leadingComments[node.leadingComments.length - 2].value) &&
-                                    node.leadingComments[node.leadingComments.length - 1].value === '*' &&
-                                    node.body.type === 'BlockStatement' &&
-                                    node.body.body.length === 1 &&
-                                    node.body.body[0].type === 'ExpressionStatement' &&
-                                    node.body.body[0].expression.type === 'AssignmentExpression' &&
-                                    node.body.body[0].expression.left.type === 'MemberExpression' &&
-                                    node.body.body[0].expression.left.object.type === 'Identifier' &&
-                                    node.body.body[0].expression.left.object.name === 'module' &&
-                                    node.body.body[0].expression.left.property.type === 'Identifier' &&
-                                    node.body.body[0].expression.left.property.name === 'exports' &&
-                                    node.body.body[0].expression.right.type === 'BinaryExpression' &&
-                                    node.body.body[0].expression.right.operator === '+' &&
-                                    node.body.body[0].expression.right.left.type === 'MemberExpression' &&
-                                    node.body.body[0].expression.right.left.object.type === 'Identifier' &&
-                                    node.body.body[0].expression.right.left.object.name === node.params[2].name &&
-                                    node.body.body[0].expression.right.left.property.type === 'Identifier' &&
-                                    node.body.body[0].expression.right.left.property.name === 'p' &&
-                                    node.body.body[0].expression.right.right.type === 'Literal' &&
-                                    typeof node.body.body[0].expression.right.right.value === 'string'
-                                ) {
-                                    node.body.body[0].expression.right = {
-                                        type: 'CallExpression',
-                                        range: node.body.body[0].expression.right.range,
-                                        callee: {
-                                            type: 'MemberExpression',
-                                            computed: false,
-                                            object: {
-                                                type: 'Literal',
-                                                // FIXME: Fall back to config.output.path instead of hardcoding /dist/:
-                                                value: (config.output.publicPath || '/dist/') + node.body.body[0].expression.right.right.value
-                                            },
-                                            property: {
-                                                type: 'Identifier',
-                                                name: 'toString'
-                                            }
-                                        },
-                                        arguments: [
-                                            {
-                                                type: 'Literal',
-                                                value: 'url'
-                                            }
-                                        ]
-                                    };
-                                    replacementsMade = true;
-                                }
-                            }
-                        });
-                        if (replacementsMade) {
-                            asset.markDirty();
-                            [].concat(asset.outgoingRelations).forEach(function (relation) {
-                                asset.removeRelation(relation);
-                            });
-                            asset._outgoingRelations = undefined;
-                            asset.isPopulated = false;
-                            asset.populate();
-                        }
-                    });
-                });
-            });
-        }, function (err) {
+        let config;
+        try {
+            config = await loadWebpackConfig();
+        } catch (err) {
             if (webpack) {
                 assetGraph.emit('info', new Error('Webpack is installed, but could not load the webpack config (tried ' + triedConfigPaths.join(' ') + '): ' + err.message));
             }
-        });
+            return;
+        }
+        config.context = config.context || urlTools.fileUrlToFsPath(assetGraph.root);
+        config.output = config.output || {};
+        if (typeof config.output.path === 'string') {
+            config.output.path = pathModule.resolve(config.context, config.output.path);
+        }
+        config.devtool = config.devtool || 'source-map';
+        config.output.devtoolModuleFilenameTemplate = config.output.devtoolModuleFilenameTemplate || '/[resource-path]';
+
+        let basePath = config.output.path;
+        if (config.output.publicPath) {
+            basePath = pathModule.resolve(config.context, config.output.publicPath.replace(/^\//, ''));
+        }
+
+        const plugins = Array.isArray(config.plugins) ? config.plugins : [];
+
+        for (const plugin of plugins) {
+            if (plugin.constructor.name === 'UglifyJsPlugin' && (plugin.options.mangle || plugin.options.compress)) {
+                plugin.options.mangle = plugin.options.compress = false;
+                assetGraph.emit('info', new Error('UglifyJsPlugin detected, turning off mangling and compression so outgoing relations can be detected. This is fine for assetgraph-builder, which will run UglifyJs later anyway'));
+            }
+        }
+
+        const hasHtmlWebpackPlugin = plugins.some(
+            plugin => plugin.constructor.name === 'HtmlWebpackPlugin'
+        );
+
+        if (!hasHtmlWebpackPlugin) {
+            // HtmlWebpackPlugin is not in the picture, so we can assume that the
+            // relevant entry points are referenced by assets that we have
+            // in the graph. Only build the actually referenced entry points:
+            let seenReferencedEntryPoints = false;
+            const potentialBundlePaths = assetGraph.findRelations({
+                to: {
+                    url: /\.js(?:\?|$)/
+                }
+            }, true).map(relation => {
+                return urlTools.fileUrlToFsPath(assetGraph.resolveUrl(relation.from.nonInlineAncestor.url, relation.to.url));
+            });
+
+            function createAbsolutePath(name) {
+                return pathModule.resolve(
+                    basePath,
+                    name ? config.output.filename.replace(/\[name]/g, name) : config.output.filename
+                );
+            };
+
+            if (config.entry && typeof config.entry === 'object' && !Array.isArray(config.entry)) {
+                config.entry = Object.keys(config.entry).reduce((entryPointsToBeBuilt, entryPointName) => {
+                    if (potentialBundlePaths.indexOf(createAbsolutePath(entryPointName)) !== -1) {
+                        entryPointsToBeBuilt[entryPointName] = config.entry[entryPointName];
+                    }
+                    return entryPointsToBeBuilt;
+                }, {});
+
+                seenReferencedEntryPoints = Object.keys(config.entry).length > 0;
+            } else {
+                // array or string
+                if (potentialBundlePaths.includes(createAbsolutePath())) {
+                    seenReferencedEntryPoints = true;
+                }
+            }
+
+            if (!seenReferencedEntryPoints) {
+                assetGraph.emit('info', new Error('No matching webpack bundles found, skipping'));
+                return;
+            }
+        }
+
+        const compiler = webpack(config);
+        const outputFileSystem = new webpack.MemoryOutputFileSystem();
+        compiler.outputFileSystem = outputFileSystem;
+        const stats = await Promise.fromNode(cb => compiler.run(cb));
+
+        const statsObj = stats.toJson({assets: true});
+        let existingAssetsWereReplaced;
+        const assetInfos = [];
+        const urlByAssetName = {};
+        for (const asset of statsObj.assets) {
+            const url = urlTools.fsFilePathToFileUrl(pathModule.resolve(basePath, asset.name));
+            const outputPath = urlTools.fsFilePathToFileUrl(pathModule.resolve(config.output.path, asset.name));
+            assetInfos.push({
+                url,
+                output: outputPath,
+                name: asset.name
+            });
+            urlByAssetName[asset.name] = url;
+            const existingAsset = assetGraph.findAssets({url: url})[0];
+            if (existingAsset) {
+                assetGraph.emit('info', new Error('Replacing previously built artifact: ' + url));
+                existingAssetsWereReplaced = true;
+                for (const relation of existingAsset.incomingRelations) {
+                    relation.to = {url: url};
+                }
+                assetGraph.removeAsset(existingAsset);
+            }
+        }
+        assetGraph.emit('info', stats.toString({colors: true}));
+        if (existingAssetsWereReplaced) {
+            assetGraph.emit('info', new Error('Please remove ' + config.output.path + ' before building with assetgraph to speed up the process'));
+        }
+
+        await assetGraph.loadAssets(assetInfos.map(url => ({
+            isInitial: /\.html$/.test(url.url),
+            url: url.url,
+            rawSrc: outputFileSystem.readFileSync(urlTools.fileUrlToFsPath(url.output))
+        })));
+
+        // Pick up CSS assets and attach them to each entry point
+        for (const chunkName of Object.keys(statsObj.assetsByChunkName)) {
+            const assets = statsObj.assetsByChunkName[chunkName];
+            const javaScriptAssets = assets.filter(asset => /\.js$/.test(asset));
+            const cssAssets = assets.filter(asset => /\.css$/.test(asset));
+            if (javaScriptAssets.length === 1 && cssAssets.length > 0) {
+                const entryPointRelations = assetGraph.findRelations(relation => {
+                    if (relation.type !== 'HtmlScript' || !relation.to || !relation.to.url) {
+                        return;
+                    }
+                    const absoluteUrl = assetGraph.resolveUrl(relation.from.nonInlineAncestor.url, relation.to.url);
+                    return absoluteUrl === urlByAssetName[javaScriptAssets[0]];
+                }, true);
+                for (const entryPointRelation of entryPointRelations) {
+                    for (const cssAsset of cssAssets) {
+                        new assetGraph.HtmlStyle({
+                            hrefType: 'rootRelative',
+                            to: assetGraph.findAssets({url: urlByAssetName[cssAsset]})[0]
+                        }).attach(entryPointRelation.from, 'last');
+                    }
+                }
+            }
+        }
+
+        for (const asset of assetGraph.findAssets({ type: 'JavaScript', url: assetInfos.map(assetInfo => assetInfo.url)})) {
+            let replacementsMade = false;
+            let requireEnsureAstTemplate;
+            estraverse.traverse(asset.parseTree, {
+                enter(node) {
+                    // Detect the __webpack_require__.e = function requireEnsure(chunkId, callback) { ... declaration at the top of a bundle
+                    if (node.type === 'AssignmentExpression' &&
+                        node.operator === '=' &&
+                        node.left.type === 'MemberExpression' &&
+                        node.left.object.type === 'Identifier' &&
+                        node.left.object.name === '__webpack_require__' &&
+                        node.left.property.type === 'Identifier' &&
+                        node.left.property.name === 'e' &&
+                        node.right.type === 'FunctionExpression' &&
+                        node.right.id &&
+                        node.right.id.type === 'Identifier' &&
+                        node.right.id.name === 'requireEnsure'
+                    ) {
+                        node.right.params.push({ type: 'Identifier', name: '_assetgraph_url' });
+                        // Replace script.src = ... in the function body:
+                        estraverse.traverse(node.right.body, {
+                            enter(node) {
+                                if (node.type === 'ExpressionStatement' &&
+                                    node.expression.type === 'AssignmentExpression' &&
+                                    node.expression.left.type === 'MemberExpression' &&
+                                    node.expression.left.object.type === 'Identifier' &&
+                                    node.expression.left.object.name === 'script' &&
+                                    node.expression.left.property.type === 'Identifier' &&
+                                    node.expression.left.property.name === 'src'
+                                ) {
+                                    const templateAst = node.expression.right;
+                                    // Quick and dirty evaluator
+                                    requireEnsureAstTemplate = chunkId => {
+                                        let result = '';
+                                        (function visit(node) {
+                                            if (
+                                                node.type === 'MemberExpression' &&
+                                                node.object.type === 'Identifier' &&
+                                                node.object.name === '__webpack_require__' &&
+                                                node.property.type === 'Identifier' &&
+                                                node.property.name === 'p'
+                                            ) {
+                                                // FIXME: Fall back to config.output.path instead of hardcoding /dist/:
+                                                result += (config.output.publicPath || '/dist/');
+                                            } else if (node.type === 'BinaryExpression' && node.operator === '+') {
+                                                visit(node.left);
+                                                visit(node.right);
+                                            } else if (node.type === 'LogicalExpression' && node.operator === '||') {
+                                                const resultBeforeLeft = result;
+                                                visit(node.left);
+                                                if (result === resultBeforeLeft) {
+                                                    visit(node.right);
+                                                }
+                                            } else if (
+                                                node.type === 'MemberExpression' &&
+                                                node.computed &&
+                                                node.property.type === 'Identifier' &&
+                                                node.property.name === 'chunkId' &&
+                                                node.object.type === 'ObjectExpression'
+                                            ) {
+                                                for (const propertyNode of node.object.properties) {
+                                                    if (propertyNode.key.type === 'Literal' && String(propertyNode.key.value) === String(chunkId)) {
+                                                        visit(propertyNode.value);
+                                                    }
+                                                }
+                                            } else if (node.type === 'Literal') {
+                                                result += String(node.value);
+                                            } else if (node.type === 'Identifier' && node.name === 'chunkId') {
+                                                result += chunkId;
+                                            } else {
+                                                throw new Error('unsupported ' + node.type + ': ' + require('escodegen').generate(node));
+                                            }
+                                        }(templateAst));
+                                        return result;
+                                    };
+                                    node.expression.right = {
+                                        type: 'BinaryExpression',
+                                        operator: '||',
+                                        left: {
+                                            type: 'Identifier',
+                                            name: '_assetgraph_url'
+                                        },
+                                        right: node.expression.right
+                                    };
+                                }
+                            }
+                        });
+                        replacementsMade = true;
+                    } else if (
+                        node.type === 'VariableDeclaration' &&
+                        node.declarations.length === 1 &&
+                        node.declarations[0].type === 'VariableDeclarator' &&
+                        node.declarations[0].id.type === 'Identifier' &&
+                        node.declarations[0].id.name === 'map' &&
+                        node.declarations[0].init &&
+                        node.declarations[0].init.type === 'ObjectExpression' &&
+                        node.declarations[0].init.properties.length > 0 &&
+                        node.declarations[0].init.properties.every(propertyNode =>
+                            propertyNode.value.type === 'ArrayExpression' &&
+                            propertyNode.value.elements.length < 3
+                        )
+                    ) {
+                        // var map = {
+                        //     './splita': [
+                        //         1,
+                        //         1
+                        //     ],
+                        //     './splita.js': [
+                        //         1,
+                        //         1
+                        //     ],
+                        //     './splitb': [
+                        //         2,
+                        //         0
+                        //     ],
+                        //     './splitb.js': [
+                        //         2,
+                        //         0
+                        //     ]
+                        // };
+                        // Add a 3rd element to each value that uses .toString('url')
+                        for (const propertyNode of node.declarations[0].init.properties) {
+                            // Not sure this is necessary yet, but pad with undefined so we always
+                            // add to the 3rd position
+                            while (propertyNode.value.elements.length < 2) {
+                                propertyNode.value.elements.push({
+                                    type: 'Identifier',
+                                    value: 'undefined'
+                                });
+                            }
+                            propertyNode.value.elements.push({
+                                type: 'CallExpression',
+                                callee: {
+                                    type: 'MemberExpression',
+                                    computed: false,
+                                    object: {
+                                        type: 'Literal',
+                                        value: requireEnsureAstTemplate(String(propertyNode.value.elements[1].value))
+                                    },
+                                    property: {
+                                        type: 'Identifier',
+                                        name: 'toString'
+                                    }
+                                },
+                                arguments: [
+                                    {
+                                        type: 'Literal',
+                                        value: 'url'
+                                    }
+                                ]
+                            });
+                        }
+                        replacementsMade = true;
+                    } else if (
+                        node.type === 'FunctionDeclaration' &&
+                        node.id.type === 'Identifier' &&
+                        node.id.name === 'webpackAsyncContext'
+                    ) {
+                        // function webpackAsyncContext(req) {
+                        //     var ids = map[req];
+                        //     if (!ids)
+                        //         return Promise.reject(new Error('Cannot find module \'' + req + '\'.'));
+                        //     return __webpack_require__.e(ids[1]).then(function () {
+                        //         return __webpack_require__(ids[0]);
+                        //     });
+                        // }
+                        // Add ids[2] to the argument list in the __webpack_require__.e call so that the JavaScriptStaticUrl is passed on
+                        const lastStatement = node.body.body[node.body.body.length - 1];
+                        if (lastStatement &&
+                            lastStatement.type === 'ReturnStatement' &&
+                            lastStatement.argument.type === 'CallExpression' &&
+                            lastStatement.argument.callee.type === 'MemberExpression' &&
+                            lastStatement.argument.callee.object.type === 'CallExpression' &&
+                            lastStatement.argument.callee.object.callee.type === 'MemberExpression' &&
+                            lastStatement.argument.callee.object.callee.object.type === 'Identifier' &&
+                            lastStatement.argument.callee.object.callee.object.name === '__webpack_require__' &&
+                            lastStatement.argument.callee.object.callee.property.type === 'Identifier' &&
+                            lastStatement.argument.callee.object.callee.property.name === 'e' &&
+                            lastStatement.argument.callee.object.arguments.length === 1 &&
+                            lastStatement.argument.callee.object.arguments[0].type === 'MemberExpression' &&
+                            lastStatement.argument.callee.object.arguments[0].computed &&
+                            lastStatement.argument.callee.object.arguments[0].object.type === 'Identifier' &&
+                            lastStatement.argument.callee.object.arguments[0].object.name === 'ids' &&
+                            lastStatement.argument.callee.object.arguments[0].property.type === 'Literal'
+                        ) {
+                            lastStatement.argument.callee.object.arguments.push({
+                                type: 'MemberExpression',
+                                computed: true,
+                                object: {
+                                    type: 'Identifier',
+                                    name: 'ids'
+                                },
+                                property: {
+                                    type: 'Literal',
+                                    value: 2
+                                }
+                            });
+                            replacementsMade = true;
+                        }
+                    } else if (
+                        node.type === 'CallExpression' &&
+                        node.callee.type === 'MemberExpression' &&
+                        node.callee.object.type === 'Identifier' &&
+                        node.callee.object.name === '__webpack_require__' &&
+                        node.callee.property.type === 'Identifier' &&
+                        node.callee.property.name === 'e' &&
+                        node.arguments.length >= 1 &&
+                        node.arguments[0].type === 'Literal' &&
+                        typeof node.arguments[0].value === 'number' &&
+                        requireEnsureAstTemplate
+                    ) {
+                        node.arguments.push({
+                            type: 'CallExpression',
+                            callee: {
+                                type: 'MemberExpression',
+                                computed: false,
+                                object: {
+                                    type: 'Literal',
+                                    value: requireEnsureAstTemplate(node.arguments[0].value)
+                                },
+                                property: {
+                                    type: 'Identifier',
+                                    name: 'toString'
+                                }
+                            },
+                            arguments: [
+                                {
+                                    type: 'Literal',
+                                    value: 'url'
+                                }
+                            ]
+                        });
+                        replacementsMade = true;
+                    } else if (
+                        node.type === 'FunctionExpression' &&
+                        node.params.length === 3 &&
+                        node.params[0].type === 'Identifier' && node.params[0].name === 'module' &&
+                        node.params[1].type === 'Identifier' && node.params[1].name === 'exports' &&
+                        node.params[2].type === 'Identifier' && node.params[2].name === '__webpack_require__' &&
+                        node.leadingComments && (node.leadingComments.length === 2 || node.leadingComments.length === 3) &&
+                        /^ \d+ $/.test(node.leadingComments[node.leadingComments.length - 2].value) &&
+                        node.leadingComments[node.leadingComments.length - 1].value === '*' &&
+                        node.body.type === 'BlockStatement' &&
+                        node.body.body.length === 1 &&
+                        node.body.body[0].type === 'ExpressionStatement' &&
+                        node.body.body[0].expression.type === 'AssignmentExpression' &&
+                        node.body.body[0].expression.left.type === 'MemberExpression' &&
+                        node.body.body[0].expression.left.object.type === 'Identifier' &&
+                        node.body.body[0].expression.left.object.name === 'module' &&
+                        node.body.body[0].expression.left.property.type === 'Identifier' &&
+                        node.body.body[0].expression.left.property.name === 'exports' &&
+                        node.body.body[0].expression.right.type === 'BinaryExpression' &&
+                        node.body.body[0].expression.right.operator === '+' &&
+                        node.body.body[0].expression.right.left.type === 'MemberExpression' &&
+                        node.body.body[0].expression.right.left.object.type === 'Identifier' &&
+                        node.body.body[0].expression.right.left.object.name === node.params[2].name &&
+                        node.body.body[0].expression.right.left.property.type === 'Identifier' &&
+                        node.body.body[0].expression.right.left.property.name === 'p' &&
+                        node.body.body[0].expression.right.right.type === 'Literal' &&
+                        typeof node.body.body[0].expression.right.right.value === 'string'
+                    ) {
+                        node.body.body[0].expression.right = {
+                            type: 'CallExpression',
+                            range: node.body.body[0].expression.right.range,
+                            callee: {
+                                type: 'MemberExpression',
+                                computed: false,
+                                object: {
+                                    type: 'Literal',
+                                    // FIXME: Fall back to config.output.path instead of hardcoding /dist/:
+                                    value: (config.output.publicPath || '/dist/') + node.body.body[0].expression.right.right.value
+                                },
+                                property: {
+                                    type: 'Identifier',
+                                    name: 'toString'
+                                }
+                            },
+                            arguments: [
+                                {
+                                    type: 'Literal',
+                                    value: 'url'
+                                }
+                            ]
+                        };
+                        replacementsMade = true;
+                    }
+                }
+            });
+            if (replacementsMade) {
+                asset.markDirty();
+                for (const relation of [].concat(asset.outgoingRelations)) {
+                    asset.removeRelation(relation);
+                }
+                asset._outgoingRelations = undefined;
+                asset.isPopulated = false;
+                asset.populate();
+            }
+        }
     };
 };

--- a/lib/transforms/compressJavaScript.js
+++ b/lib/transforms/compressJavaScript.js
@@ -1,24 +1,22 @@
-var _ = require('lodash');
-var os = require('os');
-var Promise = require('bluebird');
-var uglifyJs = require('uglify-js');
-var errors = require('../errors');
-var compressorByName = {};
+const _ = require('lodash');
+const os = require('os');
+const Promise = require('bluebird');
+const uglifyJs = require('uglify-js');
+const errors = require('../errors');
+const compressorByName = {};
 
-compressorByName.uglifyJs = function (assetGraph, javaScript, compressorOptions) {
+compressorByName.uglifyJs = async (assetGraph, javaScript, compressorOptions) => {
     compressorOptions = compressorOptions || {};
-    var sourceMaps = compressorOptions.sourceMaps;
+    const sourceMaps = compressorOptions.sourceMaps;
     compressorOptions = _.extend({}, _.omit(compressorOptions, 'sourceMaps'));
-    var mangleOptions = _.defaults({}, _.pick(javaScript.serializationOptions, ['screw_ie8']), this.assetGraph && _.pick(this.assetGraph.javaScriptSerializationOptions, ['screw_ie8']), compressorOptions.mangleOptions);
+    const mangleOptions = _.defaults({}, _.pick(javaScript.serializationOptions, ['screw_ie8']), _.pick(assetGraph.javaScriptSerializationOptions, ['screw_ie8']), compressorOptions.mangleOptions);
     delete compressorOptions.mangleOptions;
-    _.defaults(compressorOptions, _.pick(javaScript.serializationOptions, ['side_effects', 'screw_ie8']), this.assetGraph && _.pick(this.assetGraph.javaScriptSerializationOptions, ['side_effects', 'screw_ie8']));
+    _.defaults(compressorOptions, _.pick(javaScript.serializationOptions, ['side_effects', 'screw_ie8']), _.pick(assetGraph.javaScriptSerializationOptions, ['side_effects', 'screw_ie8']));
 
-    var text,
-        sourceMap;
+    let text;
+    let sourceMap;
     if (sourceMaps) {
-        var textAndSourceMap = javaScript.textAndSourceMap;
-        text = textAndSourceMap.text;
-        sourceMap = textAndSourceMap.sourceMap;
+        ({ text, sourceMap } = javaScript.textAndSourceMap);
     } else {
         text = javaScript.text;
     }
@@ -29,26 +27,26 @@ compressorByName.uglifyJs = function (assetGraph, javaScript, compressorOptions)
         text += '\n;';
     }
 
-    var result = uglifyJs.minify(text, {
+    const { error, ast, code, map } = uglifyJs.minify(text, {
         sourceMap: { content: sourceMap },
         compress: compressorOptions,
         mangle: mangleOptions,
         output: { comments: true, source_map: true, ast: true }
     });
-    if (result.error) {
-        return Promise.reject(new errors.ParseError({
-            message: 'Parse error in ' + javaScript.urlOrDescription + '\n' + result.error.message + ' (line ' + result.error.line + ', column ' + (result.error.col + 1) + ')',
-            line: result.error.line,
-            column: result.error.col + 1,
+    if (error) {
+        throw new errors.ParseError({
+            message: 'Parse error in ' + javaScript.urlOrDescription + '\n' + error.message + ' (line ' + error.line + ', column ' + (error.col + 1) + ')',
+            line: error.line,
+            column: error.col + 1,
             asset: javaScript
-        }));
+        });
     }
-    var outText = result.code;
+    let outText = code;
     // Workaround for https://github.com/mishoo/UglifyJS2/issues/180
     // so we avoid throwing away a trailing comment, which would be especially
     // bad if it contains an inline source map with sourcesContent.
-    if (result.ast.end && result.ast.end.comments_before && !result.ast.end._comments_dumped) {
-        result.ast.end.comments_before.forEach(function (comment) {
+    if (ast.end && ast.end.comments_before && !ast.end._comments_dumped) {
+        for (const comment of ast.end.comments_before) {
             if (assetGraph.JavaScript.shouldCommentNodeBePreservedInNonPrettyPrintedOutput(comment)) {
                 if (comment.type === 'comment1') {
                     outText += '//' + comment.value + '\n';
@@ -56,74 +54,66 @@ compressorByName.uglifyJs = function (assetGraph, javaScript, compressorOptions)
                     outText += '/*' + comment.value + '*/';
                 }
             }
-        }, this);
+        }
     }
 
-    var compressedJavaScript = new assetGraph.JavaScript({
+    return new assetGraph.JavaScript({
         lastKnownByteLength: javaScript.lastKnownByteLength, // I know, I know
         copyrightNoticeComments: javaScript.copyrightNoticeComments,
         text: outText,
         isDirty: true,
         isMinified: javaScript.isMinified,
         isPretty: javaScript.isPretty,
-        sourceMap: result.map
+        sourceMap: map
     });
-    return Promise.resolve(compressedJavaScript);
 };
 
-compressorByName.yuicompressor = function (assetGraph, javaScript, compressorOptions) {
-    var yuicompressor;
+compressorByName.yuicompressor = async (assetGraph, javaScript, compressorOptions) => {
+    let yuicompressor;
     try {
         yuicompressor = require('yui-compressor');
     } catch (e) {
         throw new Error('transforms.compressJavaScript: node-yui-compressor not found. Please run \'npm install yui-compressor\' and try again (tested with version 0.1.3).');
     }
     compressorOptions = compressorOptions || {};
-    return Promise.fromNode(function (cb) {
-        yuicompressor.compile(javaScript.text, compressorOptions);
-    }).then(function (compressedText) {
-        return new assetGraph.JavaScript({
-            copyrightNoticeComments: javaScript.copyrightNoticeComments,
-            text: compressedText
-        });
+    return new assetGraph.JavaScript({
+        copyrightNoticeComments: javaScript.copyrightNoticeComments,
+        text: await Promise.fromNode(cb => yuicompressor.compile(javaScript.text, compressorOptions, cb))
     });
 };
 
-compressorByName.closurecompiler = function (assetGraph, javaScript, compressorOptions) {
-    var closurecompiler;
+compressorByName.closurecompiler = async (assetGraph, javaScript, compressorOptions) => {
+    let closurecompiler;
     try {
         closurecompiler = require('closure-compiler');
     } catch (e) {
         throw new Error('transforms.compressJavaScript: node-closure-compiler not found. Please run \'npm install closure-compiler\' and try again (tested with version 0.1.1).');
     }
     compressorOptions = compressorOptions || {};
-    return Promise.fromNode(function (cb) {
-        closurecompiler.compile(javaScript.text, compressorOptions, cb);
-    }).then(function (compressedText) {
-        return new assetGraph.JavaScript({
-            copyrightNoticeComments: javaScript.copyrightNoticeComments,
-            text: compressedText
-        });
+    return new assetGraph.JavaScript({
+        copyrightNoticeComments: javaScript.copyrightNoticeComments,
+        text: await Promise.fromNode(cb => closurecompiler.compile(javaScript.text, compressorOptions, cb))
     });
 };
 
-module.exports = function (queryObj, compressorName, compressorOptions) {
+module.exports = (queryObj, compressorName, compressorOptions) => {
     if (!compressorName) {
         compressorName = 'uglifyJs';
     }
     if (!compressorByName[compressorName]) {
         throw new Error('transforms.compressJavaScript: Unknown compressor: ' + compressorName);
     }
-    return function compressJavaScript(assetGraph) {
-        return Promise.map(assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj)), function (javaScript) {
-            return compressorByName[compressorName](assetGraph, javaScript, compressorOptions).then(function (compressedJavaScript) {
+    return async function compressJavaScript(assetGraph) {
+        await Promise.map(assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj)), async javaScript => {
+            try {
+                const compressedJavaScript = await compressorByName[compressorName](assetGraph, javaScript, compressorOptions);
                 javaScript.replaceWith(compressedJavaScript);
                 compressedJavaScript.serializationOptions = _.extend({}, javaScript.serializationOptions);
                 compressedJavaScript.initialComments = javaScript.initialComments;
                 javaScript.unload();
-            }, function (err) {
+            } catch (err) {
                 assetGraph.emit('warn', err);
-            });
+            }
         }, {concurrency: os.cpus().length + 1});
     };
 };

--- a/lib/transforms/compressJavaScript.js
+++ b/lib/transforms/compressJavaScript.js
@@ -8,7 +8,7 @@ const compressorByName = {};
 compressorByName.uglifyJs = async (assetGraph, javaScript, compressorOptions) => {
     compressorOptions = compressorOptions || {};
     const sourceMaps = compressorOptions.sourceMaps;
-    compressorOptions = _.extend({}, _.omit(compressorOptions, 'sourceMaps'));
+    compressorOptions = Object.assign({}, _.omit(compressorOptions, 'sourceMaps'));
     const mangleOptions = _.defaults({}, _.pick(javaScript.serializationOptions, ['screw_ie8']), _.pick(assetGraph.javaScriptSerializationOptions, ['screw_ie8']), compressorOptions.mangleOptions);
     delete compressorOptions.mangleOptions;
     _.defaults(compressorOptions, _.pick(javaScript.serializationOptions, ['side_effects', 'screw_ie8']), _.pick(assetGraph.javaScriptSerializationOptions, ['side_effects', 'screw_ie8']));
@@ -104,11 +104,11 @@ module.exports = (queryObj, compressorName, compressorOptions) => {
         throw new Error('transforms.compressJavaScript: Unknown compressor: ' + compressorName);
     }
     return async function compressJavaScript(assetGraph) {
-        await Promise.map(assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj)), async javaScript => {
+        await Promise.map(assetGraph.findAssets(Object.assign({type: 'JavaScript'}, queryObj)), async javaScript => {
             try {
                 const compressedJavaScript = await compressorByName[compressorName](assetGraph, javaScript, compressorOptions);
                 javaScript.replaceWith(compressedJavaScript);
-                compressedJavaScript.serializationOptions = _.extend({}, javaScript.serializationOptions);
+                compressedJavaScript.serializationOptions = Object.assign({}, javaScript.serializationOptions);
                 compressedJavaScript.initialComments = javaScript.initialComments;
                 javaScript.unload();
             } catch (err) {

--- a/lib/transforms/convertCssImportsToHtmlStyles.js
+++ b/lib/transforms/convertCssImportsToHtmlStyles.js
@@ -1,9 +1,8 @@
-const _ = require('lodash');
 const AssetGraph = require('../AssetGraph');
 
 module.exports = queryObj => {
     return function convertCssImportsToHtmlStyles(assetGraph) {
-        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html'}, queryObj))) {
             for (const htmlStyle of assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset})) {
                 assetGraph.eachAssetPostOrder(htmlStyle, {type: 'CssImport'}, (cssAsset, incomingRelation) => {
                     if (incomingRelation.type === 'CssImport') {

--- a/lib/transforms/convertCssImportsToHtmlStyles.js
+++ b/lib/transforms/convertCssImportsToHtmlStyles.js
@@ -1,22 +1,22 @@
-var _ = require('lodash'),
-    AssetGraph = require('../AssetGraph');
+const _ = require('lodash');
+const AssetGraph = require('../AssetGraph');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function convertCssImportsToHtmlStyles(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'Html'}, queryObj)).forEach(function (htmlAsset) {
-            assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset}).forEach(function (htmlStyle) {
-                assetGraph.eachAssetPostOrder(htmlStyle, {type: 'CssImport'}, function (cssAsset, incomingRelation) {
+        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+            for (const htmlStyle of assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset})) {
+                assetGraph.eachAssetPostOrder(htmlStyle, {type: 'CssImport'}, (cssAsset, incomingRelation) => {
                     if (incomingRelation.type === 'CssImport') {
-                        var newHtmlStyle = new AssetGraph.HtmlStyle({to: cssAsset, hrefType: incomingRelation.hrefType});
+                        const newHtmlStyle = new AssetGraph.HtmlStyle({to: cssAsset, hrefType: incomingRelation.hrefType});
                         newHtmlStyle.attach(htmlAsset, 'before', htmlStyle);
-                        var media = incomingRelation.media;
+                        const media = incomingRelation.media;
                         if (media.length) {
                             newHtmlStyle.node.setAttribute('media', media);
                         }
                         incomingRelation.detach();
                     }
                 });
-            });
-        });
+            }
+        }
     };
 };

--- a/lib/transforms/convertHtmlStylesToInlineCssImports.js
+++ b/lib/transforms/convertHtmlStylesToInlineCssImports.js
@@ -1,11 +1,10 @@
-const _ = require('lodash');
 const AssetGraph = require('../AssetGraph');
 
 module.exports = queryObj => {
     return function convertHtmlStylesToInlineCssImports(assetGraph) {
         const addedInlineCssAssets = [];
         let currentInlineCssAsset;
-        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html'}, queryObj))) {
             for (const htmlStyle of assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset})) {
                 if (!htmlStyle.to.url) {
                     // Skip already inline stylesheet.

--- a/lib/transforms/convertHtmlStylesToInlineCssImports.js
+++ b/lib/transforms/convertHtmlStylesToInlineCssImports.js
@@ -1,12 +1,12 @@
-var _ = require('lodash'),
-    AssetGraph = require('../AssetGraph');
+const _ = require('lodash');
+const AssetGraph = require('../AssetGraph');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function convertHtmlStylesToInlineCssImports(assetGraph) {
-        var addedInlineCssAssets = [],
-            currentInlineCssAsset;
-        assetGraph.findAssets(_.extend({type: 'Html'}, queryObj)).forEach(function (htmlAsset) {
-            assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset}).forEach(function (htmlStyle) {
+        const addedInlineCssAssets = [];
+        let currentInlineCssAsset;
+        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+            for (const htmlStyle of assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset})) {
                 if (!htmlStyle.to.url) {
                     // Skip already inline stylesheet.
                     currentInlineCssAsset = null;
@@ -23,11 +23,11 @@ module.exports = function (queryObj) {
                         to: currentInlineCssAsset
                     }).attach(htmlAsset, 'before', htmlStyle);
                 }
-                var mediaText = htmlStyle.node.getAttribute('media');
+                const mediaText = htmlStyle.node.getAttribute('media');
                 currentInlineCssAsset.parseTree.append('@import ""' + (mediaText ? ' ' + mediaText : ''));
-                var cssImportRule = currentInlineCssAsset.parseTree.last;
+                const cssImportRule = currentInlineCssAsset.parseTree.last;
 
-                var cssImport = new AssetGraph.CssImport({
+                const cssImport = new AssetGraph.CssImport({
                     to: htmlStyle.to,
                     node: cssImportRule,
                     hrefType: htmlStyle.hrefType
@@ -35,7 +35,7 @@ module.exports = function (queryObj) {
                 currentInlineCssAsset.addRelation(cssImport, 'last');
                 cssImport.refreshHref();
                 htmlStyle.detach();
-            });
-        });
+            }
+        }
     };
 };

--- a/lib/transforms/convertStylesheetsToInlineStyles.js
+++ b/lib/transforms/convertStylesheetsToInlineStyles.js
@@ -1,32 +1,32 @@
-var _ = require('lodash'),
-    AssetGraph = require('../AssetGraph');
+const _ = require('lodash');
+const AssetGraph = require('../AssetGraph');
 
-module.exports = function (queryObj, media) {
-    var includeByMedium = {};
+module.exports = (queryObj, media) => {
+    const includeByMedium = {};
     if (!media) {
         includeByMedium.all = true;
     } else {
-        media.split(',').forEach(function (medium) {
+        for (const medium of media.split(',')) {
             includeByMedium[medium.replace(/^\s+|\s+$/g, '')] = true;
-        });
+        }
     }
     function includeMedia(media) {
-        return includeByMedium.all || media.some(function (medium) {
+        return includeByMedium.all || media.some(medium => {
             medium = medium.replace(/^\s+|\s+$/g, '');
             return medium === 'all' || includeByMedium[medium];
         });
     }
 
     return function convertStylesheetsToInlineStyles(assetGraph) {
-        assetGraph.findAssets(_.extend({isHtml: true}, queryObj)).forEach(function (htmlAsset) {
-            var document = htmlAsset.parseTree;
-            assetGraph.eachAssetPostOrder(htmlAsset, function (relation) {
+        for (const htmlAsset of assetGraph.findAssets(_.extend({isHtml: true}, queryObj))) {
+            const document = htmlAsset.parseTree;
+            assetGraph.eachAssetPostOrder(htmlAsset, relation => {
                 if (relation.type === 'HtmlStyle' || relation.type === 'CssImport') {
-                    var relationMedia = ['all'];
+                    let relationMedia = [ 'all' ];
                     if (relation.type === 'HtmlStyle') {
                         relationMedia = (relation.node.getAttribute('media') || 'all').split(',');
                     } else if (relation.type === 'CssImport') {
-                        var mediaStr = relation.media;
+                        const mediaStr = relation.media;
                         if (mediaStr) {
                             relationMedia = mediaStr.split(' ');
                         }
@@ -40,53 +40,49 @@ module.exports = function (queryObj, media) {
                     }
                 }
                 return false;
-            }, function (cssAsset, incomingRelation) {
+            }, (cssAsset, incomingRelation) => {
                 if (cssAsset.type === 'Css') {
-                    cssAsset.eachRuleInParseTree(function (cssRule) {
+                    cssAsset.eachRuleInParseTree(cssRule => {
                         if (cssRule.type === 'rule') {
-                            _.toArray(document.querySelectorAll(cssRule.selector)).forEach(function (node) {
+                            for (const node of _.toArray(document.querySelectorAll(cssRule.selector))) {
                                 if (node.nodeName.toLowerCase() === 'style' || node === document.head || node.parentNode === document.head) {
-                                    return;
+                                    continue;
                                 }
-                                var inlineCssAsset,
-                                    htmlStyleAttributeRelation = assetGraph.findRelations({
-                                        from: htmlAsset,
-                                        type: 'HtmlStyleAttribute',
-                                        node: function (_node) {
-                                            return _node === node;
-                                        }
-                                    })[0];
+                                let inlineCssAsset;
+                                let htmlStyleAttributeRelation = assetGraph.findRelations({
+                                    from: htmlAsset,
+                                    type: 'HtmlStyleAttribute',
+                                    node: _node => _node === node
+                                })[0];
                                 if (htmlStyleAttributeRelation) {
                                     inlineCssAsset = htmlStyleAttributeRelation.to;
                                 } else {
                                     inlineCssAsset = new assetGraph.Css({text: 'bogusselector {}'});
                                     htmlStyleAttributeRelation = new AssetGraph.HtmlStyleAttribute({
-                                        node: node,
+                                        node,
                                         to: inlineCssAsset
                                     });
                                     assetGraph.addAsset(inlineCssAsset);
                                     htmlAsset.addRelation(htmlStyleAttributeRelation);
                                 }
-                                var styleRuleIndex = inlineCssAsset.parseTree.nodes.length;
+                                const styleRuleIndex = inlineCssAsset.parseTree.nodes.length;
 
-                                inlineCssAsset.parseTree.nodes[0].append(cssRule.nodes.map(function (node) {
+                                inlineCssAsset.parseTree.nodes[0].append(cssRule.nodes.map(node => {
                                     return node.clone({ raws: { before: ' ', between: (node.raws && node.raws.between) || ': ' } });
                                 }));
-                                assetGraph.findRelations({
+                                for (const cssRelation of assetGraph.findRelations({
                                     from: cssAsset,
-                                    node: function (_node) {
-                                        return _node === node;
-                                    }
-                                }).forEach(function (cssRelation) {
+                                    node: _node => _node === node
+                                })) {
                                     inlineCssAsset.addRelation(new cssRelation.constructor({
                                         parentNode: inlineCssAsset.parseTree,
                                         node: inlineCssAsset.parseTree.nodes[0],
                                         propertyNode: inlineCssAsset.parseTree.nodes[styleRuleIndex],
                                         to: cssRelation.to
                                     }));
-                                });
+                                }
                                 inlineCssAsset.markDirty();
-                            });
+                            }
                         } else if (cssRule.type === 'atrule' && cssRule.name === 'media') {
                             if (!includeMedia(cssRule.params.split(' '))) {
                                 return false;
@@ -100,6 +96,6 @@ module.exports = function (queryObj, media) {
                     }
                 }
             });
-        });
+        }
     };
 };

--- a/lib/transforms/convertStylesheetsToInlineStyles.js
+++ b/lib/transforms/convertStylesheetsToInlineStyles.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const AssetGraph = require('../AssetGraph');
 
 module.exports = (queryObj, media) => {
@@ -18,7 +17,7 @@ module.exports = (queryObj, media) => {
     }
 
     return function convertStylesheetsToInlineStyles(assetGraph) {
-        for (const htmlAsset of assetGraph.findAssets(_.extend({isHtml: true}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({isHtml: true}, queryObj))) {
             const document = htmlAsset.parseTree;
             assetGraph.eachAssetPostOrder(htmlAsset, relation => {
                 if (relation.type === 'HtmlStyle' || relation.type === 'CssImport') {
@@ -44,7 +43,7 @@ module.exports = (queryObj, media) => {
                 if (cssAsset.type === 'Css') {
                     cssAsset.eachRuleInParseTree(cssRule => {
                         if (cssRule.type === 'rule') {
-                            for (const node of _.toArray(document.querySelectorAll(cssRule.selector))) {
+                            for (const node of Array.from(document.querySelectorAll(cssRule.selector))) {
                                 if (node.nodeName.toLowerCase() === 'style' || node === document.head || node.parentNode === document.head) {
                                     continue;
                                 }

--- a/lib/transforms/drawGraph.js
+++ b/lib/transforms/drawGraph.js
@@ -1,17 +1,15 @@
-var Path = require('path');
-var Promise = require('bluebird');
-var childProcess = require('child_process');
-var _ = require('lodash');
-var relationLabelByType = {
+const Path = require('path');
+const Promise = require('bluebird');
+const childProcess = require('child_process');
+const _ = require('lodash');
+const relationLabelByType = {
     HtmlScript: '<script>',
     HtmlStyle: '<style>',
     HtmlCacheManifest: '<html manifest>',
     HtmlIFrame: '<iframe>',
     HtmlFrame: '<frame>',
     HtmlAlternateLink: '<link rel=alternate>',
-    HtmlConditionalComment: function (htmlConditionalComment) {
-        return '<!--[if ' + htmlConditionalComment.condition + ']>';
-    },
+    HtmlConditionalComment: htmlConditionalComment => '<!--[if ' + htmlConditionalComment.condition + ']>',
     HtmlImage: '<img>',
     HtmlAudio: '<audio>',
     HtmlShortcutIcon: 'icon',
@@ -31,31 +29,31 @@ var relationLabelByType = {
     CssAlphaImageLoader: 'AlphaImageLoader'
 };
 
-module.exports = function (targetFileName) {
+module.exports = targetFileName => {
     targetFileName = targetFileName || 'assetgraph.svg';
 
-    return function drawGraph(assetGraph) {
-        var dotSrc = 'digraph \"' + targetFileName.replace(/^.*\/|\.[^\/\.]*$/g, '') + '\" {\n',
-            nextUniqueId = 1,
-            seenNodes = {};
+    return async function drawGraph(assetGraph) {
+        let dotSrc = 'digraph \"' + targetFileName.replace(/^.*\/|\.[^\/\.]*$/g, '') + '\" {\n';
+        let nextUniqueId = 1;
+        const seenNodes = {};
 
         function addAssetAsNode(asset, namePrefix) {
             seenNodes[asset.id] = true;
             dotSrc += '  ' + asset.id + ' [style = ' + (asset.isLoaded ? 'solid' : 'dashed') + ', label = "' + (namePrefix || '') + (asset.url ? Path.basename(asset.url) : 'i:' + asset).replace(/"/g, '\\"') + '"];\n';
         }
-        var assetsByPath = {},
-            transitionStringsByPath = {};
+        const assetsByPath = {};
+        const transitionStringsByPath = {};
 
-        assetGraph.findAssets().forEach(function (asset) {
+        for (const asset of assetGraph.findAssets()) {
             if (asset.nonInlineAncestor) {
-                var path = asset.nonInlineAncestor.url.replace(/[^\/]*(?:[\?#].*)?$/, '');
+                const path = asset.nonInlineAncestor.url.replace(/[^\/]*(?:[\?#].*)?$/, '');
                 (assetsByPath[path] = assetsByPath[path] || []).push(asset);
             }
             addAssetAsNode(asset);
-        });
+        }
 
-        assetGraph.findRelations({}, true).forEach(function (relation) {
-            var target = relation.to;
+        for (const relation of assetGraph.findRelations({}, true)) {
+            let target = relation.to;
             if (!target.id) {
                 target = _.defaults({id: 'unresolved' + nextUniqueId}, target);
                 nextUniqueId += 1;
@@ -63,45 +61,44 @@ module.exports = function (targetFileName) {
             if (!seenNodes[target.id]) {
                 addAssetAsNode(target, 'o:');
             }
-            var labelText = relationLabelByType[relation.type] || '';
+            let labelText = relationLabelByType[relation.type] || '';
             if (typeof labelText === 'function') {
                 labelText = labelText(relation);
             }
 
-            var transitionString = String(relation.from.id) + ' -> ' + target.id + ' [fontsize=9, arrowhead=empty, label="' + labelText.replace(/"/g, '\\"') + '"];\n',
-                fromPath = relation.from.nonInlineAncestor && relation.from.nonInlineAncestor.url.replace(/[^\/]*(?:[\?#].*)?$/, '');
+            const transitionString = String(relation.from.id) + ' -> ' + target.id + ' [fontsize=9, arrowhead=empty, label="' + labelText.replace(/"/g, '\\"') + '"];\n';
+            const fromPath = relation.from.nonInlineAncestor && relation.from.nonInlineAncestor.url.replace(/[^\/]*(?:[\?#].*)?$/, '');
 
             if (fromPath && relation.to.nonInlineAncestor && fromPath === relation.to.nonInlineAncestor.url.replace(/[^\/]*(?:[\?#].*)?$/, '')) {
                 (transitionStringsByPath[fromPath] = transitionStringsByPath[fromPath] || []).push(transitionString);
             } else {
                 dotSrc += '  ' + transitionString;
             }
-        });
+        }
 
-        Object.keys(assetsByPath).forEach(function (path) {
+        for (const path of Object.keys(assetsByPath)) {
             dotSrc +=
                 '  subgraph cluster_' + nextUniqueId + ' {\n' +
-                    '    style = filled;\n' +
-                    '    color = lightgrey;\n' +
-                    '    label = "' + path + '";\n' +
-                    '\n' +
-                    assetsByPath[path].map(function (asset) {
-                        return '    ' + asset.id + ' [style = ' + (asset.isLoaded ? 'solid' : 'dashed') + ', label = "' + (asset.url ? Path.basename(asset.url) : 'i:' + asset).replace(/"/g, '\\"') + '"];\n';
-                    }).join('') +
-                    (transitionStringsByPath[path] || []).map(function (transitionString) {
-                        return '    ' + transitionString + '\n';
-                    }).join('') +
+                '    style = filled;\n' +
+                '    color = lightgrey;\n' +
+                '    label = "' + path + '";\n' +
+                '\n' +
+                assetsByPath[path].map(asset =>
+                    '    ' + asset.id + ' [style = ' + (asset.isLoaded ? 'solid' : 'dashed') + ', label = "' +
+                    (asset.url ? Path.basename(asset.url) : 'i:' + asset).replace(/"/g, '\\"') + '"];\n'
+                ).join('') +
+                (transitionStringsByPath[path] || []).map(transitionString =>
+                    '    ' + transitionString + '\n'
+                ).join('') +
                 '  }\n\n';
             nextUniqueId += 1;
-        });
+        }
 
         dotSrc += '}\n';
-        var dotProcess = childProcess.spawn('dot', ['-T', Path.extname(targetFileName).substr(1), '-o', targetFileName]);
+        const dotProcess = childProcess.spawn('dot', ['-T', Path.extname(targetFileName).substr(1), '-o', targetFileName]);
         dotProcess.stdin.end(dotSrc);
-        dotProcess.stderr.on('data', function (chunk) {
-            console.warn('dot STDERR: ' + chunk);
-        });
-        return Promise.fromNode(function (cb) {
+        dotProcess.stderr.on('data', chunk => console.warn('dot STDERR: ' + chunk));
+        await Promise.fromNode(cb =>{
             dotProcess.on('error', function (error) {
                 if (error.code === 'ENOENT') {
                     cb(new Error('"dot" not found. Please install graphviz.'));

--- a/lib/transforms/duplicateFavicon.js
+++ b/lib/transforms/duplicateFavicon.js
@@ -2,12 +2,10 @@
 // it can be moved to the static dir and served with a far-future expires. Still, keep a copy at /favicon.ico for
 // old IE versions.
 
-const _ = require('lodash');
-
 module.exports = queryObj => {
     return function duplicateFavicon(assetGraph) {
         const rootFavicon = assetGraph.findAssets({url: assetGraph.root + 'favicon.ico'})[0];
-        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false, isFragment: false, isLoaded: true}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html', isInline: false, isFragment: false, isLoaded: true}, queryObj))) {
             if (rootFavicon && assetGraph.findRelations({from: htmlAsset, type: 'HtmlShortcutIcon'}).length === 0) {
                 new assetGraph.HtmlShortcutIcon({to: rootFavicon}).attach(htmlAsset);
             }

--- a/lib/transforms/duplicateFavicon.js
+++ b/lib/transforms/duplicateFavicon.js
@@ -2,22 +2,20 @@
 // it can be moved to the static dir and served with a far-future expires. Still, keep a copy at /favicon.ico for
 // old IE versions.
 
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function duplicateFavicon(assetGraph) {
-        var rootFavicon = assetGraph.findAssets({url: assetGraph.root + 'favicon.ico'})[0];
-        assetGraph.findAssets(_.extend({type: 'Html', isInline: false, isFragment: false, isLoaded: true}, queryObj)).forEach(function (htmlAsset) {
+        const rootFavicon = assetGraph.findAssets({url: assetGraph.root + 'favicon.ico'})[0];
+        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false, isFragment: false, isLoaded: true}, queryObj))) {
             if (rootFavicon && assetGraph.findRelations({from: htmlAsset, type: 'HtmlShortcutIcon'}).length === 0) {
                 new assetGraph.HtmlShortcutIcon({to: rootFavicon}).attach(htmlAsset);
             }
-        });
+        }
         if (rootFavicon) {
-            var incomingRelations = assetGraph.findRelations({to: rootFavicon}).filter(function (relation) {
-                return relation.to.isLoaded;
-            });
+            const incomingRelations = assetGraph.findRelations({to: rootFavicon}).filter(relation => relation.to.isLoaded);
             if (incomingRelations.length > 0) {
-                var rootFaviconCopy = rootFavicon.clone(incomingRelations);
+                const rootFaviconCopy = rootFavicon.clone(incomingRelations);
                 rootFaviconCopy.fileName = 'favicon.copy.ico';
                 rootFaviconCopy.isInitial = false;
             }

--- a/lib/transforms/executeJavaScriptInOrder.js
+++ b/lib/transforms/executeJavaScriptInOrder.js
@@ -1,7 +1,7 @@
-var vm = require('vm');
+const vm = require('vm');
 
 // Only really makes sense when queryObj matches a single initial asset.
-module.exports = function (queryObj, context) {
+module.exports = (queryObj, context) => {
     if (typeof queryObj === 'undefined') {
         throw new Error('executeJavaScriptInOrder: The queryObj parameter is mandatory.');
     }
@@ -9,11 +9,11 @@ module.exports = function (queryObj, context) {
         if (!context) {
             context = vm.createContext();
         }
-        var assetsInOrder = [];
-        assetGraph.findAssets(queryObj).forEach(function (initialAsset) {
-            Array.prototype.push.apply(assetsInOrder, assetGraph.collectAssetsPostOrder(initialAsset, {to: {type: 'JavaScript'}}));
-        });
-        assetsInOrder.forEach(function (asset) {
+        const assetsInOrder = [];
+        for (const initialAsset of assetGraph.findAssets(queryObj)) {
+            assetsInOrder.push(...assetGraph.collectAssetsPostOrder(initialAsset, {to: {type: 'JavaScript'}}));
+        }
+        for (const asset of assetsInOrder) {
             try {
                 vm.runInContext(asset.text, context, asset.url || '(inline)');
             } catch (e) {
@@ -21,6 +21,6 @@ module.exports = function (queryObj, context) {
                 // https://github.com/joyent/node/commit/c05936ca13681059c7aeecfe3a608e4e1afa800a
                 throw new Error('transforms.executeJavaScriptInOrder: Error in ' + (asset.url || '(inline script)') + ':\n' + e.stack);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/externalizeRelations.js
+++ b/lib/transforms/externalizeRelations.js
@@ -1,11 +1,11 @@
-var urlTools = require('urltools');
+const urlTools = require('urltools');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function externalizeRelations(assetGraph) {
-        assetGraph.findRelations(queryObj).forEach(function (relation) {
+        for (const relation of assetGraph.findRelations(queryObj)) {
             if (relation.to.isInline && relation.to.isExternalizable) {
                 relation.to.url = urlTools.resolveUrl(assetGraph.root, relation.to.id + relation.to.extension);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/gzip.js
+++ b/lib/transforms/gzip.js
@@ -1,11 +1,11 @@
-var Promise = require('bluebird');
-var  _ = require('lodash');
-var AssetGraph = require('../AssetGraph');
+const Promise = require('bluebird');
+const  _ = require('lodash');
+const AssetGraph = require('../AssetGraph');
 
-module.exports = function (queryObj) {
-    return function gzip(assetGraph) {
-        var compress,
-            gzipAssets = assetGraph.findAssets(_.extend({isInline: false}, queryObj));
+module.exports = queryObj => {
+    return async function gzip(assetGraph) {
+        let compress;
+        const gzipAssets = assetGraph.findAssets(_.extend({isInline: false}, queryObj));
 
         if (gzipAssets.length > 0) {
             try {
@@ -16,21 +16,20 @@ module.exports = function (queryObj) {
             }
         }
 
-        return Promise.map(gzipAssets, function (asset) {
+        await Promise.map(gzipAssets, async asset => {
             // http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
             if (asset.type !== 'SourceMap' && asset.rawSrc.length > 860) {
-                return Promise.fromNode(function (cb) {
-                    compress.gzip(asset.rawSrc, cb);
-                }).then(function (gzippedRawSrc) {
+                try {
+                    const gzippedRawSrc = await Promise.fromNode(cb => compress.gzip(asset.rawSrc, cb));
                     if (gzippedRawSrc.length < asset.rawSrc.length) {
                         assetGraph.addAsset(new AssetGraph.Asset({
                             url: asset.url.replace(/(?=[\?#]|$)/, '.gz'),
                             rawSrc: gzippedRawSrc
                         }));
                     }
-                }, function (err) {
+                } catch (err) {
                     assetGraph.emit('error', err);
-                });
+                }
             }
         }, {concurrency: 4});
     };

--- a/lib/transforms/gzip.js
+++ b/lib/transforms/gzip.js
@@ -1,11 +1,10 @@
 const Promise = require('bluebird');
-const  _ = require('lodash');
 const AssetGraph = require('../AssetGraph');
 
 module.exports = queryObj => {
     return async function gzip(assetGraph) {
         let compress;
-        const gzipAssets = assetGraph.findAssets(_.extend({isInline: false}, queryObj));
+        const gzipAssets = assetGraph.findAssets(Object.assign({isInline: false}, queryObj));
 
         if (gzipAssets.length > 0) {
             try {

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -18,12 +18,12 @@
  * builds and optimization.
  */
 
-var postcss = require('postcss');
+const postcss = require('postcss');
 
 // Pseudo classes and elements
 // Commented out ones are ones are deterministic at build time
 // and thus don't have to get special treatment
-var pseudos = [
+const pseudos = [
     // pseudo-classes: https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes
     'active',
     'any',
@@ -79,11 +79,11 @@ var pseudos = [
     'grammar-error '
 ];
 
-var pseudoRegex = new RegExp('::?(?:' + pseudos.join('|') + ')', 'gi');
+const pseudoRegex = new RegExp('::?(?:' + pseudos.join('|') + ')', 'gi');
 
 function getDomNodesAboveFold(fold) {
-    var currentNode = fold;
-    var criticalNodes = [];
+    let currentNode = fold;
+    const criticalNodes = [];
 
     while (currentNode) {
         if (currentNode.nodeType === 1) {
@@ -98,7 +98,7 @@ function getDomNodesAboveFold(fold) {
         if (currentNode.previousSibling) {
             // Collect all child nodes of previous siblings
             if (currentNode.previousSibling.nodeType === 1) {
-                Array.prototype.push.apply(criticalNodes, currentNode.previousSibling.querySelectorAll('*'));
+                criticalNodes.push(...currentNode.previousSibling.querySelectorAll('*'));
             }
 
             currentNode = currentNode.previousSibling;
@@ -110,11 +110,10 @@ function getDomNodesAboveFold(fold) {
     return criticalNodes;
 }
 
-var clonedAtRuleMap = [];
+let clonedAtRuleMap = [];
 
 function getClonedAtRuleScaffold(rule, root) {
-    clonedRule;
-    var cacheHit = clonedAtRuleMap.find(function (mapping) {
+    const cacheHit = clonedAtRuleMap.find(mapping => {
         if (mapping.original === rule) {
             return mapping.clone;
         }
@@ -124,7 +123,7 @@ function getClonedAtRuleScaffold(rule, root) {
         return cacheHit.clone;
     }
 
-    var clonedRule = rule.clone();
+    const clonedRule = rule.clone();
 
     clonedRule.removeAll();
 
@@ -134,7 +133,7 @@ function getClonedAtRuleScaffold(rule, root) {
     });
 
     if (rule.parent.type === 'atrule') {
-        var parentRule = getClonedAtRuleScaffold(rule.parent, root);
+        const parentRule = getClonedAtRuleScaffold(rule.parent, root);
 
         clonedRule.parent = parentRule;
 
@@ -147,7 +146,7 @@ function getClonedAtRuleScaffold(rule, root) {
     return clonedRule;
 }
 
-module.exports = function (options) {
+module.exports = options => {
     options = options || {};
 
     // Make sure to run on a clean slate on every invokation
@@ -155,54 +154,48 @@ module.exports = function (options) {
 
     return function inlineCriticalCss(assetGraph) {
         // For each html page with <link> tags in <body> and not in <head>
-        var pages = assetGraph
+        const pages = assetGraph
             .findAssets({ type: 'Html', isLoaded: true, isInline: false })
-            .filter(function (page) {
-                var relations = assetGraph
+            .filter(page => {
+                const relations = assetGraph
                     .findRelations({ type: 'HtmlStyle', from: page, to: { isInline: false }}, true);
 
                 if (relations.length === 0) {
                     return false;
                 }
 
-                return relations
-                    .every(function (relation) {
-                        return relation.node.matches('body link');
-                    });
+                return relations.every(relation => relation.node.matches('body link'));
             });
 
-        pages.forEach(function (page) {
+        for (const page of pages) {
             // Find the first external HtmlStyle relation inside <body>
-            var cssRelations = assetGraph.findRelations({ type: 'HtmlStyle', from: page, to: { isInline: false }}, true);
+            const cssRelations = assetGraph.findRelations({ type: 'HtmlStyle', from: page, to: { isInline: false }}, true);
 
-            var fold = cssRelations[0].node;
+            const fold = cssRelations[0].node;
 
             // Traverse back up the DOM to find all elements to check critical CSS for
-            var criticalNodes = getDomNodesAboveFold(fold);
+            const criticalNodes = getDomNodesAboveFold(fold);
 
             // Find all CSS included on the page
-            var stylesheets = assetGraph.collectAssetsPreOrder(page, {
+            const stylesheets = assetGraph.collectAssetsPreOrder(page, {
                 to: {
                     type: 'Css'
                 }
             })
-            .filter(function (asset) {
-                return asset.type === 'Css';
-            });
+            .filter(asset => asset.type === 'Css');
 
+            const criticalParseTree = postcss.parse('');
 
-            var criticalParseTree = postcss.parse('');
-
-            stylesheets.forEach(function (stylesheet) {
+            for (const stylesheet of stylesheets) {
                 // For each critical DOM-node, check if each style rule applies
-                stylesheet.eachRuleInParseTree(function (cssRule) {
+                stylesheet.eachRuleInParseTree(cssRule => {
                     if (!cssRule.selector) {
                         return;
                     }
 
-                    var nonPseudoSelector = cssRule.selector.replace(pseudoRegex, '');
-                    var criticalMatch = criticalNodes.some(function (node) {
-                        var match;
+                    const nonPseudoSelector = cssRule.selector.replace(pseudoRegex, '');
+                    const criticalMatch = criticalNodes.some(node => {
+                        let match;
 
                         try {
                             match = node.matches(nonPseudoSelector);
@@ -215,10 +208,10 @@ module.exports = function (options) {
 
                     // Collect all matching style rules that match critical DOM-nodes
                     if (criticalMatch) {
-                        var clonedRule = cssRule.clone();
+                        const clonedRule = cssRule.clone();
 
                         if (cssRule.parent.type === 'atrule') {
-                            var parentRule = getClonedAtRuleScaffold(cssRule.parent, criticalParseTree);
+                            const parentRule = getClonedAtRuleScaffold(cssRule.parent, criticalParseTree);
 
                             clonedRule.parent = parentRule;
 
@@ -230,14 +223,12 @@ module.exports = function (options) {
                         }
                     }
                 });
-            });
+            }
 
             // Inline critical stylesheet in <head>
-            if (criticalParseTree.nodes.length) {
-                var criticalRelation = new assetGraph.HtmlStyle({
-                    to: new assetGraph.Css({
-                        parseTree: criticalParseTree
-                    })
+            if (criticalParseTree.nodes.length > 0) {
+                const criticalRelation = new assetGraph.HtmlStyle({
+                    to: new assetGraph.Css({ parseTree: criticalParseTree })
                 });
 
                 try {
@@ -251,7 +242,6 @@ module.exports = function (options) {
                     }
                 }
             }
-        });
-
+        }
     };
 };

--- a/lib/transforms/inlineCriticalCss.js
+++ b/lib/transforms/inlineCriticalCss.js
@@ -110,9 +110,7 @@ function getDomNodesAboveFold(fold) {
     return criticalNodes;
 }
 
-let clonedAtRuleMap = [];
-
-function getClonedAtRuleScaffold(rule, root) {
+function getClonedAtRuleScaffold(rule, root, clonedAtRuleMap) {
     const cacheHit = clonedAtRuleMap.find(mapping => {
         if (mapping.original === rule) {
             return mapping.clone;
@@ -133,7 +131,7 @@ function getClonedAtRuleScaffold(rule, root) {
     });
 
     if (rule.parent.type === 'atrule') {
-        const parentRule = getClonedAtRuleScaffold(rule.parent, root);
+        const parentRule = getClonedAtRuleScaffold(rule.parent, root, clonedAtRuleMap);
 
         clonedRule.parent = parentRule;
 
@@ -149,10 +147,8 @@ function getClonedAtRuleScaffold(rule, root) {
 module.exports = options => {
     options = options || {};
 
-    // Make sure to run on a clean slate on every invokation
-    clonedAtRuleMap = [];
-
     return function inlineCriticalCss(assetGraph) {
+        const clonedAtRuleMap = [];
         // For each html page with <link> tags in <body> and not in <head>
         const pages = assetGraph
             .findAssets({ type: 'Html', isLoaded: true, isInline: false })
@@ -211,7 +207,7 @@ module.exports = options => {
                         const clonedRule = cssRule.clone();
 
                         if (cssRule.parent.type === 'atrule') {
-                            const parentRule = getClonedAtRuleScaffold(cssRule.parent, criticalParseTree);
+                            const parentRule = getClonedAtRuleScaffold(cssRule.parent, criticalParseTree, clonedAtRuleMap);
 
                             clonedRule.parent = parentRule;
 

--- a/lib/transforms/inlineCssImagesWithLegacyFallback.js
+++ b/lib/transforms/inlineCssImagesWithLegacyFallback.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
 // Inlines images in Css as data: urls
 //
@@ -18,28 +18,28 @@ function cssRuleIsInsideMediaRule(cssRule) {
     return false;
 }
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     if (typeof options === 'number') {
-        options = {sizeThreshold: options};
+        options = { sizeThreshold: options };
     } else {
         options = options || {};
     }
-    var minimumIeVersion = typeof options.minimumIeVersion === 'number' ? options.minimumIeVersion : (options.minimumIeVersion === null ? Infinity : 1);
+    const minimumIeVersion = typeof options.minimumIeVersion === 'number' ? options.minimumIeVersion : (options.minimumIeVersion === null ? Infinity : 1);
     return function inlineCssImagesWithLegacyFallback(assetGraph) {
-        var allCssImages = []; // Might contain duplicates
-        assetGraph.findAssets(_.extend({type: 'Html', isInline: false}, queryObj)).forEach(function (htmlAsset) {
-            assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset}).forEach(function (htmlStyle) {
-                var cssAsset = htmlStyle.to,
-                    cssImages = assetGraph.findRelations({type: 'CssImage', from: cssAsset, to: {isImage: true, isInline: false, isLoaded: true}}),
-                    ieVersion = 1,
-                    hasCssImagesToInline = false;
+        const allCssImages = []; // Might contain duplicates
+        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false}, queryObj))) {
+            for (const htmlStyle of assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset})) {
+                let cssAsset = htmlStyle.to;
+                const cssImages = assetGraph.findRelations({type: 'CssImage', from: cssAsset, to: {isImage: true, isInline: false, isLoaded: true}});
+                let ieVersion = 1;
+                let hasCssImagesToInline = false;
 
-                Array.prototype.push.apply(allCssImages, cssImages);
+                allCssImages.push(...cssImages);
 
                 function cssImageShouldBeInlined(cssImage) {
-                    var matchInlineParamInUrl = cssImage.to.url.match(/\?(?:|[^#]*&)inline(?:=([^#&]*))?(?:[#&]|$)/);
+                    const matchInlineParamInUrl = cssImage.to.url.match(/\?(?:|[^#]*&)inline(?:=([^#&]*))?(?:[#&]|$)/);
                     if (matchInlineParamInUrl) {
-                        var inlineParamValue = matchInlineParamInUrl[1];
+                        const inlineParamValue = matchInlineParamInUrl[1];
                         return !inlineParamValue || /^(?:true|on|yes|1)$/i.test(inlineParamValue);
                     } else {
                         return (
@@ -52,7 +52,7 @@ module.exports = function (queryObj, options) {
                     }
                 }
 
-                cssImages.forEach(function (cssImage) {
+                for (const cssImage of cssImages) {
                     if (cssImageShouldBeInlined(cssImage)) {
                         hasCssImagesToInline = true;
                         if (cssImage.to.rawSrc.length > 32 * 1024) {
@@ -61,11 +61,11 @@ module.exports = function (queryObj, options) {
                             ieVersion = 8;
                         }
                     }
-                });
+                }
                 if (hasCssImagesToInline) {
                     if (minimumIeVersion && ieVersion > minimumIeVersion) {
-                        var document = htmlAsset.parseTree,
-                            internetExplorerConditionalCommentBody = new assetGraph.Html({text: ''});
+                        const document = htmlAsset.parseTree;
+                        const internetExplorerConditionalCommentBody = new assetGraph.Html({text: ''});
 
                         assetGraph.addAsset(internetExplorerConditionalCommentBody);
 
@@ -73,39 +73,39 @@ module.exports = function (queryObj, options) {
                             to: internetExplorerConditionalCommentBody,
                             condition: 'lt IE ' + ieVersion
                         }).attach(htmlAsset, 'before', htmlStyle);
-                        var htmlStyleInInternetExplorerConditionalComment = new assetGraph.HtmlStyle({to: cssAsset, hrefType: htmlStyle.hrefType});
+                        const htmlStyleInInternetExplorerConditionalComment = new assetGraph.HtmlStyle({to: cssAsset, hrefType: htmlStyle.hrefType});
                         htmlStyleInInternetExplorerConditionalComment.attach(internetExplorerConditionalCommentBody, 'first');
 
-                        var parentNode = htmlStyle.node.parentNode;
+                        const parentNode = htmlStyle.node.parentNode;
                         parentNode.insertBefore(document.createComment('[if gte IE ' + ieVersion + ']><!'), htmlStyle.node);
-                        var endMarker = document.createComment('<![endif]');
+                        const endMarker = document.createComment('<![endif]');
                         if (htmlStyle.node.nextSibling) {
                             parentNode.insertBefore(endMarker, htmlStyle.node.nextSibling);
                         } else {
                             parentNode.appendChild(endMarker);
                         }
                         cssAsset = cssAsset.clone(htmlStyle); // Reassign so the inlining itself will happen on the clone
-                        var media = htmlStyle.node.getAttribute('media');
+                        const media = htmlStyle.node.getAttribute('media');
                         if (media) {
                             htmlStyleInInternetExplorerConditionalComment.node.setAttribute('media', media);
                             internetExplorerConditionalCommentBody.markDirty();
                         }
                     }
 
-                    assetGraph.findRelations({from: cssAsset, type: 'CssImage', to: {isImage: true, isInline: false, isLoaded: true }}).filter(cssImageShouldBeInlined).forEach(function (cssImage) {
+                    for (const cssImage of assetGraph.findRelations({from: cssAsset, type: 'CssImage', to: {isImage: true, isInline: false, isLoaded: true }}).filter(cssImageShouldBeInlined)) {
                         cssImage.inline();
-                    });
+                    }
                     if (ieVersion > minimumIeVersion) {
                         htmlAsset.markDirty();
                     }
                 }
-            });
-        });
+            }
+        }
 
         // Remove the inline parameter from the urls of all the seen CssImages (even then ones with ?inline=false)
-        allCssImages.forEach(function (cssImage) {
+        for (const cssImage of allCssImages) {
             if (cssImage.to.url) {
-                cssImage.to.url = cssImage.to.url.replace(/\?(|[^#]*&)inline(?:=[^#&]*)?([#&]|$)/, function ($0, before, after) {
+                cssImage.to.url = cssImage.to.url.replace(/\?(|[^#]*&)inline(?:=[^#&]*)?([#&]|$)/, ($0, before, after) => {
                     if (before || after) {
                         return '?' + before + after;
                     } else {
@@ -113,6 +113,6 @@ module.exports = function (queryObj, options) {
                     }
                 });
             }
-        });
+        }
     };
 };

--- a/lib/transforms/inlineCssImagesWithLegacyFallback.js
+++ b/lib/transforms/inlineCssImagesWithLegacyFallback.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 // Inlines images in Css as data: urls
 //
 //   If the url of the image has an 'inline' GET parameter, it is inlined if the parameter has a true (or no) value, eg.: foo.png?inline or foo.png?inline=true
@@ -27,7 +25,7 @@ module.exports = (queryObj, options) => {
     const minimumIeVersion = typeof options.minimumIeVersion === 'number' ? options.minimumIeVersion : (options.minimumIeVersion === null ? Infinity : 1);
     return function inlineCssImagesWithLegacyFallback(assetGraph) {
         const allCssImages = []; // Might contain duplicates
-        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html', isInline: false}, queryObj))) {
             for (const htmlStyle of assetGraph.findRelations({type: 'HtmlStyle', from: htmlAsset})) {
                 let cssAsset = htmlStyle.to;
                 const cssImages = assetGraph.findRelations({type: 'CssImage', from: cssAsset, to: {isImage: true, isInline: false, isLoaded: true}});

--- a/lib/transforms/inlineHtmlTemplates.js
+++ b/lib/transforms/inlineHtmlTemplates.js
@@ -1,16 +1,16 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function inlineHtmlTemplates(assetGraph) {
-        var relationsToDetachById = {};
-        var potentiallyOrphanedAssetsById = {};
+        const relationsToDetachById = {};
+        const potentiallyOrphanedAssetsById = {};
 
-        assetGraph.findAssets(_.extend({type: 'Html', isInline: false, isFragment: false}, queryObj)).forEach(function (htmlAsset) {
-            var assetsBySeenIdAttribute = {},
-                relationsToInline = [];
-            assetGraph.eachAssetPostOrder(htmlAsset, {type: assetGraph.query.not(['HtmlAnchor', 'HtmlMetaRefresh'])}, function (asset) {
+        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false, isFragment: false}, queryObj))) {
+            const assetsBySeenIdAttribute = {};
+            const relationsToInline = [];
+            assetGraph.eachAssetPostOrder(htmlAsset, {type: assetGraph.query.not(['HtmlAnchor', 'HtmlMetaRefresh'])}, asset => {
                 if (asset.type === 'JavaScript') {
-                    Array.prototype.push.apply(relationsToInline, assetGraph.findRelations({
+                    relationsToInline.push(...assetGraph.findRelations({
                         from: asset,
                         type: assetGraph.query.not(['JavaScriptGetText', 'JavaScriptTrHtml']),
                         to: {
@@ -21,7 +21,7 @@ module.exports = function (queryObj) {
                         }
                     }));
                 } else if (asset.type === 'Html' && asset.nonInlineAncestor.extension === '.ko' && asset.isFragment) {
-                    Array.prototype.push.apply(relationsToInline, assetGraph.findRelations({
+                    relationsToInline.push(...assetGraph.findRelations({
                         from: asset,
                         type: 'HtmlInlineScriptTemplate',
                         to: {
@@ -29,86 +29,86 @@ module.exports = function (queryObj) {
                         }
                     }));
                     if (asset.isLoaded) {
-                        _.toArray(asset.parseTree.getElementsByTagName('*')).forEach(function (element) {
-                            if (element.hasAttribute('id') && !relationsToInline.some(function (relationToInline) {
-                                return relationToInline.node === element;
-                            })) {
-                                var id = element.getAttribute('id');
+                        for (const element of _.toArray(asset.parseTree.getElementsByTagName('*'))) {
+                            if (element.hasAttribute('id') && !relationsToInline.some(relationToInline => relationToInline.node === element)) {
+                                const id = element.getAttribute('id');
                                 if (id) {
                                     (assetsBySeenIdAttribute[id] = assetsBySeenIdAttribute[id] || []).push(asset);
                                 }
                             }
-                        });
+                        }
                     }
                 }
             });
-            var alreadyInlinedById = {};
-            assetGraph.findRelations({from: htmlAsset, type: 'HtmlInlineScriptTemplate'}).forEach(function (htmlInlineScriptTemplate) {
-                var id = htmlInlineScriptTemplate.node.getAttribute('id');
+            const alreadyInlinedById = {};
+            for (const htmlInlineScriptTemplate of assetGraph.findRelations({from: htmlAsset, type: 'HtmlInlineScriptTemplate'})) {
+                const id = htmlInlineScriptTemplate.node.getAttribute('id');
                 if (id) {
                     alreadyInlinedById[id] = true;
                 }
-            });
-            var document = htmlAsset.parseTree;
-            relationsToInline.forEach(function (relationToInline) {
+            }
+            const document = htmlAsset.parseTree;
+            for (const relationToInline of relationsToInline) {
                 relationsToDetachById[relationToInline.id] = relationToInline;
-                var id;
+                let id;
                 if (relationToInline.type === 'HtmlInlineScriptTemplate') {
                     id = relationToInline.node.getAttribute('id');
                 } else {
                     id = relationToInline.to.url.split('/').pop().replace(/\..*$/, ''); // Strip .ko or .<localeId>.ko extension
                 }
-                var existingAttributes = relationToInline.type === 'HtmlInlineScriptTemplate' && relationToInline.node.attributes;
+                const existingAttributes = relationToInline.type === 'HtmlInlineScriptTemplate' && relationToInline.node.attributes;
                 if (!id || !alreadyInlinedById[id]) {
                     if (id && assetsBySeenIdAttribute[id]) {
-                        assetGraph.emit('warn', new Error('inlineTemplates: Inlining ' + relationToInline.to.urlOrDescription +
-                                                      ' into a <script> in ' + htmlAsset.urlOrDescription +
-                                                          ' with an id attribute of ' + id + ', which already exists in these assets:\n  ' +
-                                                          _.map(assetsBySeenIdAttribute[id], 'urlOrDescription').join('\n  ')));
+                        assetGraph.emit('warn', new Error(
+                            `inlineTemplates: Inlining ${relationToInline.to.urlOrDescription} ` +
+                            `into a <script> in ${htmlAsset.urlOrDescription} ` +
+                            `with an id attribute of ${id}, which already exists in these assets:` +
+                            '\n  ' + _.map(assetsBySeenIdAttribute[id], 'urlOrDescription').join('\n  ')
+                        ));
                     }
                     potentiallyOrphanedAssetsById[relationToInline.to.id] = relationToInline.to;
-                    var node = document.createElement('script');
+                    const node = document.createElement('script');
                     node.setAttribute('type', 'text/html');
                     if (id) {
                         node.setAttribute('id', id);
                     }
                     if (existingAttributes) {
-                        for (var i = 0 ; i < existingAttributes.length ; i += 1) {
-                            var attribute = existingAttributes[i];
+                        for (let i = 0 ; i < existingAttributes.length ; i += 1) {
+                            const attribute = existingAttributes[i];
                             if (attribute.name !== 'type' && attribute.name !== 'id') {
                                 node.setAttribute(attribute.name, attribute.value);
                             }
                         }
                     }
                     document.body.appendChild(node);
-                    var htmlInlineScriptTemplate = new assetGraph.HtmlInlineScriptTemplate({
+                    const htmlInlineScriptTemplate = new assetGraph.HtmlInlineScriptTemplate({
                         to: relationToInline.to,
-                        node: node
+                        node
                     });
                     htmlAsset.addRelation(htmlInlineScriptTemplate);
                     htmlInlineScriptTemplate.inline();
                     // These are attached separately
-                    assetGraph.findRelations({from: htmlInlineScriptTemplate.to, type: 'HtmlInlineScriptTemplate'}).forEach(function (htmlInlineScriptTemplate) {
-                        htmlInlineScriptTemplate.detach();
-                    });
+                    for (const template of assetGraph.findRelations({from: htmlInlineScriptTemplate.to, type: 'HtmlInlineScriptTemplate'})) {
+                        template.detach();
+                    }
                     if (id) {
                         alreadyInlinedById[id] = true;
                     }
                 }
-            });
-        });
-        Object.keys(relationsToDetachById).forEach(function (relationId) {
+            }
+        }
+        for (const relationId of Object.keys(relationsToDetachById)) {
             relationsToDetachById[relationId].detach();
-        });
+        }
 
         // Template assets that had more than one incoming relation to begin with will
         // be cloned in the .inline() call above. Remove the template assets that have
         // become orphans:
-        Object.keys(potentiallyOrphanedAssetsById).forEach(function (assetId) {
-            var asset = potentiallyOrphanedAssetsById[assetId];
+        for (const assetId of Object.keys(potentiallyOrphanedAssetsById)) {
+            const asset = potentiallyOrphanedAssetsById[assetId];
             if (assetGraph.findRelations({to: asset}).length === 0) {
                 assetGraph.removeAsset(asset);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/inlineHtmlTemplates.js
+++ b/lib/transforms/inlineHtmlTemplates.js
@@ -1,11 +1,9 @@
-const _ = require('lodash');
-
 module.exports = queryObj => {
     return function inlineHtmlTemplates(assetGraph) {
         const relationsToDetachById = {};
         const potentiallyOrphanedAssetsById = {};
 
-        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html', isInline: false, isFragment: false}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html', isInline: false, isFragment: false}, queryObj))) {
             const assetsBySeenIdAttribute = {};
             const relationsToInline = [];
             assetGraph.eachAssetPostOrder(htmlAsset, {type: assetGraph.query.not(['HtmlAnchor', 'HtmlMetaRefresh'])}, asset => {
@@ -29,7 +27,7 @@ module.exports = queryObj => {
                         }
                     }));
                     if (asset.isLoaded) {
-                        for (const element of _.toArray(asset.parseTree.getElementsByTagName('*'))) {
+                        for (const element of Array.from(asset.parseTree.getElementsByTagName('*'))) {
                             if (element.hasAttribute('id') && !relationsToInline.some(relationToInline => relationToInline.node === element)) {
                                 const id = element.getAttribute('id');
                                 if (id) {
@@ -63,7 +61,7 @@ module.exports = queryObj => {
                             `inlineTemplates: Inlining ${relationToInline.to.urlOrDescription} ` +
                             `into a <script> in ${htmlAsset.urlOrDescription} ` +
                             `with an id attribute of ${id}, which already exists in these assets:` +
-                            '\n  ' + _.map(assetsBySeenIdAttribute[id], 'urlOrDescription').join('\n  ')
+                            '\n  ' + assetsBySeenIdAttribute[id].map(asset => asset.urlOrDescription).join('\n  ')
                         ));
                     }
                     potentiallyOrphanedAssetsById[relationToInline.to.id] = relationToInline.to;

--- a/lib/transforms/inlineRelations.js
+++ b/lib/transforms/inlineRelations.js
@@ -1,7 +1,7 @@
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function inlineRelations(assetGraph) {
-        assetGraph.findRelations(queryObj).forEach(function (relation) {
+        for (const relation of assetGraph.findRelations(queryObj)) {
             relation.inline();
-        });
+        }
     };
 };

--- a/lib/transforms/logEvents.js
+++ b/lib/transforms/logEvents.js
@@ -1,8 +1,8 @@
-var chalk = require('chalk'),
-    _ = require('lodash'),
-    Path = require('path'),
-    urlTools = require('urltools'),
-    AssetGraph = require('../AssetGraph');
+const chalk = require('chalk');
+const _ = require('lodash');
+const Path = require('path');
+const urlTools = require('urltools');
+const AssetGraph = require('../AssetGraph');
 
 function indentSubsequentLines(str, level) {
     return str.replace(/\n/g, '\n' + new Array(level + 1).join(' '));
@@ -12,29 +12,27 @@ function escapeRegExpMetaChars(str) {
     return str.replace(/[$\.^\(\)\[\]\{\}]/g, '\\$&');
 }
 
-module.exports = function (options) {
-    var startReplRegExp;
+module.exports = options => {
+    let startReplRegExp;
 
     options = options || {};
 
     if (options.repl) {
-        startReplRegExp = new RegExp(_.flatten(_.flatten([options.repl]).map(function (transformName) {
+        startReplRegExp = new RegExp(_.flatten(_.flatten([options.repl]).map(transformName => {
             return transformName.split(',');
-        })).map(function (transformName) {
-            return transformName.replace(/[\.\+\{\}\[\]\(\)\?\^\$]/g, '\\$&');
-        }).join('|'));
+        })).map(transformName => transformName.replace(/[\.\+\{\}\[\]\(\)\?\^\$]/g, '\\$&')).join('|'));
     }
 
     return function logEvents(assetGraph) {
-        var assetGraphRootRelativeToCwd = Path.relative(process.cwd(), urlTools.fileUrlToFsPath(assetGraph.root)),
-            assetGraphRootRelativeToCwdRegExp = new RegExp('\\b' + escapeRegExpMetaChars(assetGraphRootRelativeToCwd) + '/', 'g'),
-            cwdRegExp = new RegExp('(?:file://)?' + escapeRegExpMetaChars(process.cwd() + '/'), 'g'),
-            colorBySeverity = {info: 'cyan', warn: 'yellow', error: 'red'},
-            symbolBySeverity = {info: 'ℹ', warn: '⚠', error: '✘'};
+        const assetGraphRootRelativeToCwd = Path.relative(process.cwd(), urlTools.fileUrlToFsPath(assetGraph.root));
+        const assetGraphRootRelativeToCwdRegExp = new RegExp('\\b' + escapeRegExpMetaChars(assetGraphRootRelativeToCwd) + '/', 'g');
+        const cwdRegExp = new RegExp('(?:file://)?' + escapeRegExpMetaChars(process.cwd() + '/'), 'g');
+        const colorBySeverity = {info: 'cyan', warn: 'yellow', error: 'red'};
+        const symbolBySeverity = {info: 'ℹ', warn: '⚠', error: '✘'};
 
         function outputMessage(messageOrError, severity) {
             severity = severity || 'info';
-            var message;
+            let message;
             if (Object.prototype.toString.call(messageOrError) === '[object Error]') {
                 if (severity === 'error') {
                     message = messageOrError.stack;
@@ -54,7 +52,7 @@ module.exports = function (options) {
                     message = messageOrError;
                 }
             }
-            var caption = ' ' + symbolBySeverity[severity] + ' ' + severity.toUpperCase() + ': ';
+            const caption = ' ' + symbolBySeverity[severity] + ' ' + severity.toUpperCase() + ': ';
 
             message = message
                 .replace(cwdRegExp, '')
@@ -63,8 +61,8 @@ module.exports = function (options) {
             console[severity](chalk[colorBySeverity[severity]](caption) + indentSubsequentLines(message, caption.length));
         }
 
-        var firstWarningSeenDuringTransform = null,
-            transformRunning = false;
+        let firstWarningSeenDuringTransform = null;
+        let transformRunning = false;
         assetGraph
             .on('beforeTransform', function () {
                 firstWarningSeenDuringTransform = null;
@@ -88,10 +86,6 @@ module.exports = function (options) {
                 outputMessage(info, 'info');
             })
             .on('warn', function (err) {
-                // These are way too noisy
-                if (options.suppressJavaScriptCommonJsRequireWarnings && err.relationType === 'JavaScriptCommonJsRequire') {
-                    return;
-                }
                 outputMessage(err, 'warn');
                 if (startReplRegExp && startReplRegExp.test('warn')) {
                     this.transformQueue.transforms.unshift(AssetGraph.transforms.startRepl());

--- a/lib/transforms/mergeIdenticalAssets.js
+++ b/lib/transforms/mergeIdenticalAssets.js
@@ -1,21 +1,21 @@
-var urlTools = require('urltools');
+const urlTools = require('urltools');
 
 // Note: Will implicitly un-inline assets found to be identical. If you want to prevent this from happening,
 // specify isInline:false or similar in the queryObj.
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function mergeIdenticalAssets(assetGraph) {
-        var seenAssetsByTypeAndMd5 = {};
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        const seenAssetsByTypeAndMd5 = {};
+        for (const asset of assetGraph.findAssets(queryObj)) {
             if (asset.isExternalizable) {
-                var md5Hex = asset.md5Hex;
+                const md5Hex = asset.md5Hex;
                 seenAssetsByTypeAndMd5[asset.type] = seenAssetsByTypeAndMd5[asset.type] || {};
-                var identicalAsset = seenAssetsByTypeAndMd5[asset.type][md5Hex];
+                const identicalAsset = seenAssetsByTypeAndMd5[asset.type][md5Hex];
                 if (identicalAsset) {
                     if (!identicalAsset.url) {
                         // Un-inline the identical asset so that the two can be merged:
                         identicalAsset.url = urlTools.resolveUrl(assetGraph.root, identicalAsset.id + identicalAsset.extension);
                     }
-                    assetGraph.findRelations({to: asset}).forEach(function (incomingRelation) {
+                    for (const incomingRelation of assetGraph.findRelations({to: asset})) {
                         // Avoid introducing duplicate CacheManifestEntry relations:
                         if (incomingRelation.type === 'CacheManifestEntry' && assetGraph.findRelations({from: incomingRelation.from, to: identicalAsset}).length > 0) {
                             incomingRelation.detach();
@@ -23,12 +23,12 @@ module.exports = function (queryObj) {
                             incomingRelation.to = identicalAsset;
                             incomingRelation.refreshHref();
                         }
-                    });
+                    }
                     assetGraph.removeAsset(asset);
                 } else {
                     seenAssetsByTypeAndMd5[asset.type][md5Hex] = asset;
                 }
             }
-        });
+        }
     };
 };

--- a/lib/transforms/minifyAssets.js
+++ b/lib/transforms/minifyAssets.js
@@ -1,9 +1,9 @@
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function minifyAssets(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(queryObj)) {
             if (asset.minify) {
                 asset.minify();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/minifySvgAssetsWithSvgo.js
+++ b/lib/transforms/minifySvgAssetsWithSvgo.js
@@ -1,64 +1,61 @@
-var _ = require('lodash');
-var Promise = require('bluebird');
+const _ = require('lodash');
+const Promise = require('bluebird');
 
-module.exports = function (queryObj) {
-    return function minifySvgAssetsWithSvgo(assetGraph) {
-        var Svgo,
-            svgAssets = assetGraph.findAssets(_.extend({type: 'Svg'}, queryObj));
+module.exports = queryObj => {
+    return async function minifySvgAssetsWithSvgo(assetGraph) {
+        let Svgo;
+        const svgAssets = assetGraph.findAssets(_.extend({type: 'Svg'}, queryObj));
         if (svgAssets.length > 0) {
             try {
                 Svgo = require('svgo');
             } catch (e) {
-                assetGraph.emit('info', new Error('minifySvgAssetsWithSvgo: Found ' + svgAssets.length + ' svg asset(s), but no svgo module is available. Please use npm to install svgo in your project so minifySvgAssetsWithSvgo can require it.'));
+                assetGraph.emit('info', new Error(`minifySvgAssetsWithSvgo: Found ${svgAssets.length} svg asset(s), but no svgo module is available. Please use npm to install svgo in your project so minifySvgAssetsWithSvgo can require it.`));
                 return;
             }
         }
-        return Promise.map(svgAssets, function (svgAsset) {
-            return Promise.fromNode(function (cb) {
-                // The removeUnknownsAndDefaults SVGO plugin strips top-level attributes of the <svg> element
-                // that could be important. Note down all the attributes so they can be re-attached after the optimization
-                // https://github.com/svg/svgo/issues/301
-                var originalTopLevelAttributes = {};
-                if (svgAsset.isInline) {
-                    Array.prototype.forEach.call(svgAsset.parseTree.documentElement.attributes, function (attribute) {
-                        originalTopLevelAttributes[attribute.name] = attribute.value;
-                    });
+        await Promise.map(svgAssets, async svgAsset => {
+            // The removeUnknownsAndDefaults SVGO plugin strips top-level attributes of the <svg> element
+            // that could be important. Note down all the attributes so they can be re-attached after the optimization
+            // https://github.com/svg/svgo/issues/301
+            const originalTopLevelAttributes = {};
+            if (svgAsset.isInline) {
+                for (const attribute of _.toArray(svgAsset.parseTree.documentElement.attributes)) {
+                    originalTopLevelAttributes[attribute.name] = attribute.value;
                 }
+            }
 
-                // svgo both calls the callback with an error _and_ throws if it encounters and error
-                var callbackCalled = false;
+            const { error, data } = await Promise.fromNode(cb => {
                 try {
                     new Svgo({
                         floatPrecision: 6 // The default of 2 is so low that it's visibly lossy in some cases
-                    }).optimize(svgAsset.text, function (result) {
-                        callbackCalled = true;
-                        if (result.error) {
-                            assetGraph.emit('warn', new Error('SVG optimization error in ' + svgAsset.urlOrDescription + '\nOptimiztion skipped.\n' + result.error));
-                        } else {
-                            svgAsset.text = result.data;
-                            if (svgAsset.isInline) {
-                                var dirty = false;
-                                Object.keys(originalTopLevelAttributes).forEach(function (attributeName) {
-                                    if (!svgAsset.parseTree.documentElement.hasAttribute(attributeName)) {
-                                        svgAsset.parseTree.documentElement.setAttribute(attributeName, originalTopLevelAttributes[attributeName]);
-                                        dirty = true;
-                                    }
-                                });
-                                if (dirty) {
-                                    svgAsset.markDirty();
-                                }
-                            }
-                        }
-                        cb();
-                    });
+                    }).optimize(svgAsset.text, cb.bind(null, null)); // svgo does not reselve the first position to the error
                 } catch (e) {
-                    if (!callbackCalled) {
-                        // Error not already handled in callback
-                        assetGraph.emit('warn', new Error('svgo threw a hissyfit in ' + svgAsset.urlOrDescription + '\n' + e.stack));
-                        cb();
-                    }
+                    assetGraph.emit('warn', new Error(
+                        `svgo threw a hissyfit in ${svgAsset.urlOrDescription}\n${e.stack}`
+                    ));
+                    cb(null, {}); // Make sure that we do call the callback (svgo might or might not also do that)
                 }
             });
+
+            if (error) {
+                assetGraph.emit('warn', new Error(
+                    `SVG optimization error in ${svgAsset.urlOrDescription}\nOptimiztion skipped.\n${error}`
+                ));
+            } else if (data) {
+                svgAsset.text = data;
+                if (svgAsset.isInline) {
+                    let dirty = false;
+                    for (const attributeName of Object.keys(originalTopLevelAttributes)) {
+                        if (!svgAsset.parseTree.documentElement.hasAttribute(attributeName)) {
+                            svgAsset.parseTree.documentElement.setAttribute(attributeName, originalTopLevelAttributes[attributeName]);
+                            dirty = true;
+                        }
+                    }
+                    if (dirty) {
+                        svgAsset.markDirty();
+                    }
+                }
+            }
         });
     };
 };

--- a/lib/transforms/minifySvgAssetsWithSvgo.js
+++ b/lib/transforms/minifySvgAssetsWithSvgo.js
@@ -1,10 +1,9 @@
-const _ = require('lodash');
 const Promise = require('bluebird');
 
 module.exports = queryObj => {
     return async function minifySvgAssetsWithSvgo(assetGraph) {
         let Svgo;
-        const svgAssets = assetGraph.findAssets(_.extend({type: 'Svg'}, queryObj));
+        const svgAssets = assetGraph.findAssets(Object.assign({type: 'Svg'}, queryObj));
         if (svgAssets.length > 0) {
             try {
                 Svgo = require('svgo');
@@ -19,7 +18,7 @@ module.exports = queryObj => {
             // https://github.com/svg/svgo/issues/301
             const originalTopLevelAttributes = {};
             if (svgAsset.isInline) {
-                for (const attribute of _.toArray(svgAsset.parseTree.documentElement.attributes)) {
+                for (const attribute of Array.from(svgAsset.parseTree.documentElement.attributes)) {
                     originalTopLevelAttributes[attribute.name] = attribute.value;
                 }
             }

--- a/lib/transforms/moveAssets.js
+++ b/lib/transforms/moveAssets.js
@@ -1,7 +1,10 @@
-var assetMover = require('../util/assetMover');
+const createAssetMover = require('../util/assetMover');
 
-module.exports = function (queryObj, newUrlFunctionOrString) {
+module.exports = (queryObj, newUrlFunctionOrString) => {
     return function moveAssets(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(assetMover(newUrlFunctionOrString, assetGraph));
+        const assetMover = createAssetMover(newUrlFunctionOrString, assetGraph);
+        for (const asset of assetGraph.findAssets(queryObj)) {
+            assetMover(asset);
+        }
     };
 };

--- a/lib/transforms/moveAssetsInOrder.js
+++ b/lib/transforms/moveAssetsInOrder.js
@@ -1,39 +1,39 @@
-var query = require('../query');
-var assetMover = require('../util/assetMover');
+const query = require('../query');
+const createAssetMover = require('../util/assetMover');
 
 // Helper function for determining the order in which the hashes can be computed and the assets
 // moved. The challenge lies in the fact that updating a relation to point at <hash>.<extension>
 // will change the hash of the asset that owns the relation.
 // Needless to say this will fail if the graph of assets to be moved has cycles, so be careful.
 function findAssetMoveOrderBatches(assetGraph, queryObj) {
-    var batches = [],
-        outgoingRelationsByAssetId = {},
-        assetMatcher = query.queryObjToMatcherFunction(queryObj);
+    const batches = [];
+    const outgoingRelationsByAssetId = {};
+    const assetMatcher = query.queryObjToMatcherFunction(queryObj);
 
-    assetGraph.findAssets({isInline: false}).forEach(function (asset) {
+    for (const asset of assetGraph.findAssets({isInline: false})) {
         if (assetMatcher(asset)) {
-            var relationFrom = assetGraph.collectAssetsPostOrder(asset, {to: {isInline: true}});
-            var relationTo = {isInline: false};
+            const relationFrom = assetGraph.collectAssetsPostOrder(asset, {to: {isInline: true}});
+            const relationTo = {isInline: false};
             // Filter source map file relation to prevent possible recursion
             outgoingRelationsByAssetId[asset.id] = assetGraph.findRelations({from: relationFrom, to: relationTo, type: query.not(['SourceMapFile'])});
         }
-    });
+    }
 
     while (true) {
-        var remainingAssetIds = Object.keys(outgoingRelationsByAssetId);
+        const remainingAssetIds = Object.keys(outgoingRelationsByAssetId);
         if (remainingAssetIds.length === 0) {
             break;
         }
-        var currentBatch = [];
-        remainingAssetIds.forEach(function (assetId) {
-            if (!outgoingRelationsByAssetId[assetId].some(function (outgoingRelation) { return outgoingRelationsByAssetId[outgoingRelation.to.id]; })) {
+        const currentBatch = [];
+        for (const assetId of remainingAssetIds) {
+            if (!outgoingRelationsByAssetId[assetId].some(outgoingRelation => outgoingRelationsByAssetId[outgoingRelation.to.id])) {
                 currentBatch.push(assetGraph.idIndex[assetId]);
             }
-        });
+        }
 
-        currentBatch.forEach(function (asset) {
+        for (const asset of currentBatch) {
             delete outgoingRelationsByAssetId[asset.id];
-        });
+        }
 
         if (currentBatch.length === 0) {
             throw new Error('transforms.moveAssetsInOrder: Couldn\'t find a suitable rename order due to cycles in the selection');
@@ -43,10 +43,13 @@ function findAssetMoveOrderBatches(assetGraph, queryObj) {
     return batches;
 }
 
-module.exports = function (queryObj, newUrlFunctionOrString) {
+module.exports = (queryObj, newUrlFunctionOrString) => {
     return function moveAssetsInOrder(assetGraph) {
-        findAssetMoveOrderBatches(assetGraph, queryObj).forEach(function (assetBatch) {
-            assetBatch.forEach(assetMover(newUrlFunctionOrString, assetGraph));
-        });
+        const assetMover = createAssetMover(newUrlFunctionOrString, assetGraph);
+        for (const assetBatch of findAssetMoveOrderBatches(assetGraph, queryObj)) {
+            for (const asset of assetBatch) {
+                assetMover(asset);
+            }
+        }
     };
 };

--- a/lib/transforms/populate.js
+++ b/lib/transforms/populate.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var Promise = require('bluebird');
 var query = require('../query');
 
@@ -13,7 +12,7 @@ module.exports = options => {
     }
     return function populate(assetGraph) {
         var followRelationsMatcher = query.queryObjToMatcherFunction(options.followRelations || assetGraph.followRelations),
-            assetQueue = assetGraph.findAssets(_.extend({isInline: false}, options.startAssets || options.from)),
+            assetQueue = assetGraph.findAssets(Object.assign({isInline: false}, options.startAssets || options.from)),
             maxWaitingCallbacks = options.concurrency || 100,
             numWaitingCallbacks = 0,
             firstErrorOrNull = null;

--- a/lib/transforms/populate.js
+++ b/lib/transforms/populate.js
@@ -2,7 +2,7 @@ var _ = require('lodash');
 var Promise = require('bluebird');
 var query = require('../query');
 
-module.exports = function (options) {
+module.exports = options => {
     options = options || {};
     var stopAssetsMatcher = function () {
         return false;

--- a/lib/transforms/prettyPrintAssets.js
+++ b/lib/transforms/prettyPrintAssets.js
@@ -1,9 +1,9 @@
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function prettyPrintAssets(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(queryObj)) {
             if (asset.prettyPrint) {
                 asset.prettyPrint();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/pullGlobalsIntoVariables.js
+++ b/lib/transforms/pullGlobalsIntoVariables.js
@@ -1,68 +1,68 @@
-var _ = require('lodash'),
-    symbolNames = {
-        ' ': 'SPACE',
-        '!': 'BANG',
-        '.': 'DOT',
-        '=': 'EQUALS',
-        '~': 'TILDE',
-        '$': 'DOLLAR',
-        '#': 'HASH',
-        '%': 'PERCENT',
-        '/': 'SLASH',
-        '<': 'LESSTHAN',
-        '>': 'GREATERTHAN',
-        '&': 'AMPERSAND',
-        '?': 'QUESTIONMARK',
-        '\'': 'SINGLEQUOTE',
-        '"': 'DOUBLEQUOTE',
-        '+': 'PLUS',
-        ',': 'COMMA',
-        ';': 'SEMICOLON',
-        ':': 'COLON',
-        '(': 'LPAREN',
-        ')': 'RPAREN',
-        '{': 'LBRACE',
-        '}': 'RBRACE',
-        '[': 'LSQBRACE',
-        ']': 'RSQBRACE'
-    },
-    escodegen = require('escodegen'),
-    replaceDescendantNode = require('../replaceDescendantNode'),
-    estraverse = require('estraverse');
+const _ = require('lodash');
+const symbolNames = {
+    ' ': 'SPACE',
+    '!': 'BANG',
+    '.': 'DOT',
+    '=': 'EQUALS',
+    '~': 'TILDE',
+    '$': 'DOLLAR',
+    '#': 'HASH',
+    '%': 'PERCENT',
+    '/': 'SLASH',
+    '<': 'LESSTHAN',
+    '>': 'GREATERTHAN',
+    '&': 'AMPERSAND',
+    '?': 'QUESTIONMARK',
+    '\'': 'SINGLEQUOTE',
+    '"': 'DOUBLEQUOTE',
+    '+': 'PLUS',
+    ',': 'COMMA',
+    ';': 'SEMICOLON',
+    ':': 'COLON',
+    '(': 'LPAREN',
+    ')': 'RPAREN',
+    '{': 'LBRACE',
+    '}': 'RBRACE',
+    '[': 'LSQBRACE',
+    ']': 'RSQBRACE'
+};
+const escodegen = require('escodegen');
+const replaceDescendantNode = require('../replaceDescendantNode');
+const estraverse = require('estraverse');
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
-    options.globalNames = options.globalNames || [];
-    Array.prototype.push.apply(options.globalNames, ['eval', 'clearInterval', 'clearTimeout', 'document', 'event', 'frames', 'history', 'Image', 'localStorage', 'location', 'name', 'navigator', 'Option', 'parent', 'screen', 'sessionStorage', 'setInterval', 'setTimeout', 'Storage', 'window', 'XMLHttpRequest', 'Math', 'Math.min', 'Math.max', 'Math.round', 'Function', 'Date', 'Date.prototype', 'Math.E', 'Math.LN2', 'Math.LN10', 'Math.LOG2E', 'Math.LOG10E', 'Math.PI', 'Math.SQRT1_2', 'Math.SQRT2', 'Math.abs', 'Math.acos', 'Math.asin', 'Math.atan', 'Math.atan2', 'Math.ceil', 'Math.cos', 'Math.exp', 'Math.floor', 'Math.log', 'Math.max', 'Math.min', 'Math.pow', 'Math.random', 'Math.round', 'Math.sin', 'Math.sqrt', 'Math.tan', 'parseInt', 'parseFloat', 'isNaN', 'NaN', 'RegExp', 'RegExp.prototype', 'RegExp.prototype.compile', 'RegExp.prototype.test', 'RegExp.prototype.exec', 'String', 'String.fromCharCode', 'String.prototype', 'String.prototype.charAt', 'String.prototype.charCodeAt', 'String.prototype.indexOf', 'String.prototype.match', 'String.prototype.replace', 'String.prototype.slice', 'String.prototype.split', 'String.prototype.substr', 'String.prototype.substring', 'String.prototype.toLowerCase', 'String.prototype.toUpperCase', 'Array', 'Array.prototype', 'Array.prototype.concat', 'Array.prototype.indexOf', 'Array.prototype.join', 'Array.prototype.pop', 'Array.prototype.push', 'Array.prototype.reverse', 'Array.prototype.shift', 'Array.prototype.slice', 'Array.prototype.sort', 'Array.prototype.splice', 'Array.prototype.unshift', 'Number', 'Number.prototype', 'Number.prototype.toFixed', 'Number.MAX_VALUE', 'Number.MIN_VALUE', 'Number.NEGATIVE_INFINITY', 'Number.NaN', 'Number.POSITIVE_INFINITY', 'Number.prototype', 'Boolean', 'Boolean.prototype', 'Error', 'Error.prototype', 'EvalError', 'EvalError.prototype', 'Infinity', 'JSON', 'JSON.stringify', 'JSON.parse', 'Object', 'Object.prototype', 'Object.prototype.toString', 'RangeError', 'RangeError.prototype', 'ReferenceError', 'ReferenceError.prototype', 'SyntaxError', 'SyntaxError.prototype', 'TypeError', 'TypeError.prototype', 'URIError', 'URIError.prototype', 'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'isFinite', 'undefined']);
+    const allGlobalNames = options.globalNames ? [].concat(options.globalNames) : [];
+    allGlobalNames.push('eval', 'clearInterval', 'clearTimeout', 'document', 'event', 'frames', 'history', 'Image', 'localStorage', 'location', 'name', 'navigator', 'Option', 'parent', 'screen', 'sessionStorage', 'setInterval', 'setTimeout', 'Storage', 'window', 'XMLHttpRequest', 'Math', 'Math.min', 'Math.max', 'Math.round', 'Function', 'Date', 'Date.prototype', 'Math.E', 'Math.LN2', 'Math.LN10', 'Math.LOG2E', 'Math.LOG10E', 'Math.PI', 'Math.SQRT1_2', 'Math.SQRT2', 'Math.abs', 'Math.acos', 'Math.asin', 'Math.atan', 'Math.atan2', 'Math.ceil', 'Math.cos', 'Math.exp', 'Math.floor', 'Math.log', 'Math.max', 'Math.min', 'Math.pow', 'Math.random', 'Math.round', 'Math.sin', 'Math.sqrt', 'Math.tan', 'parseInt', 'parseFloat', 'isNaN', 'NaN', 'RegExp', 'RegExp.prototype', 'RegExp.prototype.compile', 'RegExp.prototype.test', 'RegExp.prototype.exec', 'String', 'String.fromCharCode', 'String.prototype', 'String.prototype.charAt', 'String.prototype.charCodeAt', 'String.prototype.indexOf', 'String.prototype.match', 'String.prototype.replace', 'String.prototype.slice', 'String.prototype.split', 'String.prototype.substr', 'String.prototype.substring', 'String.prototype.toLowerCase', 'String.prototype.toUpperCase', 'Array', 'Array.prototype', 'Array.prototype.concat', 'Array.prototype.indexOf', 'Array.prototype.join', 'Array.prototype.pop', 'Array.prototype.push', 'Array.prototype.reverse', 'Array.prototype.shift', 'Array.prototype.slice', 'Array.prototype.sort', 'Array.prototype.splice', 'Array.prototype.unshift', 'Number', 'Number.prototype', 'Number.prototype.toFixed', 'Number.MAX_VALUE', 'Number.MIN_VALUE', 'Number.NEGATIVE_INFINITY', 'Number.NaN', 'Number.POSITIVE_INFINITY', 'Number.prototype', 'Boolean', 'Boolean.prototype', 'Error', 'Error.prototype', 'EvalError', 'EvalError.prototype', 'Infinity', 'JSON', 'JSON.stringify', 'JSON.parse', 'Object', 'Object.prototype', 'Object.prototype.toString', 'RangeError', 'RangeError.prototype', 'ReferenceError', 'ReferenceError.prototype', 'SyntaxError', 'SyntaxError.prototype', 'TypeError', 'TypeError.prototype', 'URIError', 'URIError.prototype', 'decodeURI', 'decodeURIComponent', 'encodeURI', 'encodeURIComponent', 'isFinite', 'undefined');
 
-    var globalsObj = {};
-    options.globalNames.forEach(function (global) {
-        globalsObj[global] = true;
-    });
+    const globalsObj = {};
+    for (const globalName of allGlobalNames) {
+        globalsObj[globalName] = true;
+    }
     return function pullGlobalsIntoVariables(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj)).forEach(function (javaScriptAsset) {
-            var occurrencesByGlobalName = {},
-                occurrencesByString = {},
-                ast = javaScriptAsset.parseTree,
-                seenNames = {}, // To avoid collisions when introducing new vars
-                seenLocals = {}; // To avoid aliasing globals that are shadowed by a local var somewhere
+        for (const javaScriptAsset of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
+            const occurrencesByGlobalName = {};
+            const occurrencesByString = {};
+            const ast = javaScriptAsset.parseTree;
+            const seenNames = {}; // To avoid collisions when introducing new vars
+            const seenLocals = {}; // To avoid aliasing globals that are shadowed by a local var somewhere
 
             estraverse.traverse(ast, {
-                enter: function (node, parentNode) {
+                enter(node, parentNode) {
                     if (node.type === 'MemberExpression' && !node.computed) {
-                        var name = escodegen.generate(node);
+                        const name = escodegen.generate(node);
                         if (typeof globalsObj[name] !== 'undefined') {
                             if (!occurrencesByGlobalName.hasOwnProperty(name)) {
                                 occurrencesByGlobalName[name] = [];
                             }
-                            occurrencesByGlobalName[name].push({node: node, parentNode: parentNode});
+                            occurrencesByGlobalName[name].push({ node, parentNode });
                         } else if (node.property.name.length > 2) {
                             // .foo() => [a]() won't save anything if the method name is 2 chars or less
 
                             if (!Object.prototype.hasOwnProperty.call(occurrencesByString, node.property.name)) {
                                 occurrencesByString[node.property.name] = [];
                             }
-                            occurrencesByString[node.property.name].push({node: node, parentNode: parentNode});
+                            occurrencesByString[node.property.name].push({ node, parentNode });
                         }
                     } else if (node.type === 'FunctionDeclaration') {
                         seenLocals[node.id.name] = true;
@@ -71,37 +71,37 @@ module.exports = function (queryObj, options) {
                             seenLocals[node.id.name] = true;
                         }
                     } else if (node.type === 'VariableDeclaration') {
-                        node.declarations.forEach(function (declaration) {
+                        for (const declaration of node.declarations) {
                             seenNames[declaration.id.name] = true;
                             seenLocals[declaration.id.name] = true;
-                        });
+                        }
                     } else if (node.type === 'Literal' && typeof node.value === 'string') {
                         if (!Object.prototype.hasOwnProperty.call(occurrencesByString, node.value)) {
                             occurrencesByString[node.value] = [];
                         }
-                        occurrencesByString[node.value].push({node: node, parentNode: parentNode});
+                        occurrencesByString[node.value].push({ node, parentNode });
                     } else if (node.type === 'Identifier') {
                         seenNames[node.name] = true;
                         if (globalsObj.hasOwnProperty(node.name)) {
                             if (!occurrencesByGlobalName.hasOwnProperty(node.name)) {
                                 occurrencesByGlobalName[node.name] = [];
                             }
-                            occurrencesByGlobalName[node.name].push({node: node, parentNode: parentNode});
+                            occurrencesByGlobalName[node.name].push({ node, parentNode });
                         }
                     }
                 }
             });
 
             // Order by number of dots ascending so e.g. Math is considered before Math.min:
-            var globalNames = Object.keys(occurrencesByGlobalName).sort(function (a, b) {
+            const globalNames = Object.keys(occurrencesByGlobalName).sort((a, b) => {
                 return a.split('.').length - b.split('.').length;
             });
-            var aliasDeclarations = [],
-                aliasByGlobalName = {};
+            const aliasDeclarations = [];
+            const aliasByGlobalName = {};
 
             function nameToAst(name) {
                 name = (!options.wrapInFunction && aliasByGlobalName.hasOwnProperty(name) && aliasByGlobalName[name]) || name;
-                var nameFragments = name.split('.');
+                const nameFragments = name.split('.');
                 if (nameFragments.length > 1) {
                     return {
                         type: 'MemberExpression',
@@ -114,34 +114,34 @@ module.exports = function (queryObj, options) {
                 }
             }
 
-            globalNames.forEach(function (globalName) {
+            for (const globalName of globalNames) {
                 if (!seenLocals.hasOwnProperty(globalName) && occurrencesByGlobalName[globalName].length > 1) {
-                    var alias = globalName.replace(/\./g, '').toUpperCase();
+                    let alias = globalName.replace(/\./g, '').toUpperCase();
                     while (seenNames.hasOwnProperty(alias)) {
                         alias += '_';
                     }
                     seenNames[alias] = true;
                     aliasDeclarations.push({name: alias, valueAst: nameToAst(globalName)});
-                    occurrencesByGlobalName[globalName].forEach(function (occurrence) {
+                    for (const occurrence of occurrencesByGlobalName[globalName]) {
                         replaceDescendantNode(occurrence.parentNode, occurrence.node, { type: 'Identifier', name: alias });
-                    });
+                    }
                     aliasByGlobalName[globalName] = alias;
                 } else {
                     occurrencesByGlobalName[globalName] = undefined;
                 }
-            });
+            }
 
             if (options.stringLiterals) {
-                Object.keys(occurrencesByString).forEach(function (string) {
-                    var occurrences = occurrencesByString[string];
+                for (const string of Object.keys(occurrencesByString)) {
+                    const occurrences = occurrencesByString[string];
 
                     if (occurrences.length >= 2) {
-                        var alias = string || 'EMPTY';
-                        Object.keys(symbolNames).forEach(function (symbol) {
-                            while (alias.indexOf(symbol) !== -1) {
-                                alias = alias.replace(symbol, symbolNames[symbol]);
+                        let alias = string || 'EMPTY';
+                        for (const symbolName of Object.keys(symbolNames)) {
+                            while (alias.indexOf(symbolName) !== -1) {
+                                alias = alias.replace(symbolName, symbolNames[symbolName]);
                             }
-                        });
+                        }
 
                         if (/^[0-9]/.test(alias)) {
                             alias = '_' + alias;
@@ -155,7 +155,7 @@ module.exports = function (queryObj, options) {
                             name: alias,
                             valueAst: { type: 'Literal', value: string }
                         });
-                        occurrences.forEach(function (occurrence) {
+                        for (const occurrence of occurrences) {
                             if (occurrence.node.type === 'Literal' && typeof occurrence.node.value === 'string') {
                                 replaceDescendantNode(occurrence.parentNode, occurrence.node, { type: 'Identifier', name: alias });
                             } else {
@@ -167,9 +167,9 @@ module.exports = function (queryObj, options) {
                                     object: occurrence.node.object
                                 });
                             }
-                        });
+                        }
                     }
-                });
+                }
             }
 
             if (aliasDeclarations.length) {
@@ -182,7 +182,7 @@ module.exports = function (queryObj, options) {
                                 arguments: _.map(aliasDeclarations, 'valueAst'),
                                 callee: {
                                     type: 'FunctionExpression',
-                                    params: aliasDeclarations.map(function (aliasDeclaration) {
+                                    params: aliasDeclarations.map(aliasDeclaration => {
                                         return { type: 'Identifier', name: aliasDeclaration.name };
                                     }),
                                     body: {
@@ -197,7 +197,7 @@ module.exports = function (queryObj, options) {
                     ast.body.unshift({
                         type: 'VariableDeclaration',
                         kind: 'var',
-                        declarations: aliasDeclarations.map(function (aliasDeclaration) {
+                        declarations: aliasDeclarations.map(aliasDeclaration => {
                             return {
                                 type: 'VariableDeclarator',
                                 id: { type: 'Identifier', name: aliasDeclaration.name },
@@ -208,6 +208,6 @@ module.exports = function (queryObj, options) {
                 }
                 javaScriptAsset.markDirty();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/pullGlobalsIntoVariables.js
+++ b/lib/transforms/pullGlobalsIntoVariables.js
@@ -40,7 +40,7 @@ module.exports = (queryObj, options) => {
         globalsObj[globalName] = true;
     }
     return function pullGlobalsIntoVariables(assetGraph) {
-        for (const javaScriptAsset of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
+        for (const javaScriptAsset of assetGraph.findAssets(Object.assign({type: 'JavaScript'}, queryObj))) {
             const occurrencesByGlobalName = {};
             const occurrencesByString = {};
             const ast = javaScriptAsset.parseTree;

--- a/lib/transforms/removeAssets.js
+++ b/lib/transforms/removeAssets.js
@@ -1,15 +1,15 @@
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     if (typeof options === 'boolean') {
-        options = {detachIncomingRelations: options};
+        options = { detachIncomingRelations: options };
     } else {
         options = options || {};
     }
     return function removeAssets(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(queryObj)) {
             assetGraph.removeAsset(asset, options.detachIncomingRelations);
             if (options.unload) {
                 asset.unload();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/removeDuplicateHtmlStyles.js
+++ b/lib/transforms/removeDuplicateHtmlStyles.js
@@ -1,18 +1,18 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
 // https://github.com/One-com/assetgraph/issues/82
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function removeDuplicateHtmlStyles(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'Html'}, queryObj)).forEach(function (htmlAsset) {
-            var seenCssAssetsById = {};
-            assetGraph.findRelations({from: htmlAsset, type: 'HtmlStyle'}).forEach(function (htmlStyle) {
+        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+            const seenCssAssetsById = {};
+            for (const htmlStyle of assetGraph.findRelations({from: htmlAsset, type: 'HtmlStyle'})) {
                 if (seenCssAssetsById[htmlStyle.to.id]) {
                     htmlStyle.detach();
                 } else {
                     seenCssAssetsById[htmlStyle.to.id] = true;
                 }
-            });
-        });
+            }
+        }
     };
 };

--- a/lib/transforms/removeDuplicateHtmlStyles.js
+++ b/lib/transforms/removeDuplicateHtmlStyles.js
@@ -1,10 +1,9 @@
-const _ = require('lodash');
 
 // https://github.com/One-com/assetgraph/issues/82
 
 module.exports = queryObj => {
     return function removeDuplicateHtmlStyles(assetGraph) {
-        for (const htmlAsset of assetGraph.findAssets(_.extend({type: 'Html'}, queryObj))) {
+        for (const htmlAsset of assetGraph.findAssets(Object.assign({type: 'Html'}, queryObj))) {
             const seenCssAssetsById = {};
             for (const htmlStyle of assetGraph.findRelations({from: htmlAsset, type: 'HtmlStyle'})) {
                 if (seenCssAssetsById[htmlStyle.to.id]) {

--- a/lib/transforms/removeEmptyJavaScripts.js
+++ b/lib/transforms/removeEmptyJavaScripts.js
@@ -1,28 +1,33 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function removeEmptyJavaScripts(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'JavaScript', isLoaded: true, isEmpty: true}, queryObj)).forEach(function (asset) {
-            var everyIncomingRelationRemoved = true;
-            asset.incomingRelations.forEach(function (incomingRelation) {
+        for (const asset of assetGraph.findAssets(_.extend({type: 'JavaScript', isLoaded: true, isEmpty: true}, queryObj))) {
+            let everyIncomingRelationRemoved = true;
+            for (const incomingRelation of asset.incomingRelations) {
+                let safeToRemove = true;
                 if (incomingRelation.type === 'HtmlScript') {
-                    for (var i = 0 ; i < incomingRelation.node.attributes.length ; i += 1) {
-                        var attribute = incomingRelation.node.attributes[i];
+                    for (let i = 0 ; i < incomingRelation.node.attributes.length ; i += 1) {
+                        const attribute = incomingRelation.node.attributes[i];
                         if (attribute.name !== 'src' &&
                             (attribute.name !== 'defer' || attribute.value !== 'defer') &&
                             (attribute.name !== 'async' || attribute.value !== 'async') &&
                             (attribute.name !== 'type' || attribute.value !== 'text/javascript')) {
 
-                            everyIncomingRelationRemoved = false;
-                            return;
+                            safeToRemove = false;
+                            break; // Don't bother checking the remaining attributes
                         }
                     }
                 }
-                incomingRelation.detach();
-            });
+                if (safeToRemove) {
+                    incomingRelation.detach();
+                } else {
+                    everyIncomingRelationRemoved = false;
+                }
+            }
             if (everyIncomingRelationRemoved) {
                 assetGraph.removeAsset(asset, true);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/removeEmptyJavaScripts.js
+++ b/lib/transforms/removeEmptyJavaScripts.js
@@ -1,8 +1,6 @@
-const _ = require('lodash');
-
 module.exports = queryObj => {
     return function removeEmptyJavaScripts(assetGraph) {
-        for (const asset of assetGraph.findAssets(_.extend({type: 'JavaScript', isLoaded: true, isEmpty: true}, queryObj))) {
+        for (const asset of assetGraph.findAssets(Object.assign({type: 'JavaScript', isLoaded: true, isEmpty: true}, queryObj))) {
             let everyIncomingRelationRemoved = true;
             for (const incomingRelation of asset.incomingRelations) {
                 let safeToRemove = true;

--- a/lib/transforms/removeEmptyStylesheets.js
+++ b/lib/transforms/removeEmptyStylesheets.js
@@ -1,8 +1,6 @@
-const _ = require('lodash');
-
 module.exports = queryObj => {
     return function removeEmptyStylesheets(assetGraph) {
-        for (const asset of assetGraph.findAssets(_.extend({type: 'Css', isLoaded: true, isEmpty: true}, queryObj))) {
+        for (const asset of assetGraph.findAssets(Object.assign({type: 'Css', isLoaded: true, isEmpty: true}, queryObj))) {
             let everyIncomingRelationRemoved = true;
             for (const incomingRelation of asset.incomingRelations) {
                 let safeToRemove = true;

--- a/lib/transforms/removeEmptyStylesheets.js
+++ b/lib/transforms/removeEmptyStylesheets.js
@@ -1,28 +1,33 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function removeEmptyStylesheets(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'Css', isLoaded: true, isEmpty: true}, queryObj)).forEach(function (asset) {
-            var everyIncomingRelationRemoved = true;
-            asset.incomingRelations.forEach(function (incomingRelation) {
+        for (const asset of assetGraph.findAssets(_.extend({type: 'Css', isLoaded: true, isEmpty: true}, queryObj))) {
+            let everyIncomingRelationRemoved = true;
+            for (const incomingRelation of asset.incomingRelations) {
+                let safeToRemove = true;
                 if (incomingRelation.type === 'HtmlStyle') {
-                    for (var i = 0 ; i < incomingRelation.node.attributes.length ; i += 1) {
-                        var attribute = incomingRelation.node.attributes[i];
+                    for (let i = 0 ; i < incomingRelation.node.attributes.length ; i += 1) {
+                        const attribute = incomingRelation.node.attributes[i];
                         if (attribute.name !== 'media' &&
                             (attribute.name !== 'rel' || attribute.value !== 'stylesheet') &&
                             (attribute.name !== 'href' || incomingRelation.node.nodeName.toLowerCase() !== 'link') &&
                             (attribute.name !== 'type' || attribute.value !== 'text/css')) {
 
-                            everyIncomingRelationRemoved = false;
-                            return;
+                            safeToRemove = false;
+                            break; // Don't bother checking the remaining attributes
                         }
                     }
                 }
-                incomingRelation.detach();
-            });
+                if (safeToRemove) {
+                    incomingRelation.detach();
+                } else {
+                    everyIncomingRelationRemoved = false;
+                }
+            }
             if (everyIncomingRelationRemoved) {
                 assetGraph.removeAsset(asset, true);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/removeRelations.js
+++ b/lib/transforms/removeRelations.js
@@ -1,7 +1,7 @@
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
     return function removeRelations(assetGraph) {
-        assetGraph.findRelations(queryObj, options.unresolved).forEach(function (relation) {
+        for (const relation of assetGraph.findRelations(queryObj, options.unresolved)) {
             if (options.detach) {
                 relation.detach();
             } else {
@@ -10,6 +10,6 @@ module.exports = function (queryObj, options) {
             if (options.removeOrphan && relation.to.isAsset && relation.to.incomingRelations.length === 0) {
                 assetGraph.removeAsset(relation.to);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/removeUnreferencedAssets.js
+++ b/lib/transforms/removeUnreferencedAssets.js
@@ -1,8 +1,6 @@
-const _ = require('lodash');
-
 module.exports = queryObj => {
     return function removeUnreferencedAssets(assetGraph) {
-        const assets = assetGraph.findAssets(_.extend({isInline: false}, queryObj));
+        const assets = assetGraph.findAssets(Object.assign({isInline: false}, queryObj));
         let numRemoved;
         do {
             numRemoved = 0;

--- a/lib/transforms/removeUnreferencedAssets.js
+++ b/lib/transforms/removeUnreferencedAssets.js
@@ -1,13 +1,13 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function removeUnreferencedAssets(assetGraph) {
-        var assets = assetGraph.findAssets(_.extend({isInline: false}, queryObj)),
-            numRemoved;
+        const assets = assetGraph.findAssets(_.extend({isInline: false}, queryObj));
+        let numRemoved;
         do {
             numRemoved = 0;
-            for (var i = 0 ; i < assets.length ; i += 1) {
-                var asset = assets[i];
+            for (let i = 0 ; i < assets.length ; i += 1) {
+                const asset = assets[i];
                 if (assetGraph.findRelations({to: asset}).length === 0) {
                     assetGraph.removeAsset(asset);
                     assets.splice(i, 1);
@@ -15,6 +15,6 @@ module.exports = function (queryObj) {
                     numRemoved += 1;
                 }
             }
-        } while (numRemoved !== 0);
+        } while (numRemoved > 0);
     };
 };

--- a/lib/transforms/replaceSymbolsInJavaScript.js
+++ b/lib/transforms/replaceSymbolsInJavaScript.js
@@ -1,11 +1,11 @@
 // Poor man's uglifyjs --define ... intended for use with --nocompress
 
-var _ = require('lodash');
-var parseExpression = require('../parseExpression');
-var replaceDescendantNode = require('../replaceDescendantNode');
-var esanimate = require('esanimate');
-var estraverse = require('estraverse');
-var escodegen = require('escodegen');
+const _ = require('lodash');
+const parseExpression = require('../parseExpression');
+const replaceDescendantNode = require('../replaceDescendantNode');
+const esanimate = require('esanimate');
+const estraverse = require('estraverse');
+const escodegen = require('escodegen');
 
 function astNodesAreIdentical(a, b) {
     // The horror!
@@ -13,7 +13,7 @@ function astNodesAreIdentical(a, b) {
 }
 
 function isLeftHandSideOfAssignment(stack, topNode) {
-    for (var i = stack.length - 1 ; i >= 0 ; i -= 1) {
+    for (let i = stack.length - 1 ; i >= 0 ; i -= 1) {
         if (stack[i].type === 'AssignmentExpression') {
             if (stack[i + 1] === stack[i].left) {
                 return true;
@@ -33,26 +33,23 @@ function isLeftHandSideOfAssignment(stack, topNode) {
 
 function astObjectIndexOfProperty(ast, key) {
     if (ast.properties && ast.properties.length) {
-        var index = -1;
-        ast.properties.some(function (prop, propIndex) {
-            if ((prop.key.type === 'Identifier' || prop.key.type === 'Literal') && (prop.key.name || prop.key.value) === key) {
-                index = propIndex;
-                return true;
+        for (let propIndex = 0 ; propIndex < ast.properties.length ; propIndex += 1) {
+            const propertyNode = ast.properties[propIndex];
+            if ((propertyNode.key.type === 'Identifier' || propertyNode.key.type === 'Literal') && (propertyNode.key.name || propertyNode.key.value) === key) {
+                return propIndex;
             }
-            return false;
-        });
-        return index;
+        }
     }
     return -1;
 }
 
 
-module.exports = function (queryObj, replacementAstBySymbolName) {
-    replacementAstBySymbolName = _.extend({}, replacementAstBySymbolName);
-    var nonSymbols = [];
-    Object.keys(replacementAstBySymbolName).forEach(function (symbolName) {
-        var expression = parseExpression(symbolName),
-            replacementAst = replacementAstBySymbolName[symbolName];
+module.exports = (queryObj, replacementAstBySymbolName) => {
+    replacementAstBySymbolName = Object.assign({}, replacementAstBySymbolName);
+    const nonSymbols = [];
+    for (const symbolName of Object.keys(replacementAstBySymbolName)) {
+        const expression = parseExpression(symbolName);
+        let replacementAst = replacementAstBySymbolName[symbolName];
         // FIXME: Figure out how to avoid this polymorphism. Where is it being used?
         if (!(replacementAst && typeof replacementAst.type === 'string')) {
             if (replacementAst && typeof replacementAst === 'object') {
@@ -64,21 +61,21 @@ module.exports = function (queryObj, replacementAstBySymbolName) {
         if (expression.type === 'Identifier') {
             replacementAstBySymbolName[expression.name] = replacementAst;
         } else {
-            nonSymbols.push({expression: expression, replacementAst: replacementAst});
+            nonSymbols.push({ expression, replacementAst });
         }
-    });
+    }
 
     return function replaceSymbolsInJavaScript(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj)).forEach(function (javaScript) {
-            var replacementPerformed = false;
+        for (const javaScript of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
+            let replacementPerformed = false;
             estraverse.traverse(javaScript.parseTree, {
-                enter: function (node) {
-                    var replacementAst;
+                enter(node) {
+                    let replacementAst;
                     if ((node.type === 'Literal' || node.type === 'Identifier') && Object.prototype.hasOwnProperty.call(replacementAstBySymbolName, node.name || node.value) && !isLeftHandSideOfAssignment(this.parents(), node)) {
                         replacementAst = replacementAstBySymbolName[node.name || node.value];
                     } else {
-                        for (var i = 0 ; i < nonSymbols.length ; i += 1) {
-                            var expression = nonSymbols[i].expression;
+                        for (let i = 0 ; i < nonSymbols.length ; i += 1) {
+                            const expression = nonSymbols[i].expression;
                             if (node.constructor === expression.constructor && astNodesAreIdentical(node, expression)) {
                                 replacementAst = nonSymbols[i].replacementAst;
                                 break;
@@ -86,45 +83,46 @@ module.exports = function (queryObj, replacementAstBySymbolName) {
                         }
                     }
                     if (replacementAst) {
-                        var stack = this.parents().reverse();
+                        const stack = this.parents().reverse();
                         if (stack[0].type === 'MemberExpression' && stack[0].property === node) {
                             // Don't consider cases where the identifier is the "property" part of
                             // a MemberExpression (eg. don't replace FOO when used as: window.FOO)
                             return;
                         }
                         stack.unshift(node);
-                        var replacement = node;
-                        var originalNode = node;
-                        var dontReplace = false;
-                        var unmatchedPart = '';
-                        var replacedUntil = -1;
+                        let replacement = node;
+                        let originalNode = node;
+                        let dontReplace = false;
+                        let unmatchedPart = '';
+                        let replacedUntil = -1;
 
-                        stack.some(function (node, stackIndex) {
+                        for (let stackIndex = 0 ; stackIndex < stack.length ; stackIndex += 1) {
+                            const node = stack[stackIndex];
                             replacedUntil = stackIndex;
                             if (originalNode === node) {
                                 replacement = _.cloneDeep(replacementAst);
-                                return false;
+                                continue;
                             } else if (node.type === 'MemberExpression' && replacement !== node) {
-                                if (node.computed && node.property.type !== 'Literal' && node.property.type !== 'Identifier')   {
-                                    return true;
+                                if (node.computed && node.property.type !== 'Literal' && node.property.type !== 'Identifier') {
+                                    break;
                                 } else {
-                                    var propVal = node.computed ? String(node.property.value) : node.property.name || node.property.value;
-                                    var astIndex = astObjectIndexOfProperty(replacement, propVal);
+                                    const propVal = node.computed ? String(node.property.value) : node.property.name || node.property.value;
+                                    const astIndex = astObjectIndexOfProperty(replacement, propVal);
                                     if (astIndex !== -1) {
                                         replacement = replacement.properties[astIndex].value;
                                     } else {
                                         dontReplace = true;
                                         unmatchedPart = node;
                                     }
-                                    return false; // continue up the stack
+                                    continue;
                                 }
                             }
-                            return true; // stop traversing the stack
-                        });
+                            break;
+                        }
 
                         if (dontReplace) {
                             assetGraph.emit('warn', new Error(
-                                'Could not find a value for "' + escodegen.generate(unmatchedPart) + '". Replacing with undefined.'
+                                `Could not find a value for "${escodegen.generate(unmatchedPart)}". Replacing with undefined.`
                             ));
                             replaceDescendantNode(stack[replacedUntil], stack[replacedUntil - 1], { type: 'Identifier', name: 'undefined' });
                             replacementPerformed = true;
@@ -140,6 +138,6 @@ module.exports = function (queryObj, replacementAstBySymbolName) {
             if (replacementPerformed) {
                 javaScript.markDirty();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/replaceSymbolsInJavaScript.js
+++ b/lib/transforms/replaceSymbolsInJavaScript.js
@@ -66,7 +66,7 @@ module.exports = (queryObj, replacementAstBySymbolName) => {
     }
 
     return function replaceSymbolsInJavaScript(assetGraph) {
-        for (const javaScript of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
+        for (const javaScript of assetGraph.findAssets(Object.assign({type: 'JavaScript'}, queryObj))) {
             let replacementPerformed = false;
             estraverse.traverse(javaScript.parseTree, {
                 enter(node) {

--- a/lib/transforms/reviewContentSecurityPolicy.js
+++ b/lib/transforms/reviewContentSecurityPolicy.js
@@ -1,9 +1,9 @@
-var urlModule = require('url');
-var _ = require('lodash');
-var crypto = require('crypto');
-var ContentSecurityPolicy = require('../assets/ContentSecurityPolicy');
+const urlModule = require('url');
+const _ = require('lodash');
+const crypto = require('crypto');
+const ContentSecurityPolicy = require('../assets/ContentSecurityPolicy');
 
-var directiveByRelationType = {
+const directiveByRelationType = {
     HtmlStyle: 'styleSrc',
     CssImport: 'styleSrc',
     HtmlScript: 'scriptSrc',
@@ -28,29 +28,25 @@ var directiveByRelationType = {
 };
 
 function toCamelCase(str) {
-    return str.replace(/-([a-z])/g, function ($0, ch) {
-        return ch.toUpperCase();
-    });
+    return str.replace(/-([a-z])/g, ($0, ch) => ch.toUpperCase());
 }
 
 function fromCamelCase(str) {
-    return str.replace(/[A-Z]/g, function ($0) {
-        return '-' + $0.toLowerCase();
-    });
+    return str.replace(/[A-Z]/g, $0 => '-' + $0.toLowerCase());
 }
 
 function isNonceOrHash(sourceExpression) {
     return /^'nonce-|^'sha\d+-/.test(sourceExpression);
 }
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
     return function reviewContentSecurityPolicy(assetGraph) {
-        var includePathByDirective = {};
+        const includePathByDirective = {};
         if (options.includePath) {
-            _.flatten(options.includePath).forEach(function (directive) {
+            for (const directive of _.flatten(options.includePath)) {
                 includePathByDirective[toCamelCase(directive)] = true;
-            });
+            }
         }
 
         function originFromUrl(url, directive, isInProtocolRelativeContext) {
@@ -63,8 +59,8 @@ module.exports = function (queryObj, options) {
                     return url;
                 }
             } else {
-                var urlObj = urlModule.parse(url);
-                var host = urlObj.hostname;
+                const urlObj = urlModule.parse(url);
+                let host = urlObj.hostname;
                 if (urlObj.port && parseInt(urlObj.port, 10) !== {'https:': 443, 'http:': 80}[urlObj.protocol]) {
                     host += ':' + urlObj.port;
                 }
@@ -77,17 +73,17 @@ module.exports = function (queryObj, options) {
             }
         }
 
-        assetGraph.findAssets(queryObj || { type: 'Html', isInline: false, isFragment: false, isLoaded: true }).forEach(function (htmlAsset) {
-            var htmlContentSecurityPolicies = assetGraph.findRelations({from: htmlAsset, type: 'HtmlContentSecurityPolicy'});
-            htmlContentSecurityPolicies.forEach(function (htmlContentSecurityPolicy) {
-                var contentSecurityPolicy = htmlContentSecurityPolicy.to;
-                var defaultSrc = contentSecurityPolicy.parseTree.defaultSrc;
+        for (const htmlAsset of assetGraph.findAssets(queryObj || { type: 'Html', isInline: false, isFragment: false, isLoaded: true })) {
+            const htmlContentSecurityPolicies = assetGraph.findRelations({from: htmlAsset, type: 'HtmlContentSecurityPolicy'});
+            for (const htmlContentSecurityPolicy of htmlContentSecurityPolicies) {
+                const contentSecurityPolicy = htmlContentSecurityPolicy.to;
+                const defaultSrc = contentSecurityPolicy.parseTree.defaultSrc;
 
                 function supportsUnsafeInline(directive) {
                     return (
                         contentSecurityPolicy.parseTree[directive] ?
-                            contentSecurityPolicy.parseTree[directive].indexOf('\'unsafe-inline\'') !== -1 :
-                            defaultSrc && ContentSecurityPolicy.directiveFallsBackToDefaultSrc(directive) && defaultSrc.indexOf('\'unsafe-inline\'') !== -1
+                            contentSecurityPolicy.parseTree[directive].includes('\'unsafe-inline\'') :
+                            defaultSrc && ContentSecurityPolicy.directiveFallsBackToDefaultSrc(directive) && defaultSrc.includes('\'unsafe-inline\'')
                     );
                 }
 
@@ -99,8 +95,8 @@ module.exports = function (queryObj, options) {
                     );
                 }
 
-                var disallowedRelationsByDirectiveAndOrigin = {};
-                var seenNoncesByDirective = {};
+                const disallowedRelationsByDirectiveAndOrigin = {};
+                const seenNoncesByDirective = {};
 
                 function noteAsset(asset, incomingRelation, isInProtocolRelativeContext, directive) {
                     directive = directive || (incomingRelation && directiveByRelationType[incomingRelation.type]);
@@ -108,7 +104,7 @@ module.exports = function (queryObj, options) {
                         if (asset.isInline) {
                             if ((directive === 'styleSrc' || directive === 'scriptSrc') && (!supportsUnsafeInline(directive) || hasNonceOrHash(directive))) {
                                 disallowedRelationsByDirectiveAndOrigin[directive] = disallowedRelationsByDirectiveAndOrigin[directive] || {};
-                                var hashSource = '\'sha256-' + crypto.createHash('sha256').update(asset.rawSrc).digest('base64') + '\'';
+                                const hashSource = '\'sha256-' + crypto.createHash('sha256').update(asset.rawSrc).digest('base64') + '\'';
                                 (disallowedRelationsByDirectiveAndOrigin[directive][hashSource] = disallowedRelationsByDirectiveAndOrigin[directive][hashSource] || []).push(incomingRelation);
                             } else if (/^data:/.test(incomingRelation.href)) {
                                 disallowedRelationsByDirectiveAndOrigin[directive] = disallowedRelationsByDirectiveAndOrigin[directive] || {};
@@ -116,11 +112,11 @@ module.exports = function (queryObj, options) {
                             }
                         } else if (!contentSecurityPolicy.allows(directive, asset.url)) {
                             disallowedRelationsByDirectiveAndOrigin[directive] = disallowedRelationsByDirectiveAndOrigin[directive] || {};
-                            var origin = originFromUrl(asset.url, directive, isInProtocolRelativeContext);
+                            const origin = originFromUrl(asset.url, directive, isInProtocolRelativeContext);
                             (disallowedRelationsByDirectiveAndOrigin[directive][origin] = disallowedRelationsByDirectiveAndOrigin[directive][origin] || []).push(incomingRelation);
                         }
                         if (incomingRelation.from.type === 'Html') {
-                            var nonce = incomingRelation.node.getAttribute('nonce');
+                            const nonce = incomingRelation.node.getAttribute('nonce');
                             if (nonce) {
                                 (seenNoncesByDirective[directive] = seenNoncesByDirective[directive] || []).push('\'nonce-' + nonce + '\'');
                                 if (options.update) {
@@ -132,25 +128,26 @@ module.exports = function (queryObj, options) {
                     }
                 }
 
-                var isSeenByAssetId = {};
-                isSeenByAssetId[htmlAsset.id] = true;
-                var protocolRelativeStack = [false];
-                assetGraph._traverse(htmlAsset, {type: assetGraph.query.not(['HtmlAnchor', 'HtmlMetaRefresh', 'JavaScriptSourceUrl', 'JavaScriptSourceMappingUrl', 'CssSourceUrl', 'CssSourceMappingUrl'])}, function (asset, incomingRelation) {
-                    var isInProtocolRelativeContext = protocolRelativeStack[protocolRelativeStack.length - 1] || (incomingRelation && incomingRelation.hrefType === 'protocolRelative');
+                const isSeenByAssetId = {
+                    [htmlAsset.id]: true
+                };
+                const protocolRelativeStack = [false];
+                assetGraph._traverse(htmlAsset, {type: assetGraph.query.not(['HtmlAnchor', 'HtmlMetaRefresh', 'JavaScriptSourceUrl', 'JavaScriptSourceMappingUrl', 'CssSourceUrl', 'CssSourceMappingUrl'])}, (asset, incomingRelation) => {
+                    const isInProtocolRelativeContext = protocolRelativeStack[protocolRelativeStack.length - 1] || (incomingRelation && incomingRelation.hrefType === 'protocolRelative');
                     protocolRelativeStack.push(isInProtocolRelativeContext);
                     isSeenByAssetId[asset.id] = true;
                     if (incomingRelation && incomingRelation.type === 'HttpRedirect') {
                         // Work backwards through all the seen assets to find all relevant paths through this redirect:
-                        var isSeenByRelationId = {};
-                        var queue = [].concat(incomingRelation.from.incomingRelations.filter(function (relation) {
-                            return isSeenByAssetId[relation.from.id];
-                        }));
+                        const isSeenByRelationId = {};
+                        const queue = [].concat(incomingRelation.from.incomingRelations.filter(
+                            relation => isSeenByAssetId[relation.from.id]
+                        ));
                         while (queue.length > 0) {
-                            var relation = queue.shift();
+                            const relation = queue.shift();
                             if (!isSeenByRelationId[relation.id]) {
                                 isSeenByRelationId[relation.id] = true;
                                 if (relation.type === 'HttpRedirect') {
-                                    Array.prototype.push.apply(queue, relation.from.incomingRelations.filter(function (relation) {
+                                    queue.push(...relation.from.incomingRelations.filter(relation => {
                                         return isSeenByAssetId[relation.from.id] && !isSeenByRelationId[relation.id];
                                     }));
                                 } else {
@@ -161,11 +158,13 @@ module.exports = function (queryObj, options) {
                     } else {
                         noteAsset(asset, incomingRelation, isInProtocolRelativeContext);
                     }
-                }, function () {
-                    protocolRelativeStack.pop();
-                });
+                }, () => protocolRelativeStack.pop());
 
-                var directives = _.uniq(Object.keys(disallowedRelationsByDirectiveAndOrigin).concat(Object.keys(seenNoncesByDirective)).concat(Object.keys(contentSecurityPolicy.parseTree)));
+                const directives = _.uniq(
+                    Object.keys(disallowedRelationsByDirectiveAndOrigin)
+                        .concat(Object.keys(seenNoncesByDirective))
+                        .concat(Object.keys(contentSecurityPolicy.parseTree))
+                );
 
                 if (options.infoObject) {
                     options.infoObject[contentSecurityPolicy.id] = {
@@ -173,16 +172,16 @@ module.exports = function (queryObj, options) {
                     };
                 }
 
-                directives.forEach(function (directive) {
-                    var origins = Object.keys(disallowedRelationsByDirectiveAndOrigin[directive] || {});
+                for (const directive of directives) {
+                    let origins = Object.keys(disallowedRelationsByDirectiveAndOrigin[directive] || {});
                     if (options.update) {
                         if (contentSecurityPolicy.parseTree[directive]) {
                             origins = _.uniq(origins.concat(contentSecurityPolicy.parseTree[directive]));
                         } else if (ContentSecurityPolicy.directiveFallsBackToDefaultSrc(directive) && contentSecurityPolicy.parseTree.defaultSrc) {
                             origins = _.uniq(origins.concat(contentSecurityPolicy.parseTree.defaultSrc));
                         }
-                        var noncesWereRemoved = false;
-                        var originsWithNoncesSubtracted = _.difference(origins, ["'nonce-developmentonly'"].concat(seenNoncesByDirective[directive]));
+                        let noncesWereRemoved = false;
+                        const originsWithNoncesSubtracted = _.difference(origins, ["'nonce-developmentonly'"].concat(seenNoncesByDirective[directive]));
                         if (originsWithNoncesSubtracted.length < origins.length) {
                             noncesWereRemoved = true;
                         }
@@ -199,12 +198,10 @@ module.exports = function (queryObj, options) {
                             origins.push("'unsafe-inline'");
                         }
                         if (options.level < 2) {
-                            origins = origins.filter(function (origin) {
-                                return !isNonceOrHash(origin);
-                            });
+                            origins = origins.filter(origin => !isNonceOrHash(origin));
                         }
                         if (origins.length > 1) {
-                            var indexOfNoneToken = origins.indexOf('\'none\'');
+                            const indexOfNoneToken = origins.indexOf('\'none\'');
                             if (indexOfNoneToken !== -1) {
                                 origins.splice(indexOfNoneToken, 1);
                             }
@@ -216,8 +213,8 @@ module.exports = function (queryObj, options) {
                         }
                         contentSecurityPolicy.markDirty();
                     } else {
-                        var allowedOrigins = contentSecurityPolicy.parseTree[directive];
-                        var directiveInEffect = directive;
+                        let allowedOrigins = contentSecurityPolicy.parseTree[directive];
+                        let directiveInEffect = directive;
                         if (!allowedOrigins) {
                             if (directive !== 'frameAncestors' && contentSecurityPolicy.parseTree.defaultSrc) {
                                 directiveInEffect = 'defaultSrc';
@@ -226,32 +223,30 @@ module.exports = function (queryObj, options) {
                                 allowedOrigins = ['\'none\''];
                             }
                         }
-                        origins.forEach(function (nonWhitelistedOrigin) {
-                            var relations = disallowedRelationsByDirectiveAndOrigin[directive][nonWhitelistedOrigin];
+                        for (const nonWhitelistedOrigin of origins) {
+                            let relations = disallowedRelationsByDirectiveAndOrigin[directive][nonWhitelistedOrigin];
                             if (relations) {
-                                relations = relations.filter(function (relation) {
-                                    var nonce;
+                                relations = relations.filter(relation => {
+                                    let nonce;
                                     if (relation.from.type === 'Html') {
                                         nonce = relation.node.getAttribute('nonce');
                                     }
-                                    return !nonce || allowedOrigins.indexOf('\'nonce-' + nonce + '\'') === -1;
+                                    return !nonce || !allowedOrigins.includes('\'nonce-' + nonce + '\'');
                                 });
                                 if (relations.length > 0) {
                                     assetGraph.emit(
                                         'warn',
                                         new Error(
                                             htmlAsset.urlOrDescription + ': ' + (relations.length === 1 ? 'An asset violates' : relations.length + ' relations violate') + ' the ' + fromCamelCase(directiveInEffect) + ' ' + allowedOrigins.join(' ') + ' Content-Security-Policy directive:\n  ' +
-                                            relations.map(function (asset) {
-                                                return asset.to.urlOrDescription;
-                                            }).join('\n  ')
+                                            relations.map(asset => asset.to.urlOrDescription).join('\n  ')
                                         )
                                     );
                                 }
                             }
-                        });
+                        }
                     }
-                });
-            });
-        });
+                }
+            }
+        }
     };
 };

--- a/lib/transforms/reviewSubResourceIntegrity.js
+++ b/lib/transforms/reviewSubResourceIntegrity.js
@@ -1,62 +1,58 @@
-var crypto = require('crypto');
+const crypto = require('crypto');
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
-    var algorithm = options.algorithm || 'sha256';
+    const algorithm = options.algorithm || 'sha256';
     return function reviewSubResourceIntegrity(assetGraph) {
-        assetGraph.findAssets(queryObj || { type: 'Html', isInline: false, isFragment: false, isLoaded: true }).forEach(function (htmlAsset) {
-            var changed = false;
-            assetGraph.findRelations({from: htmlAsset, type: ['HtmlStyle', 'HtmlScript'], to: {isInline: false, isLoaded: true}}).forEach(function (relation) {
-                var integrityFragments;
-                var foundMatch;
+        for (const htmlAsset of assetGraph.findAssets(queryObj || { type: 'Html', isInline: false, isFragment: false, isLoaded: true })) {
+            let changed = false;
+            for (const relation of assetGraph.findRelations({from: htmlAsset, type: ['HtmlStyle', 'HtmlScript'], to: {isInline: false, isLoaded: true}})) {
+                let integrityFragments;
+                let foundMatch;
                 if (relation.node.hasAttribute('integrity')) {
-                    integrityFragments = relation.node.getAttribute('integrity').split(' ').map(function (hash) {
-                        return hash.replace(/^sha/i, 'sha');
-                    });
-                    integrityFragments.forEach(function (integrityFragment) {
-                        var matchIntegrityFragment = integrityFragment.match(/^(sha(?:256|384|512))-(.*)/);
+                    integrityFragments = relation.node.getAttribute('integrity').split(' ').map(
+                        hash => hash.replace(/^sha/i, 'sha')
+                    );
+                    for (const integrityFragment of integrityFragments) {
+                        const matchIntegrityFragment = integrityFragment.match(/^(sha(?:256|384|512))-(.*)/);
                         if (matchIntegrityFragment) {
-                            var algorithmName = matchIntegrityFragment[1];
-                            var hash = matchIntegrityFragment[2];
+                            const [ , algorithmName, hash ] = matchIntegrityFragment;
                             if (crypto.createHash(algorithmName).update(relation.to.rawSrc).digest('base64') === hash) {
                                 foundMatch = integrityFragment;
                             } else if (options.single) {
-                                assetGraph.emit(
-                                    'warn',
-                                    new Error(htmlAsset.urlOrDescription + ': integrity hash does not match that of the linked resource (' + relation.to.urlOrDescription + ') ' + integrityFragment)
-                                );
+                                assetGraph.emit('warn', new Error(
+                                    `${htmlAsset.urlOrDescription}: integrity hash does not match that of the linked resource (${relation.to.urlOrDescription}) ${integrityFragment}`
+                                ));
                             }
                         } else {
-                            assetGraph.emit(
-                                'warn',
-                                new Error(htmlAsset.urlOrDescription + ': Cannot parse hash in integrity attribute: ' + integrityFragment)
-                            );
+                            assetGraph.emit('warn', new Error(
+                                `${htmlAsset.urlOrDescription}: Cannot parse hash in integrity attribute: ${integrityFragment}`
+                            ));
                         }
-                    });
+                    }
                     if (!foundMatch && !options.single) {
-                        assetGraph.emit(
-                            'warn',
-                            new Error(htmlAsset.urlOrDescription + ': integrity attribute ' + integrityFragments.join(' ') + ' does not match the linked resource: ' + relation.to.urlOrDescription)
-                        );
+                        assetGraph.emit('warn', new Error(
+                            `${htmlAsset.urlOrDescription}: integrity attribute ${integrityFragments.join(' ')} does not match the linked resource: ${relation.to.urlOrDescription}`
+                        ));
                     }
                 } else {
                     integrityFragments = [];
                 }
                 if (options.update) {
-                    var hash = algorithm + '-' + crypto.createHash(algorithm).update(relation.to.rawSrc).digest('base64');
+                    const hash = algorithm + '-' + crypto.createHash(algorithm).update(relation.to.rawSrc).digest('base64');
                     if (options.single) {
                         relation.node.setAttribute('integrity', hash);
                         changed = true;
-                    } else if (integrityFragments.indexOf(hash) === -1) {
+                    } else if (!integrityFragments.includes(hash)) {
                         integrityFragments.push(hash);
                         relation.node.setAttribute('integrity', integrityFragments.join(' '));
                         changed = true;
                     }
                 }
-            });
+            }
             if (changed) {
                 htmlAsset.markDirty();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/serializeSourceMaps.js
+++ b/lib/transforms/serializeSourceMaps.js
@@ -1,23 +1,23 @@
-var AssetGraph = require('../AssetGraph');
-var estraverse = require('estraverse');
+const AssetGraph = require('../AssetGraph');
+const estraverse = require('estraverse');
 
-module.exports = function (options) {
+module.exports = options => {
     options = options || {};
     return function serializeSourceMaps(assetGraph) {
-        var potentiallyOrphanedAssetsById = {};
+        const potentiallyOrphanedAssetsById = {};
 
-        assetGraph.findAssets({ type: [ 'Css', 'JavaScript' ], isLoaded: true }).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets({ type: [ 'Css', 'JavaScript' ], isLoaded: true })) {
             // For now, don't attempt to attach source maps to data-bind attributes etc.:
             if (asset.isInline && assetGraph.findRelations({ type: [ 'HtmlDataBindAttribute', 'HtmlKnockoutContainerless', 'HtmlParamsAttribute', 'HtmlStyleAttribute' ], to: asset }).length > 0) {
-                return;
+                continue;
             }
 
-            var nonInlineAncestorUrl = asset.nonInlineAncestor.url;
+            const nonInlineAncestorUrl = asset.nonInlineAncestor.url;
             if (!asset.isDirty) {
-                var hasLocationInformationPointingAtADifferentSourceFile = false;
+                let hasLocationInformationPointingAtADifferentSourceFile = false;
                 if (asset.type === 'JavaScript') {
                     estraverse.traverse(asset.parseTree, {
-                        enter: function (node) {
+                        enter(node) {
                             if (node.loc && node.loc.source !== nonInlineAncestorUrl) {
                                 hasLocationInformationPointingAtADifferentSourceFile = true;
                                 return this.break();
@@ -25,7 +25,7 @@ module.exports = function (options) {
                         }
                     });
                 } else if (asset.type === 'Css') {
-                    asset.parseTree.walk(function (node) {
+                    asset.parseTree.walk(node => {
                         if (node.source.input.file !== nonInlineAncestorUrl) {
                             hasLocationInformationPointingAtADifferentSourceFile = true;
                             return false;
@@ -34,52 +34,50 @@ module.exports = function (options) {
                 }
 
                 if (!hasLocationInformationPointingAtADifferentSourceFile) {
-                    return;
+                    continue;
                 }
             }
-            var sourcesContentByUrl = options.sourcesContent && {};
-            assetGraph.findRelations({ from: asset, type: /SourceMappingUrl$/ }).forEach(function (existingSourceMapRelation) {
+            const sourcesContentByUrl = options.sourcesContent && {};
+            for (const existingSourceMapRelation of assetGraph.findRelations({ from: asset, type: /SourceMappingUrl$/ })) {
                 potentiallyOrphanedAssetsById[existingSourceMapRelation.to.id] = existingSourceMapRelation.to;
-                var existingSourceMap = existingSourceMapRelation.to;
+                const existingSourceMap = existingSourceMapRelation.to;
                 if (options.sourcesContent && existingSourceMap.parseTree && existingSourceMap.parseTree.sourcesContent && existingSourceMap.parseTree.sources) {
-                    for (var i = 0 ; i < existingSourceMap.parseTree.sources.length ; i += 1) {
+                    for (let i = 0 ; i < existingSourceMap.parseTree.sources.length ; i += 1) {
                         if (typeof existingSourceMap.parseTree.sourcesContent[i] === 'string') {
-                            var absoluteUrl = assetGraph.resolveUrl(existingSourceMap.nonInlineAncestor.url, existingSourceMap.parseTree.sources[i]);
+                            const absoluteUrl = assetGraph.resolveUrl(existingSourceMap.nonInlineAncestor.url, existingSourceMap.parseTree.sources[i]);
                             sourcesContentByUrl[absoluteUrl] = existingSourceMap.parseTree.sourcesContent[i];
                         }
                     }
                 }
                 existingSourceMapRelation.detach();
-            });
+            }
 
-            var sourceMap = asset.sourceMap;
+            const sourceMap = asset.sourceMap;
             if (options.sourcesContent) {
-                sourceMap.sourcesContent = sourceMap.sources.map(function (url) {
-                    return sourcesContentByUrl[url] || null;
-                });
+                sourceMap.sourcesContent = sourceMap.sources.map(url => sourcesContentByUrl[url] || null);
             } else {
                 sourceMap.sourcesContent = undefined;
             }
 
-            var sourceMapAsset = new AssetGraph.SourceMap({
+            const sourceMapAsset = new AssetGraph.SourceMap({
                 url: (asset.isInline ? nonInlineAncestorUrl && nonInlineAncestorUrl.replace(/\..*$/, '-') + asset.id : asset.url) + '.map',
                 parseTree: sourceMap
             });
             assetGraph.addAsset(sourceMapAsset);
-            var sourceMappingUrl = new AssetGraph[asset.type + 'SourceMappingUrl']({ to: sourceMapAsset }).attach(asset, 'last');
+            const sourceMappingUrl = new AssetGraph[asset.type + 'SourceMappingUrl']({ to: sourceMapAsset }).attach(asset, 'last');
             // This is a(nother) case where it'd be nice if an inline relation could be yet another hrefType (#208), because
             // then the logical thing would be that attaching the sourceMappingUrl relation would automatically inline the asset:
             if (sourceMapAsset.isInline) {
                 sourceMappingUrl.inline();
             }
-        });
+        }
 
         // Clean up old source maps:
-        Object.keys(potentiallyOrphanedAssetsById).forEach(function (id) {
-            var asset = potentiallyOrphanedAssetsById[id];
+        for (const id of Object.keys(potentiallyOrphanedAssetsById)) {
+            const asset = potentiallyOrphanedAssetsById[id];
             if (asset.incomingRelations.length === 0) {
                 assetGraph.removeAsset(asset);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/setAssetContentType.js
+++ b/lib/transforms/setAssetContentType.js
@@ -1,11 +1,11 @@
-module.exports = function (queryObj, contentType) {
+module.exports = (queryObj, contentType) => {
     if (typeof encoding !== 'string') {
         throw new Error('transforms.setContentType: The \'contentType\' parameter is mandatory');
     }
     console.warn('The setAssetContentType transform is deprecated, please use updateAsset(queryObj, {contentType: ...}) instead');
     return function setContentType(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(queryObj)) {
             asset.contentType = contentType;
-        });
+        }
     };
 };

--- a/lib/transforms/setAssetEncoding.js
+++ b/lib/transforms/setAssetEncoding.js
@@ -1,12 +1,10 @@
-const _ = require('lodash');
-
 module.exports = (queryObj, encoding) => {
     if (typeof encoding !== 'string') {
         throw new Error('transforms.setAssetEncoding: The \'encoding\' parameter is mandatory');
     }
     console.warn('The setAssetEncoding transform is deprecated, please use updateAssets(queryObj, {encoding: ...}) instead');
     return function setAssetEncoding(assetGraph) {
-        for (const asset of assetGraph.findAssets(_.extend({isText: true}, queryObj))) {
+        for (const asset of assetGraph.findAssets(Object.assign({isText: true}, queryObj))) {
             asset.encoding = encoding;
         }
     };

--- a/lib/transforms/setAssetEncoding.js
+++ b/lib/transforms/setAssetEncoding.js
@@ -1,13 +1,13 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj, encoding) {
+module.exports = (queryObj, encoding) => {
     if (typeof encoding !== 'string') {
         throw new Error('transforms.setAssetEncoding: The \'encoding\' parameter is mandatory');
     }
     console.warn('The setAssetEncoding transform is deprecated, please use updateAssets(queryObj, {encoding: ...}) instead');
     return function setAssetEncoding(assetGraph) {
-        assetGraph.findAssets(_.extend({isText: true}, queryObj)).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(_.extend({isText: true}, queryObj))) {
             asset.encoding = encoding;
-        });
+        }
     };
 };

--- a/lib/transforms/setAssetExtension.js
+++ b/lib/transforms/setAssetExtension.js
@@ -1,11 +1,11 @@
-module.exports = function (queryObj, extension) {
+module.exports = (queryObj, extension) => {
     if (typeof extension !== 'string') {
         throw new Error('transforms.setAssetExtension: The \'extension\' parameter is mandatory (but can be the empty string)');
     }
     console.warn('The setAssetExtension transform is deprecated, please use updateAsset(queryObj, {extension: ...}) instead');
     return function setAssetExtension(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(queryObj)) {
             asset.extension = extension;
-        });
+        }
     };
 };

--- a/lib/transforms/setAsyncOrDeferOnHtmlScripts.js
+++ b/lib/transforms/setAsyncOrDeferOnHtmlScripts.js
@@ -1,9 +1,7 @@
-const _ = require('lodash');
-
 module.exports = (queryObj, setAsyncAttribute, setDeferAttribute) => {
     return function setAsyncOrDeferOnHtmlScripts(assetGraph) {
         if (setAsyncAttribute || setDeferAttribute) {
-            for (const htmlScript of assetGraph.findRelations(_.extend({type: 'HtmlScript'}, queryObj))) {
+            for (const htmlScript of assetGraph.findRelations(Object.assign({type: 'HtmlScript'}, queryObj))) {
                 if (setAsyncAttribute) {
                     htmlScript.node.setAttribute('async', 'async');
                 }

--- a/lib/transforms/setAsyncOrDeferOnHtmlScripts.js
+++ b/lib/transforms/setAsyncOrDeferOnHtmlScripts.js
@@ -1,16 +1,16 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj, setAsyncAttribute, setDeferAttribute) {
+module.exports = (queryObj, setAsyncAttribute, setDeferAttribute) => {
     return function setAsyncOrDeferOnHtmlScripts(assetGraph) {
         if (setAsyncAttribute || setDeferAttribute) {
-            assetGraph.findRelations(_.extend({type: 'HtmlScript'}, queryObj)).forEach(function (htmlScript) {
+            for (const htmlScript of assetGraph.findRelations(_.extend({type: 'HtmlScript'}, queryObj))) {
                 if (setAsyncAttribute) {
                     htmlScript.node.setAttribute('async', 'async');
                 }
                 if (setDeferAttribute) {
                     htmlScript.node.setAttribute('defer', 'defer');
                 }
-            });
+            }
         }
     };
 };

--- a/lib/transforms/setHtmlImageDimensions.js
+++ b/lib/transforms/setHtmlImageDimensions.js
@@ -1,25 +1,25 @@
-var _ = require('lodash'),
-    imageinfo = require('imageinfo');
+const _ = require('lodash');
+const imageinfo = require('imageinfo');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function setHtmlImageDimensions(assetGraph) {
-        assetGraph.findRelations(_.extend({type: 'HtmlImage'}, queryObj)).forEach(function (htmlImage) {
+        for (const htmlImage of assetGraph.findRelations(_.extend({type: 'HtmlImage'}, queryObj))) {
             if (!htmlImage.node.hasAttribute('height') && !htmlImage.node.hasAttribute('width')) {
                 if (htmlImage.to) {
                     if (htmlImage.to.type === 'Svg') {
-                        var svgElement = htmlImage.to.parseTree.documentElement;
+                        const svgElement = htmlImage.to.parseTree.documentElement;
                         if (svgElement) {
-                            var intrinsicWidth = svgElement.getAttribute('width');
+                            const intrinsicWidth = svgElement.getAttribute('width');
                             if (intrinsicWidth && /^\d+(?:\.\d+)?\s*(?:px)?\s*$/.test(intrinsicWidth)) {
                                 htmlImage.node.setAttribute('width', intrinsicWidth.replace(/\s*px\s*$/i, ''));
                             }
-                            var intrinsicHeight = svgElement.getAttribute('height');
+                            const intrinsicHeight = svgElement.getAttribute('height');
                             if (intrinsicHeight && /^\d+(?:\.\d+)?\s*(?:px)?\s*$/.test(intrinsicHeight)) {
                                 htmlImage.node.setAttribute('height', intrinsicHeight.replace(/\s*px\s*$/i, ''));
                             }
                         }
                     } else {
-                        var info = imageinfo(htmlImage.to.rawSrc);
+                        const info = imageinfo(htmlImage.to.rawSrc);
                         if (info) {
                             htmlImage.node.setAttribute('width', info.width);
                             htmlImage.node.setAttribute('height', info.height);
@@ -28,6 +28,6 @@ module.exports = function (queryObj) {
                     }
                 }
             }
-        });
+        }
     };
 };

--- a/lib/transforms/setHtmlImageDimensions.js
+++ b/lib/transforms/setHtmlImageDimensions.js
@@ -1,9 +1,8 @@
-const _ = require('lodash');
 const imageinfo = require('imageinfo');
 
 module.exports = queryObj => {
     return function setHtmlImageDimensions(assetGraph) {
-        for (const htmlImage of assetGraph.findRelations(_.extend({type: 'HtmlImage'}, queryObj))) {
+        for (const htmlImage of assetGraph.findRelations(Object.assign({type: 'HtmlImage'}, queryObj))) {
             if (!htmlImage.node.hasAttribute('height') && !htmlImage.node.hasAttribute('width')) {
                 if (htmlImage.to) {
                     if (htmlImage.to.type === 'Svg') {

--- a/lib/transforms/setSourceMapRoot.js
+++ b/lib/transforms/setSourceMapRoot.js
@@ -1,25 +1,25 @@
-var query = require('../query');
+const query = require('../query');
 
-module.exports = function (queryObj, root) {
-    var combinedQuery = {type: 'SourceMap'};
+module.exports = (queryObj, root) => {
+    let combinedQuery = { type: 'SourceMap' };
     if (queryObj) {
         combinedQuery = query.and(queryObj, combinedQuery);
     }
 
     return function setSourceMapRoot(assetGraph) {
-        assetGraph.findAssets(combinedQuery).forEach(function (mapFile) {
+        for (const sourceMap of assetGraph.findAssets(combinedQuery)) {
             if (root) {
-                mapFile.parseTree.sourceRoot = root;
+                sourceMap.parseTree.sourceRoot = root;
             } else {
-                delete mapFile.parseTree.sourceRoot;
+                delete sourceMap.parseTree.sourceRoot;
             }
-            assetGraph.findRelations({from: mapFile, type: 'SourceMapSource'}, true).forEach(function (sourceMapSource) {
+            for (const sourceMapSource of assetGraph.findRelations({from: sourceMap, type: 'SourceMapSource'}, true)) {
                 if (!sourceMapSource.to.isAsset) {
                     // Patch up target url of unpopulated relation
                     sourceMapSource.to.url = assetGraph.resolveUrl(sourceMapSource.baseUrl, sourceMapSource.href);
                 }
                 sourceMapSource.refreshHref();
-            });
-        });
+            }
+        }
     };
 };

--- a/lib/transforms/splitCssIfIeLimitIsReached.js
+++ b/lib/transforms/splitCssIfIeLimitIsReached.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const postcss = require('postcss');
 const Css = require('../assets/Css');
 
@@ -72,7 +71,7 @@ module.exports = (queryObj, options) => {
         if (rulesPerStylesheetLimit === Infinity) {
             return;
         }
-        for (const largeAsset of assetGraph.findAssets(_.extend({type: 'Css', isLoaded: true}, queryObj))) {
+        for (const largeAsset of assetGraph.findAssets(Object.assign({type: 'Css', isLoaded: true}, queryObj))) {
             const count = countRules(largeAsset.parseTree);
             let replacements;
 

--- a/lib/transforms/splitCssIfIeLimitIsReached.js
+++ b/lib/transforms/splitCssIfIeLimitIsReached.js
@@ -1,12 +1,12 @@
-var _ = require('lodash');
-var postcss = require('postcss');
-var Css = require('../assets/Css');
+const _ = require('lodash');
+const postcss = require('postcss');
+const Css = require('../assets/Css');
 
-module.exports = function (queryObj, options) {
+module.exports = (queryObj, options) => {
     options = options || {};
     // http://blogs.msdn.com/b/ieinternals/archive/2011/05/14/internet-explorer-stylesheet-rule-selector-import-sheet-limit-maximum.aspx
-    var minimumIeVersion = typeof options.minimumIeVersion === 'undefined' ? 1 : options.minimumIeVersion,
-        rulesPerStylesheetLimit = options.rulesPerStylesheetLimit;
+    const minimumIeVersion = typeof options.minimumIeVersion === 'undefined' ? 1 : options.minimumIeVersion;
+    let rulesPerStylesheetLimit = options.rulesPerStylesheetLimit;
 
     if (typeof rulesPerStylesheetLimit === 'undefined') {
         if (minimumIeVersion === null) {
@@ -19,7 +19,7 @@ module.exports = function (queryObj, options) {
     }
 
     function countRules(node) {
-        var count = 0;
+        let count = 0;
 
         if (node.selector) {
             count += node.selector.split(',').length;
@@ -27,21 +27,23 @@ module.exports = function (queryObj, options) {
 
         if (Array.isArray(node.nodes)) {
             // FIXME: Verify that this counting algorithm is identical to what IE does
-            node.nodes.forEach(function (childNode) {
+            for (const childNode of node.nodes) {
                 count += countRules(childNode);
-            });
+            }
         }
 
         return count;
     }
 
     function splitStyleSheet(cssAsset) {
-        var output = [],
-            accumulatedRules = 0,
-            offset = 0;
+        const output = [];
+        let accumulatedRules = 0;
+        let offset = 0;
 
-        cssAsset.parseTree.nodes.forEach(function (rule, idx) {
-            var selectors = countRules(rule);
+        const topLevelNodes = cssAsset.parseTree.nodes;
+        for (let i = 0 ; i < topLevelNodes.length ; i += 1) {
+            const rule = topLevelNodes[i];
+            const selectors = countRules(rule);
 
             if (accumulatedRules + selectors <= rulesPerStylesheetLimit) {
                 accumulatedRules += selectors;
@@ -49,13 +51,13 @@ module.exports = function (queryObj, options) {
                 output.push({
                     type: cssAsset.type,
                     isPopulated: false,
-                    parseTree: postcss.root().append(cssAsset.parseTree.nodes.slice(offset, idx).map(Css.cloneWithRaws))
+                    parseTree: postcss.root().append(cssAsset.parseTree.nodes.slice(offset, i).map(Css.cloneWithRaws))
                 });
 
-                offset = idx;
+                offset = i;
                 accumulatedRules = selectors;
             }
-        });
+        }
 
         output.push({
             type: cssAsset.type,
@@ -70,23 +72,24 @@ module.exports = function (queryObj, options) {
         if (rulesPerStylesheetLimit === Infinity) {
             return;
         }
-        assetGraph.findAssets(_.extend({type: 'Css', isLoaded: true}, queryObj)).forEach(function (largeAsset) {
-            var count = countRules(largeAsset.parseTree),
-                info,
-                replacements;
+        for (const largeAsset of assetGraph.findAssets(_.extend({type: 'Css', isLoaded: true}, queryObj))) {
+            const count = countRules(largeAsset.parseTree);
+            let replacements;
 
             if (count > rulesPerStylesheetLimit) {
                 replacements = splitStyleSheet(largeAsset);
-                info = new Error(count + ' CSS rules, ' + (count - rulesPerStylesheetLimit) + ' would be ignored by IE9 and below. Splitting into ' + replacements.length + ' chunks to resolve the problem.');
+                let info = new Error(
+                    `${count} CSS rules, ${count - rulesPerStylesheetLimit} would be ignored by IE9 and below. Splitting into ${replacements.length} chunks to resolve the problem.`
+                );
                 info.asset = largeAsset;
                 assetGraph.emit('info', info);
 
                 // Add replacement css assets to the graph
-                replacements = replacements.map(function (replacement, idx) {
-                    var asset = assetGraph.createAsset(replacement);
+                replacements = replacements.map((replacement, i) => {
+                    const asset = assetGraph.createAsset(replacement);
 
                     if (!largeAsset.isInline) {
-                        asset.url = require('url').resolve(largeAsset.url, largeAsset.fileName.split('.').shift() + '-' + idx + largeAsset.extension);
+                        asset.url = require('url').resolve(largeAsset.url, largeAsset.fileName.split('.').shift() + '-' + i + largeAsset.extension);
                     }
 
                     assetGraph.addAsset(asset);
@@ -95,21 +98,21 @@ module.exports = function (queryObj, options) {
                 });
 
                 // Add relations to new replacement assets to the graph
-                largeAsset.incomingRelations.forEach(function (oldRelation) {
-                    replacements.forEach(function (replacement) {
-                        var newIncomingRelation = new assetGraph[oldRelation.type]({
+                for (const oldRelation of largeAsset.incomingRelations) {
+                    for (const replacement of replacements) {
+                        const newIncomingRelation = new assetGraph[oldRelation.type]({
                             to: replacement
                         });
                         newIncomingRelation.attach(oldRelation.from, 'before', oldRelation);
                         if (replacement.isInline) {
                             newIncomingRelation.inline();
                         }
-                    });
-                });
+                    }
+                }
 
                 // Remove all traces of the oiginal to large Css asset
                 assetGraph.removeAsset(largeAsset, true);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/startOverIfAssetSourceFilesChange.js
+++ b/lib/transforms/startOverIfAssetSourceFilesChange.js
@@ -1,29 +1,28 @@
-var fs = require('fs'),
-    urlTools = require('urltools'),
-    query = require('../query');
+const fs = require('fs');
+const urlTools = require('urltools');
+const query = require('../query');
 
-module.exports = function (queryObj) {
-    var watchedFilesByName = {},
-        watchAssetMatcher = query.queryObjToMatcherFunction(queryObj),
-        transforms = [],
-        isFirstRun = true,
-        isIdle = false,
-        changedFilesByName = {};
+module.exports = queryObj => {
+    const watchedFilesByName = {};
+    const watchAssetMatcher = query.queryObjToMatcherFunction(queryObj);
+    const transforms = [];
+    let changedFilesByName = {};
+    let isFirstRun = true;
+    let isIdle = false;
 
     return function startOverIfAssetSourceFilesChange(assetGraph) {
-
         function rerunTransformsIfIdleAndFilesChanged() {
-            var changedFileNames = Object.keys(changedFilesByName);
+            const changedFileNames = Object.keys(changedFilesByName);
             if (isIdle && changedFileNames.length > 0) {
                 console.warn('----------------------------------\nrestartIfAssetSourceFilesChange: Source files changed:\n  ' + changedFileNames.join('\n  '));
                 isIdle = false;
                 changedFilesByName = {};
-                assetGraph.findRelations().forEach(function (relation) {
+                for (const relation of assetGraph.findRelations()) {
                     relation.from.removeRelation(relation);
-                });
-                assetGraph.findAssets().forEach(function (asset) {
+                }
+                for (const asset of assetGraph.findAssets()) {
                     assetGraph.removeAsset(asset);
-                });
+                }
                 assetGraph.queue(transforms).run();
             } else if (isIdle) {
                 console.warn('transforms.restartIfAssetSourceFilesChange: Waiting...');
@@ -32,10 +31,10 @@ module.exports = function (queryObj) {
 
         assetGraph.on('addAsset', function (asset) {
             if (asset.url && /^file:/.test(asset.url)) {
-                var fileName = urlTools.fileUrlToFsPath(asset.url);
+                const fileName = urlTools.fileUrlToFsPath(asset.url);
                 if (watchAssetMatcher(asset) && !watchedFilesByName[fileName]) {
                     watchedFilesByName[fileName] = true;
-                    fs.watchFile(fileName, function (currStat, prevStat) {
+                    fs.watchFile(fileName, (currStat, prevStat) => {
                         if (currStat.mtime.getTime() !== prevStat.mtime.getTime()) {
                             changedFilesByName[fileName] = true;
                             rerunTransformsIfIdleAndFilesChanged();

--- a/lib/transforms/startRepl.js
+++ b/lib/transforms/startRepl.js
@@ -1,6 +1,6 @@
-var Repl = require('repl');
-var Promise = require('bluebird');
-var open = require('open');
+const Repl = require('repl');
+const Promise = require('bluebird');
+const open = require('open');
 
 function quoteRegExpMetaChars(str) {
     return str.replace(/[\\\|\.\+\*\{\}\[\]\(\)\?\^\$]/g, '\\$&');
@@ -10,46 +10,46 @@ function htmlEncode(str) {
     return str.replace(/</g, '&lt;');
 }
 
-module.exports = function (options) {
+module.exports = options => {
     if (typeof options === 'string') {
-        options = {prompt: options};
+        options = { prompt: options };
     } else {
         options = options || {};
     }
-    return function startRepl(assetGraph) {
-        var repl = Repl.start({prompt: options.prompt || 'assetGraph> '});
+    return async function startRepl(assetGraph) {
+        const repl = Repl.start({prompt: options.prompt || 'assetGraph> '});
         repl.context.assetGraph = assetGraph;
-        var server;
+        let server;
         if (options.server) {
-            server = require('http').createServer(function (req, res) {
-                var foundAsset;
+            server = require('http').createServer((req, res) => {
+                let foundAsset;
                 if (/\/$/.test(req.url)) {
-                    var prefixUrl = assetGraph.root + req.url.substr(1);
+                    const prefixUrl = assetGraph.root + req.url.substr(1);
                     foundAsset = assetGraph.findAssets({url: prefixUrl + 'index.html'})[0];
                     if (!foundAsset) {
-                        var title = 'Index of ' + prefixUrl;
+                        const title = 'Index of ' + prefixUrl;
                         res.setHeader('Content-Type', 'text/html; charset=utf-8');
                         res.write('<!DOCTYPE html><html><head><title>' + htmlEncode(title) + '</title></head><body><h1>' + htmlEncode(title) + '</h1>');
-                        var assetsInDirectory = assetGraph.findAssets({url: new RegExp('^' + quoteRegExpMetaChars(prefixUrl))});
+                        const assetsInDirectory = assetGraph.findAssets({url: new RegExp('^' + quoteRegExpMetaChars(prefixUrl))});
                         if (assetsInDirectory.length > 0) {
-                            var isSubdirectoryByHref = {};
-                            var immediateChildren = [];
-                            assetsInDirectory.forEach(function (asset) {
-                                var relativeUrl = asset.url.replace(prefixUrl, '');
-                                var indexOfSlash = relativeUrl.indexOf('/');
+                            const isSubdirectoryByHref = {};
+                            const immediateChildren = [];
+                            for (const asset of assetsInDirectory) {
+                                const relativeUrl = asset.url.replace(prefixUrl, '');
+                                const indexOfSlash = relativeUrl.indexOf('/');
                                 if (indexOfSlash === -1) {
                                     immediateChildren.push(asset);
                                 } else {
                                     isSubdirectoryByHref[relativeUrl.substr(0, indexOfSlash)] = true;
                                 }
-                            });
+                            }
                             res.write('<ul>');
-                            Object.keys(isSubdirectoryByHref).forEach(function (subdirectoryHref) {
+                            for (const subdirectoryHref of Object.keys(isSubdirectoryByHref)) {
                                 res.write('<li><a href="' + htmlEncode(subdirectoryHref) + '/">' + htmlEncode(decodeURIComponent(subdirectoryHref)) + '</a></li>');
-                            });
-                            immediateChildren.forEach(function (asset) {
+                            }
+                            for (const asset of immediateChildren) {
                                 res.write('<li><a href="' + htmlEncode(asset.url.replace(prefixUrl, '')) + '">' + htmlEncode(decodeURIComponent(asset.url.replace(prefixUrl, ''))) + '</a></li>');
-                            });
+                            }
                             res.write('</ul>');
                         } else {
                             res.write('<h2>No entries found</h1>');
@@ -59,12 +59,12 @@ module.exports = function (options) {
                 }
                 foundAsset = foundAsset || assetGraph.findAssets({isLoaded: true, url: assetGraph.root + req.url.substr(1)})[0];
                 if (foundAsset) {
-                    var etag = '"' + foundAsset.md5Hex + '"';
+                    const etag = '"' + foundAsset.md5Hex + '"';
                     res.setHeader('ETag', etag);
                     res.setHeader('Content-Type', foundAsset.contentType);
-                    var rawSrc = foundAsset.rawSrc;
+                    const rawSrc = foundAsset.rawSrc;
                     res.setHeader('Content-Length', String(foundAsset.rawSrc.length));
-                    if (req.headers['if-none-match'] && req.headers['if-none-match'].indexOf(etag) !== -1) {
+                    if (req.headers['if-none-match'] && req.headers['if-none-match'].includes(etag)) {
                         res.writeHead(304);
                         res.end();
                     } else {
@@ -75,9 +75,9 @@ module.exports = function (options) {
                     res.end();
                 }
             });
-            server.listen(0, function () {
-                var url = 'http://localhost:' + server.address().port + '/';
-                var initialAssetsAtRoot = assetGraph.findAssets({ isInitial: true, isInline: false }).filter(function (initialAsset) {
+            server.listen(0, () => {
+                let url = 'http://localhost:' + server.address().port + '/';
+                const initialAssetsAtRoot = assetGraph.findAssets({ isInitial: true, isInline: false }).filter(initialAsset => {
                     return initialAsset.url.indexOf(assetGraph.root) === 0 && initialAsset.url.indexOf('/', assetGraph.root.length + 1) === -1;
                 });
                 if (initialAssetsAtRoot.length === 1) {
@@ -87,14 +87,16 @@ module.exports = function (options) {
             });
         }
 
-        return new Promise(function (resolve, reject) {
-            repl.on('error', function (err) {
-                assetGraph.emit('warn', err);
-            }).on('exit', resolve);
-        }).finally(function () {
+        try {
+            await new Promise(resolve => {
+                repl.on('error', function (err) {
+                    assetGraph.emit('warn', err);
+                }).on('exit', resolve);
+            });
+        } finally {
             if (server) {
                 server.close();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/stripDebug.js
+++ b/lib/transforms/stripDebug.js
@@ -1,20 +1,20 @@
-var _ = require('lodash');
-var estraverse = require('estraverse');
-var replaceDescendantNode = require('../replaceDescendantNode');
+const _ = require('lodash');
+const estraverse = require('estraverse');
+const replaceDescendantNode = require('../replaceDescendantNode');
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function stripDebug(assetGraph) {
-        assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj)).forEach(function (javaScript) {
-            var isInScopeByIdentifierName = {};
+        for (const javaScript of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
+            const isInScopeByIdentifierName = {};
             estraverse.traverse(javaScript.parseTree, {
-                enter: function (node, parentNode) {
+                enter(node, parentNode) {
                     if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration') {
-                        node.params.forEach(function (param) {
+                        for (const param of node.params) {
                             if (param.type === 'Identifier') {
                                 isInScopeByIdentifierName[param.name] = isInScopeByIdentifierName[param.name] || 0;
                                 isInScopeByIdentifierName[param.name] += 1;
                             }
-                        });
+                        }
                     } else if (node.type === 'ExpressionStatement' &&
                         node.expression.type === 'CallExpression' &&
                         node.expression.callee.type === 'MemberExpression' &&
@@ -27,17 +27,17 @@ module.exports = function (queryObj) {
                         replaceDescendantNode(parentNode, node, { type: 'EmptyStatement' });
                     }
                 },
-                leave: function (node) {
+                leave(node) {
                     if (node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration') {
-                        node.params.forEach(function (param) {
+                        for (const param of node.params) {
                             if (param.type === 'Identifier') {
                                 isInScopeByIdentifierName[param.name] = isInScopeByIdentifierName[param.name] || 0;
                                 isInScopeByIdentifierName[param.name] -= 1;
                             }
-                        });
+                        }
                     }
                 }
             });
-        });
+        }
     };
 };

--- a/lib/transforms/stripDebug.js
+++ b/lib/transforms/stripDebug.js
@@ -1,10 +1,9 @@
-const _ = require('lodash');
 const estraverse = require('estraverse');
 const replaceDescendantNode = require('../replaceDescendantNode');
 
 module.exports = queryObj => {
     return function stripDebug(assetGraph) {
-        for (const javaScript of assetGraph.findAssets(_.extend({type: 'JavaScript'}, queryObj))) {
+        for (const javaScript of assetGraph.findAssets(Object.assign({type: 'JavaScript'}, queryObj))) {
             const isInScopeByIdentifierName = {};
             estraverse.traverse(javaScript.parseTree, {
                 enter(node, parentNode) {

--- a/lib/transforms/updateAssets.js
+++ b/lib/transforms/updateAssets.js
@@ -1,6 +1,6 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj, properties, options) {
+module.exports = (queryObj, properties, options) => {
     if (typeof options === 'boolean') {
         options = { deep: options };
     } else {
@@ -8,7 +8,7 @@ module.exports = function (queryObj, properties, options) {
     }
 
     return function updateAssets(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(queryObj)) {
             if (options.deep) {
                 _.merge(asset, properties);
             } else {
@@ -17,6 +17,6 @@ module.exports = function (queryObj, properties, options) {
             if (properties.serializationOptions) {
                 asset.markDirty();
             }
-        });
+        }
     };
 };

--- a/lib/transforms/updateAssets.js
+++ b/lib/transforms/updateAssets.js
@@ -12,7 +12,7 @@ module.exports = (queryObj, properties, options) => {
             if (options.deep) {
                 _.merge(asset, properties);
             } else {
-                _.extend(asset, properties);
+                Object.assign(asset, properties);
             }
             if (properties.serializationOptions) {
                 asset.markDirty();

--- a/lib/transforms/updateRelations.js
+++ b/lib/transforms/updateRelations.js
@@ -1,6 +1,6 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
-module.exports = function (queryObj, properties, options) {
+module.exports = (queryObj, properties, options) => {
     if (typeof options === 'boolean') {
         options = { deep: options };
     } else {
@@ -8,12 +8,12 @@ module.exports = function (queryObj, properties, options) {
     }
 
     return function updateRelations(assetGraph) {
-        assetGraph.findRelations(queryObj, options.includeUnresolved).forEach(function (relation) {
+        for (const relation of assetGraph.findRelations(queryObj, options.includeUnresolved)) {
             if (options.deep) {
                 _.merge(relation, properties);
             } else {
                 _.extend(relation, properties);
             }
-        });
+        }
     };
 };

--- a/lib/transforms/updateRelations.js
+++ b/lib/transforms/updateRelations.js
@@ -12,7 +12,7 @@ module.exports = (queryObj, properties, options) => {
             if (options.deep) {
                 _.merge(relation, properties);
             } else {
-                _.extend(relation, properties);
+                Object.assign(relation, properties);
             }
         }
     };

--- a/lib/transforms/writeAssetsToDisc.js
+++ b/lib/transforms/writeAssetsToDisc.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const Promise = require('bluebird');
 const fs = Promise.promisifyAll(require('fs'));
 const Path = require('path');
@@ -25,7 +24,7 @@ module.exports = (queryObj, outRoot, root) => {
     }
 
     return async function writeAssetsToDisc(assetGraph) {
-        await Promise.map(assetGraph.findAssets(_.extend({isInline: false}, queryObj || {})), async asset => {
+        await Promise.map(assetGraph.findAssets(Object.assign({isInline: false}, queryObj || {})), async asset => {
             let targetUrl;
             let error;
 

--- a/lib/transforms/writeAssetsToDisc.js
+++ b/lib/transforms/writeAssetsToDisc.js
@@ -1,30 +1,33 @@
-var _ = require('lodash');
-var Promise = require('bluebird');
-var fs = Promise.promisifyAll(require('fs'));
-var Path = require('path');
-var constants = process.ENOENT ? process : require('constants');
-var mkdirpAsync = Promise.promisify(require('mkdirp'));
-var urlTools = require('urltools');
+const _ = require('lodash');
+const Promise = require('bluebird');
+const fs = Promise.promisifyAll(require('fs'));
+const Path = require('path');
+const constants = process.ENOENT ? process : require('constants');
+const mkdirpAsync = Promise.promisify(require('mkdirp'));
+const urlTools = require('urltools');
 
-function mkpathAndWriteFileAsync(fileName, contents, encoding) {
-    return fs.writeFileAsync(fileName, contents, encoding).caught(function (err) {
+async function mkpathAndWriteFileAsync(fileName, contents, encoding) {
+    try {
+        await fs.writeFileAsync(fileName, contents, encoding);
+    } catch (err) {
         if (err.code === 'ENOENT' || err.errno === constants.ENOENT) {
-            return mkdirpAsync(Path.dirname(fileName)).then(function () {
-                return fs.writeFileAsync(fileName, contents, encoding);
-            });
+            await mkdirpAsync(Path.dirname(fileName));
+            await fs.writeFileAsync(fileName, contents, encoding);
+        } else {
+            throw err;
         }
-    });
+    }
 }
 
-module.exports = function (queryObj, outRoot, root) {
+module.exports = (queryObj, outRoot, root) => {
     if (outRoot && outRoot.indexOf('file://') === -1) {
         outRoot = urlTools.fsDirToFileUrl(outRoot);
     }
 
-    return function writeAssetsToDisc(assetGraph) {
-        return Promise.map(assetGraph.findAssets(_.extend({isInline: false}, queryObj || {})), function (asset) {
-            var targetUrl,
-                error;
+    return async function writeAssetsToDisc(assetGraph) {
+        await Promise.map(assetGraph.findAssets(_.extend({isInline: false}, queryObj || {})), async asset => {
+            let targetUrl;
+            let error;
 
             if (outRoot) {
                 targetUrl = urlTools.resolveUrl(outRoot, urlTools.buildRelativeUrl(root || assetGraph.root, asset.url));
@@ -37,7 +40,7 @@ module.exports = function (queryObj, outRoot, root) {
                 error.asset = asset;
                 assetGraph.emit('error', error);
             } else {
-                return mkpathAndWriteFileAsync(urlTools.fileUrlToFsPath(targetUrl), asset.rawSrc, null);
+                await mkpathAndWriteFileAsync(urlTools.fileUrlToFsPath(targetUrl), asset.rawSrc, null);
             }
         }, {concurrency: 40});
     };

--- a/lib/transforms/writeAssetsToStdout.js
+++ b/lib/transforms/writeAssetsToStdout.js
@@ -1,7 +1,7 @@
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function writeAssetsToStdout(assetGraph) {
-        assetGraph.findAssets(queryObj).forEach(function (asset) {
+        for (const asset of assetGraph.findAssets(queryObj)) {
             process.stdout.write(asset.rawSrc);
-        });
+        }
     };
 };

--- a/lib/transforms/writeStatsToStderr.js
+++ b/lib/transforms/writeStatsToStderr.js
@@ -34,7 +34,7 @@ module.exports = queryObj => {
     return function writeStatsToStderr(assetGraph) {
         const countByDisplayType = {};
         const sumSizesByDisplayType = {};
-        const allLoadedAssets = assetGraph.findAssets(_.extend(queryObj || {}, {isInline: false, isLoaded: true}));
+        const allLoadedAssets = assetGraph.findAssets(Object.assign(queryObj || {}, {isInline: false, isLoaded: true}));
         let totalSize = 0;
 
         for (const asset of allLoadedAssets) {

--- a/lib/transforms/writeStatsToStderr.js
+++ b/lib/transforms/writeStatsToStderr.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+const _ = require('lodash');
 
 function renderFileSize(numBytes) {
     if (numBytes < 1000) {
@@ -30,45 +30,48 @@ function rightPad(str, width) {
     return str;
 }
 
-module.exports = function (queryObj) {
+module.exports = queryObj => {
     return function writeStatsToStderr(assetGraph) {
-        var totalSize = 0,
-            countByDisplayType = {},
-            sumSizesByDisplayType = {},
-            allLoadedAssets = assetGraph.findAssets(_.extend(queryObj || {}, {isInline: false, isLoaded: true}));
+        const countByDisplayType = {};
+        const sumSizesByDisplayType = {};
+        const allLoadedAssets = assetGraph.findAssets(_.extend(queryObj || {}, {isInline: false, isLoaded: true}));
+        let totalSize = 0;
 
-        allLoadedAssets.forEach(function (asset) {
-            var displayType = asset.type;
+        for (const asset of allLoadedAssets) {
+            let displayType = asset.type;
             if (displayType === 'Asset' && asset.extension) {
                 displayType = asset.extension;
             }
-            var size = asset.rawSrc.length;
+            const size = asset.rawSrc.length;
             totalSize += size;
             sumSizesByDisplayType[displayType] = (sumSizesByDisplayType[displayType] || 0) + size;
             countByDisplayType[displayType] = (countByDisplayType[displayType] || 0) + 1;
-        });
-        var rows = [],
-            columnWidths = [];
+        }
+        const rows = [];
+        const columnWidths = [];
 
-        function addRow() { // ...
-            var row = _.flatten(arguments);
-            row.forEach(function (column, i) {
-                if (!columnWidths[i] || column.toString().length > columnWidths[i]) {
-                    columnWidths[i] = column.toString().length;
+        function addRow(...args) {
+            const row = _.flatten(args);
+            for (let i = 0 ; i < row.length ; i += 1) {
+                const column = row[i];
+                const length = column.toString().length;
+                if (!columnWidths[i] || length > columnWidths[i]) {
+                    columnWidths[i] = length;
                 }
-            });
+            }
             rows.push(row);
         }
 
-        _.each(countByDisplayType, function (count, type) {
-            addRow(type, count, renderFileSize(sumSizesByDisplayType[type]).split(' '));
-        });
+        for (const displayType of Object.keys(countByDisplayType)) {
+            const count = countByDisplayType[displayType];
+            addRow(displayType, count, renderFileSize(sumSizesByDisplayType[displayType]).split(' '));
+        }
         addRow('Total:', allLoadedAssets.length, renderFileSize(totalSize).split(' '));
 
-        rows.forEach(function (row) {
-            console.warn(row.map(function (column, i) {
+        for (const row of rows) {
+            console.warn(row.map((column, i) => {
                 return (i === 3 ? rightPad : leftPad)(column, columnWidths[i]);
             }).join(' '));
-        });
+        }
     };
 };

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "file-loader": "^0.11.0",
     "httpception": "^0.5.0",
     "iconv-lite": "^0.4.15",
-    "istanbul": "^0.4.1",
     "less": "2.7.2",
     "mocha": "^3.0.0",
+    "nyc": "11.0.2",
     "open": "^0.0.5",
     "requirejs": "^2.3.3",
     "sinon": "^2.0.0",
@@ -88,6 +88,11 @@
     "lint": "eslint .",
     "test": "npm run lint && mocha",
     "travis": "npm run lint && npm run coverage",
-    "coverage": "NODE_ENV=development ./node_modules/.bin/istanbul cover -x '**/examples/**' -x '**/testdata/**' --include-all-sources ./node_modules/mocha/bin/_mocha -- --reporter dot && echo google-chrome coverage/lcov-report/index.html"
+    "coverage": "NODE_ENV=test nyc --reporter=lcov --reporter=text --all -- mocha --reporter dot && echo google-chrome coverage/lcov-report/index.html"
+  },
+  "nyc": {
+    "include": [
+      "lib/**"
+    ]
   }
 }

--- a/test/transforms/addDataVersionAttributeToHtmlElement.js
+++ b/test/transforms/addDataVersionAttributeToHtmlElement.js
@@ -1,0 +1,41 @@
+/*global describe, it*/
+const expect = require('../unexpected-with-plugins');
+const AssetGraph = require('../../lib/AssetGraph');
+
+describe('transforms/addDataVersionAttributeToHtmlElement', function () {
+    it('should add the specified data-version tag', function () {
+        return new AssetGraph()
+            .queue(assetGraph => {
+                assetGraph.addAsset(new AssetGraph.Html({
+                    url: 'http://example.com/index.html',
+                    text: '<!DOCTYPE html><html><head></head><body></body></html>'
+                }));
+            })
+            .addDataVersionAttributeToHtmlElement({type: 'Html'}, 'theDataVersionTag')
+            .queue(assetGraph => {
+                expect(
+                    assetGraph.findAssets({url: 'http://example.com/index.html'})[0].text,
+                    'to contain',
+                    '<!DOCTYPE html><html data-version="theDataVersionTag"><head></head><body></body></html>'
+                );
+            });
+    });
+
+    it('should use git-describe to retrieve a suitable version tag if none is given', function () {
+        return new AssetGraph()
+            .queue(assetGraph => {
+                assetGraph.addAsset(new AssetGraph.Html({
+                    url: 'http://example.com/index.html',
+                    text: '<!DOCTYPE html><html><head></head><body></body></html>'
+                }));
+            })
+            .addDataVersionAttributeToHtmlElement({type: 'Html'})
+            .queue(assetGraph => {
+                expect(
+                    assetGraph.findAssets({url: 'http://example.com/index.html'})[0].text,
+                    'to contain',
+                    '<!DOCTYPE html><html data-version="v'
+                );
+            });
+    });
+});


### PR DESCRIPTION
I did a sweep through all the transforms (except `loadAssets` and `populate` which are involved in another plan). The changes include:

* `for ... of` instead of `forEach`
* `const`/`let` instead of `var`, changed style to one per line
* arrow functions
* a little bit of destructuring when I noticed it
* `async`/`await`
* template strings

In other words, I move that we drop support for node.js < 8 in the next major release.