### PR TITLE
Support media queries, media attributes, @import media lists, and filter out impossible combinations

### DIFF
--- a/lib/relations/HtmlStyle.js
+++ b/lib/relations/HtmlStyle.js
@@ -36,6 +36,23 @@ extendWithGettersAndSetters(HtmlStyle.prototype, {
         }
     },
 
+    get media() {
+        var media = this.node.getAttribute('media');
+        if (media) {
+            return media.trim();
+        }
+    },
+
+    set media(media) {
+        if (media) {
+            this.node.setAttribute('media', media.trim());
+            this.from.markDirty();
+        } else if (this.node.hasAttribute('media')) {
+            this.from.markDirty();
+            this.node.removeAttribute('media');
+        }
+    },
+
     inline: function () {
         Relation.prototype.inline.call(this);
         if (this.node.nodeName.toLowerCase() === 'style') {

--- a/lib/util/fonts/gatherStylesheetsWithIncomingMedia.js
+++ b/lib/util/fonts/gatherStylesheetsWithIncomingMedia.js
@@ -1,0 +1,30 @@
+module.exports = function gatherStylesheetsWithIncomingMedia(assetGraph, htmlAsset) {
+    var assetStack = [];
+    var incomingMedia = [];
+    var result = [];
+    (function traverse(asset) {
+        if (assetStack.includes(asset)) {
+            // Cycle detected
+            return;
+        } else if (!asset.isLoaded) {
+            return;
+        }
+        assetStack.push(asset);
+        assetGraph.findRelations({ from: asset, type: ['HtmlStyle', 'CssImport']}).forEach(function (relation) {
+            var media = relation.media;
+            if (media) {
+                incomingMedia.push(media);
+            }
+            traverse(relation.to);
+            if (media) {
+                incomingMedia.pop();
+            }
+        });
+        assetStack.pop();
+        if (asset.type === 'Css') {
+            result.push({ text: asset.text, incomingMedia: [].concat(incomingMedia)});
+        }
+    }(htmlAsset));
+
+    return result;
+};

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -12,17 +12,26 @@ var INITIAL_VALUES = {
 var SUPPORTED_SHORTHANDS = ['font'];
 
 function eachDeclarationInParseTree(ruleOrStylesheet, lambda) {
-    ruleOrStylesheet.nodes.forEach(function (node) {
+    var mediaStack = [];
+    (function visit(node) {
         // Check for selector. We might be in an at-rule like @font-face
         if (node.type === 'decl' && node.parent.selector) {
-            lambda(node);
+            lambda(node, mediaStack);
         }
 
         // TODO: Filter by media type if it's an @media block?
         if (node.nodes) {
-            eachDeclarationInParseTree(node, lambda);
+            if (node.name === 'media') {
+                mediaStack.push(node.params);
+            }
+            node.nodes.forEach(function (childNode) {
+                visit(childNode);
+            });
+            if (node.name === 'media') {
+                mediaStack.pop();
+            }
         }
-    });
+    }(ruleOrStylesheet));
 }
 
 function getCssRulesByProperty(properties, cssSource) {
@@ -42,7 +51,7 @@ function getCssRulesByProperty(properties, cssSource) {
         rulesByProperty[property] = [];
     });
 
-    eachDeclarationInParseTree(parseTree, function (node) {
+    eachDeclarationInParseTree(parseTree, function (node, mediaStack) {
         if (properties.includes(node.prop)) {
             // Split up combined selectors as they might have different specificity
             specificity.calculate(node.parent.selector)
@@ -50,6 +59,7 @@ function getCssRulesByProperty(properties, cssSource) {
                     var isStyleAttribute = specificityObject.selector === 'bogusselector';
 
                     rulesByProperty[node.prop].push({
+                        mediaStack: [].concat(mediaStack),
                         selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
                         specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
                         prop: node.prop,
@@ -88,6 +98,7 @@ function getCssRulesByProperty(properties, cssSource) {
 
                             if (Array.isArray(rulesByProperty[prop])) {
                                 rulesByProperty[prop].push({
+                                    mediaStack: [],
                                     selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
                                     specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
                                     prop: prop,

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -12,35 +12,39 @@ var INITIAL_VALUES = {
 var SUPPORTED_SHORTHANDS = ['font'];
 
 function eachDeclarationInParseTree(ruleOrStylesheet, lambda) {
-    var mediaStack = [];
+    var mediaQuery;
     (function visit(node) {
         // Check for selector. We might be in an at-rule like @font-face
         if (node.type === 'decl' && node.parent.selector) {
-            lambda(node, mediaStack);
+            lambda(node, mediaQuery);
         }
 
-        // TODO: Filter by media type if it's an @media block?
         if (node.nodes) {
             if (node.name === 'media') {
-                mediaStack.push(node.params);
+                if (typeof mediaQuery !== 'undefined') {
+                    throw new Error('Nested media queries are not supported');
+                }
+                mediaQuery = node.params;
             }
             node.nodes.forEach(function (childNode) {
                 visit(childNode);
             });
             if (node.name === 'media') {
-                mediaStack.pop();
+                mediaQuery = undefined;
             }
         }
     }(ruleOrStylesheet));
 }
 
-function getCssRulesByProperty(properties, cssSource) {
+function getCssRulesByProperty(properties, cssSource, incomingMedia) {
     if (!Array.isArray(properties)) {
         throw new Error('properties argument must be an array');
     }
-
     if (typeof cssSource !== 'string') {
         throw new Error('cssSource argument must be a string containing valid CSS');
+    }
+    if (!Array.isArray(incomingMedia)) {
+        throw new Error('incomingMedia argument must be an array');
     }
 
     var parseTree = postcss.parse(cssSource);
@@ -51,7 +55,7 @@ function getCssRulesByProperty(properties, cssSource) {
         rulesByProperty[property] = [];
     });
 
-    eachDeclarationInParseTree(parseTree, function (node, mediaStack) {
+    eachDeclarationInParseTree(parseTree, function (node, mediaQuery) {
         if (properties.includes(node.prop)) {
             // Split up combined selectors as they might have different specificity
             specificity.calculate(node.parent.selector)
@@ -59,7 +63,8 @@ function getCssRulesByProperty(properties, cssSource) {
                     var isStyleAttribute = specificityObject.selector === 'bogusselector';
 
                     rulesByProperty[node.prop].push({
-                        mediaStack: [].concat(mediaStack),
+                        incomingMedia: incomingMedia,
+                        mediaQuery: mediaQuery,
                         selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
                         specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
                         prop: node.prop,
@@ -98,7 +103,7 @@ function getCssRulesByProperty(properties, cssSource) {
 
                             if (Array.isArray(rulesByProperty[prop])) {
                                 rulesByProperty[prop].push({
-                                    mediaStack: [],
+                                    incomingMedia: [],
                                     selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
                                     specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
                                     prop: prop,

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -117,8 +117,8 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
     var nonInheritingTags = ['BUTTON', 'INPUT', 'OPTION', 'TEXTAREA'];
 
     var getComputedStyle = memoizeSync(function (node, idArray, truePredicates, falsePredicates) {
-        truePredicates = truePredicates || [];
-        falsePredicates = falsePredicates || [];
+        truePredicates = truePredicates || {};
+        falsePredicates = falsePredicates || {};
         var localFontPropRules = Object.assign({}, fontPropRules);
         var props = Object.keys(fontPropRules);
         var result = {};
@@ -148,7 +148,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
             for (var i = startIndex; i < localFontPropRules[prop].length; i += 1) {
                 var declaration = localFontPropRules[prop][i];
                 // Skip to the next rule if we are doing a trace where one of the incoming media attributes are already assumed false:
-                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates.includes(incomingMedia); })) {
+                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates[incomingMedia]; })) {
                     continue;
                 }
 
@@ -206,13 +206,9 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                             if (Object.keys(predicatePermutation).length === 0) {
                                 return;
                             }
-                            var recursiveTruePredicates = [].concat(truePredicates);
-                            var recursiveFalsePredicates = [].concat(falsePredicates);
-                            Object.keys(predicatePermutation).forEach(function (predicate) {
-                                recursiveTruePredicates.push(predicate);
-                                recursiveFalsePredicates.push(predicate);
-                            });
-                            if (declaration.incomingMedia.every(function (incomingMedia) { return recursiveTruePredicates.includes(incomingMedia); })) {
+                            var recursiveTruePredicates = Object.assign({}, truePredicates, predicatePermutation);
+                            var recursiveFalsePredicates = Object.assign({}, falsePredicates, predicatePermutation);
+                            if (declaration.incomingMedia.every(function (incomingMedia) { return recursiveTruePredicates[incomingMedia]; })) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
                                     hypotheticalValues.map(function (hypotheticalValue) {
@@ -250,20 +246,11 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
         return result;
     }, {
         argumentsStringifier: function (args) {
-            var stringifiedArguments = args[1].join(',');
-            if (args[2]) {
-                stringifiedArguments += '\x1e';
-                args[2].forEach(function (assumption) {
-                    stringifiedArguments += assumption + '\x1d';
-                });
-            }
-            if (args[3]) {
-                stringifiedArguments += '\x1e';
-                args[3].forEach(function (assumption) {
-                    stringifiedArguments += assumption + '\x1d';
-                });
-            }
-            return stringifiedArguments;
+            return (
+                args[1].join(',') + '\x1e' +
+                (args[2] ? Object.keys(args[2]).join('\x1d') : '') + '\x1e' +
+                (args[3] ? Object.keys(args[3]).join('\x1d') : '')
+            );
         }
     });
 
@@ -416,14 +403,14 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
         var seenPermutationByKey = {};
         expandPermutations(styledText)
             .filter(function (hypotheticalValuesByProp) {
-                var allTruePredicates = [];
-                var allFalsePredicates = [];
+                var allTruePredicates = {};
+                var allFalsePredicates = {};
                 FONT_PROPS.forEach(function (prop) {
-                    Array.prototype.push.apply(allTruePredicates, hypotheticalValuesByProp[prop].truePredicates);
-                    Array.prototype.push.apply(allFalsePredicates, hypotheticalValuesByProp[prop].falsePredicates);
+                    Object.assign(allTruePredicates, hypotheticalValuesByProp[prop].truePredicates);
+                    Object.assign(allFalsePredicates, hypotheticalValuesByProp[prop].falsePredicates);
                 });
-                return allTruePredicates.every(function (truePredicate) {
-                    return !allFalsePredicates.includes(truePredicate);
+                return Object.keys(allTruePredicates).every(function (truePredicate) {
+                    return !allFalsePredicates[truePredicate];
                 });
             })
             .forEach(function (hypotheticalValuesByProp) {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -403,14 +403,13 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
         var seenPermutationByKey = {};
         expandPermutations(styledText)
             .filter(function (hypotheticalValuesByProp) {
-                var allTruePredicates = {};
-                var allFalsePredicates = {};
-                FONT_PROPS.forEach(function (prop) {
-                    Object.assign(allTruePredicates, hypotheticalValuesByProp[prop].truePredicates);
-                    Object.assign(allFalsePredicates, hypotheticalValuesByProp[prop].falsePredicates);
-                });
-                return Object.keys(allTruePredicates).every(function (truePredicate) {
-                    return !allFalsePredicates[truePredicate];
+                // Check that none of the predicates assumed true are assumed false, too:
+                return FONT_PROPS.every(function (prop) {
+                    return Object.keys(hypotheticalValuesByProp[prop].truePredicates).every(function (truePredicate) {
+                        return FONT_PROPS.every(function (otherProp) {
+                            return !hypotheticalValuesByProp[otherProp].falsePredicates[truePredicate];
+                        });
+                    });
                 });
             })
             .forEach(function (hypotheticalValuesByProp) {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -1,4 +1,3 @@
-/*global Set*/
 var _ = require('lodash');
 var getCssRulesByProperty = require('./getCssRulesByProperty');
 var defaultStylesheet = require('./defaultStylesheet');
@@ -118,8 +117,8 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
     var nonInheritingTags = ['BUTTON', 'INPUT', 'OPTION', 'TEXTAREA'];
 
     var getComputedStyle = memoizeSync(function (node, idArray, truePredicates, falsePredicates) {
-        truePredicates = truePredicates || new Set();
-        falsePredicates = falsePredicates || new Set();
+        truePredicates = truePredicates || [];
+        falsePredicates = falsePredicates || [];
         var localFontPropRules = Object.assign({}, fontPropRules);
         var props = Object.keys(fontPropRules);
         var result = {};
@@ -149,7 +148,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
             for (var i = startIndex; i < localFontPropRules[prop].length; i += 1) {
                 var declaration = localFontPropRules[prop][i];
                 // Skip to the next rule if we are doing a trace where one of the incoming media attributes are already assumed false:
-                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates.has(incomingMedia); })) {
+                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates.includes(incomingMedia); })) {
                     continue;
                 }
 
@@ -207,15 +206,13 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                             if (Object.keys(predicatePermutation).length === 0) {
                                 return;
                             }
-                            var recursiveTruePredicates = new Set(truePredicates);
-                            var recursiveFalsePredicates = new Set(falsePredicates);
+                            var recursiveTruePredicates = [].concat(truePredicates);
+                            var recursiveFalsePredicates = [].concat(falsePredicates);
                             Object.keys(predicatePermutation).forEach(function (predicate) {
-                                if (predicatePermutation[predicate]) {
-                                    recursiveTruePredicates.add(predicate);
-                                    recursiveFalsePredicates.add(predicate);
-                                }
+                                recursiveTruePredicates.push(predicate);
+                                recursiveFalsePredicates.push(predicate);
                             });
-                            if (declaration.incomingMedia.every(function (incomingMedia) { return recursiveTruePredicates.has(incomingMedia); })) {
+                            if (declaration.incomingMedia.every(function (incomingMedia) { return recursiveTruePredicates.includes(incomingMedia); })) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
                                     hypotheticalValues.map(function (hypotheticalValue) {
@@ -419,27 +416,15 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
         var seenPermutationByKey = {};
         expandPermutations(styledText)
             .filter(function (hypotheticalValuesByProp) {
-                var allTruePredicates = new Set();
-                var allFalsePredicates = new Set();
+                var allTruePredicates = [];
+                var allFalsePredicates = [];
                 FONT_PROPS.forEach(function (prop) {
-                    hypotheticalValuesByProp[prop].truePredicates.forEach(function (value) {
-                        allTruePredicates.add(value);
-                    });
-                    hypotheticalValuesByProp[prop].falsePredicates.forEach(function (value) {
-                        allFalsePredicates.add(value);
-                    });
+                    Array.prototype.push.apply(allTruePredicates, hypotheticalValuesByProp[prop].truePredicates);
+                    Array.prototype.push.apply(allFalsePredicates, hypotheticalValuesByProp[prop].falsePredicates);
                 });
-                // This will be nicer with for...of and destructuring:
-                var allTruePredicatesIterator = allTruePredicates.values();
-                var done = false;
-                while (!done) {
-                    var next = allTruePredicatesIterator.next();
-                    done = next.done;
-                    if (!done && allFalsePredicates.has(next.value)) {
-                        return false;
-                    }
-                }
-                return true;
+                return allTruePredicates.every(function (truePredicate) {
+                    return !allFalsePredicates.includes(truePredicate);
+                });
             })
             .forEach(function (hypotheticalValuesByProp) {
                 // Unwrap the "hypothetical value" objects:

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -9,6 +9,7 @@ var cssFontWeightNames = require('css-font-weight-names');
 var cssPseudoElementRegExp = require('../cssPseudoElementRegExp');
 var getPseudoElements = require('./getPseudoElements');
 var stripPseudoClassesFromSelector = require('./stripPseudoClassesFromSelector');
+var gatherStylesheetsWithIncomingMedia = require('./gatherStylesheetsWithIncomingMedia');
 
 var FONT_PROPS = [
     'font-family',
@@ -65,17 +66,9 @@ function getNodeIdArray(node) {
 }
 
 function getFontRulesWithDefaultStylesheetApplied(htmlAsset) {
-    var stylesheets = htmlAsset.assetGraph.collectAssetsPreOrder(htmlAsset)
-        .filter(function (asset) { return asset.isLoaded; })
-        .filter(function (asset) {
-            return asset.type === 'Css'
-                && asset.isExternalizable === true; // exclude inline style attributes
-        })
-        .map(function (asset) { return asset.text; });
-
-    var fontPropRules = [defaultStylesheet].concat(stylesheets)
-        .map(function (stylesheet) {
-            return getCssRulesByProperty(FONT_PROPS, stylesheet);
+    var fontPropRules = [{ text: defaultStylesheet, incomingMedia: [] }].concat(gatherStylesheetsWithIncomingMedia(htmlAsset.assetGraph, htmlAsset))
+        .map(function (stylesheetAndIncomingMedia) {
+            return getCssRulesByProperty(FONT_PROPS, stylesheetAndIncomingMedia.text, stylesheetAndIncomingMedia.incomingMedia);
         })
         .reduce(function (rules, current) {
             // Input:
@@ -140,7 +133,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
         }
 
         if (node.getAttribute('style')) {
-            var attributeStyles = getCssRulesByProperty(FONT_PROPS, 'bogusselector { ' + node.getAttribute('style') + ' }');
+            var attributeStyles = getCssRulesByProperty(FONT_PROPS, 'bogusselector { ' + node.getAttribute('style') + ' }', []);
 
             Object.keys(attributeStyles).forEach(function (prop) {
                 if (attributeStyles[prop].length > 0) {
@@ -155,6 +148,10 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
 
             for (var i = startIndex; i < localFontPropRules[prop].length; i += 1) {
                 var declaration = localFontPropRules[prop][i];
+                // Skip to the next rule if we are doing a trace where one of the incoming media attributes are already assumed false:
+                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates.has(incomingMedia); })) {
+                    continue;
+                }
 
                 // Style attributes always have a specificity array of [1, 0, 0, 0]
                 var isStyleAttribute = declaration.specificityArray[0] === 1;
@@ -196,10 +193,14 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                         hypotheticalValues = [ { value: value, truePredicates: truePredicates, falsePredicates: falsePredicates } ];
                     }
 
-                    var predicatesToVary = [].concat(declaration.mediaStack);
+                    var predicatesToVary = [];
                     if (!isStyleAttribute && selectorWithoutPseudoClasses !== declaration.selector) {
                         predicatesToVary.push(declaration.selector);
                     }
+                    if (declaration.mediaQuery) {
+                        predicatesToVary.push(declaration.mediaQuery);
+                    }
+                    Array.prototype.push.apply(predicatesToVary, declaration.incomingMedia);
                     if (predicatesToVary.length > 0) {
                         var multipliedHypotheticalValues = [];
                         createPredicatePermutations(predicatesToVary).forEach(function (predicatePermutation) {
@@ -227,17 +228,18 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                             if (hasPredicateThatIsAlreadyAssumedFalse) {
                                 return;
                             }
-
-                            Array.prototype.push.apply(
-                                multipliedHypotheticalValues,
-                                hypotheticalValues.map(function (hypotheticalValue) {
-                                    return {
-                                        value: hypotheticalValue.value,
-                                        truePredicates: recursiveTruePredicates,
-                                        falsePredicates: falsePredicates
-                                    };
-                                })
-                            );
+                            if (declaration.incomingMedia.every(function (incomingMedia) { return recursiveTruePredicates.has(incomingMedia); })) {
+                                Array.prototype.push.apply(
+                                    multipliedHypotheticalValues,
+                                    hypotheticalValues.map(function (hypotheticalValue) {
+                                        return {
+                                            value: hypotheticalValue.value,
+                                            truePredicates: recursiveTruePredicates,
+                                            falsePredicates: falsePredicates
+                                        };
+                                    })
+                                );
+                            }
                             if (someThatWereNotAlreadyTrue) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
@@ -428,11 +430,13 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
     }
 
     var multipliedStyledTexts = _.flatten(styledTexts.map(function (styledText) {
-        return expandPermutations(styledText)
+        var deduplicatedExpandedPermutations = [];
+        var seenPermutationByKey = {};
+        expandPermutations(styledText)
             .filter(function (hypotheticalValuesByProp) {
                 var allTruePredicates = new Set();
                 var allFalsePredicates = new Set();
-                Object.keys(hypotheticalValuesByProp).forEach(function (prop) {
+                FONT_PROPS.forEach(function (prop) {
                     hypotheticalValuesByProp[prop].truePredicates.forEach(function (value) {
                         allTruePredicates.add(value);
                     });
@@ -452,17 +456,24 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
                 }
                 return true;
             })
-            .map(function (hypotheticalValuesByProp) {
+            .forEach(function (hypotheticalValuesByProp) {
                 // Unwrap the "hypothetical value" objects:
+                var permutationKey = '';
                 var props = {};
-                Object.keys(hypotheticalValuesByProp).forEach(function (prop) {
+                FONT_PROPS.forEach(function (prop) {
+                    permutationKey += prop + '\x1d' + hypotheticalValuesByProp[prop].value + '\x1d';
                     props[prop] = hypotheticalValuesByProp[prop].value;
                 });
-                return {
-                    text: styledText.text,
-                    props: props
-                };
+                // Deduplicate:
+                if (!seenPermutationByKey[permutationKey]) {
+                    seenPermutationByKey[permutationKey] = true;
+                    deduplicatedExpandedPermutations.push({
+                        text: styledText.text,
+                        props: props
+                    });
+                }
             });
+        return deduplicatedExpandedPermutations;
     }));
 
     // multipliedStyledTexts After:

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -148,7 +148,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
             for (var i = startIndex; i < localFontPropRules[prop].length; i += 1) {
                 var declaration = localFontPropRules[prop][i];
                 // Skip to the next rule if we are doing a trace where one of the incoming media attributes are already assumed false:
-                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates[incomingMedia]; })) {
+                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates['incomingMedia:' + incomingMedia]; })) {
                     continue;
                 }
 
@@ -194,12 +194,14 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
 
                     var predicatesToVary = [];
                     if (!isStyleAttribute && selectorWithoutPseudoClasses !== declaration.selector) {
-                        predicatesToVary.push(declaration.selector);
+                        predicatesToVary.push('selectorWithPseudoClasses:' + declaration.selector);
                     }
                     if (declaration.mediaQuery) {
-                        predicatesToVary.push(declaration.mediaQuery);
+                        predicatesToVary.push('mediaQuery:' + declaration.mediaQuery);
                     }
-                    Array.prototype.push.apply(predicatesToVary, declaration.incomingMedia);
+                    Array.prototype.push.apply(predicatesToVary, declaration.incomingMedia.map(function (incomingMedia) {
+                        return 'incomingMedia:' + incomingMedia;
+                    }));
                     if (predicatesToVary.length > 0) {
                         var multipliedHypotheticalValues = [];
                         createPredicatePermutations(predicatesToVary).forEach(function (predicatePermutation) {
@@ -207,7 +209,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                                 return;
                             }
                             var truePredicatesForThisPermutation = Object.assign({}, truePredicates, predicatePermutation);
-                            if (declaration.incomingMedia.every(function (incomingMedia) { return truePredicatesForThisPermutation[incomingMedia]; })) {
+                            if (declaration.incomingMedia.every(function (incomingMedia) { return truePredicatesForThisPermutation['incomingMedia:' + incomingMedia]; })) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
                                     hypotheticalValues.map(function (hypotheticalValue) {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -206,15 +206,14 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                             if (Object.keys(predicatePermutation).length === 0) {
                                 return;
                             }
-                            var recursiveTruePredicates = Object.assign({}, truePredicates, predicatePermutation);
-                            var recursiveFalsePredicates = Object.assign({}, falsePredicates, predicatePermutation);
-                            if (declaration.incomingMedia.every(function (incomingMedia) { return recursiveTruePredicates[incomingMedia]; })) {
+                            var truePredicatesForThisPermutation = Object.assign({}, truePredicates, predicatePermutation);
+                            if (declaration.incomingMedia.every(function (incomingMedia) { return truePredicatesForThisPermutation[incomingMedia]; })) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
                                     hypotheticalValues.map(function (hypotheticalValue) {
                                         return {
                                             value: hypotheticalValue.value,
-                                            truePredicates: recursiveTruePredicates,
+                                            truePredicates: truePredicatesForThisPermutation,
                                             falsePredicates: falsePredicates
                                         };
                                     })
@@ -222,7 +221,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                             }
                             Array.prototype.push.apply(
                                 multipliedHypotheticalValues,
-                                traceProp(prop, i + 1, truePredicates, recursiveFalsePredicates)
+                                traceProp(prop, i + 1, truePredicates, Object.assign({}, falsePredicates, predicatePermutation))
                             );
                         });
                         return multipliedHypotheticalValues;

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -207,27 +207,14 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                             if (Object.keys(predicatePermutation).length === 0) {
                                 return;
                             }
-                            var hasPredicateThatIsAlreadyAssumedFalse = false;
-
                             var recursiveTruePredicates = new Set(truePredicates);
                             var recursiveFalsePredicates = new Set(falsePredicates);
-                            var someThatWereNotAlreadyTrue = false;
                             Object.keys(predicatePermutation).forEach(function (predicate) {
                                 if (predicatePermutation[predicate]) {
-                                    if (!truePredicates.has(predicate)) {
-                                        recursiveTruePredicates.add(predicate);
-                                        someThatWereNotAlreadyTrue = true;
-                                    }
-                                    if (falsePredicates.has(predicate)) {
-                                        hasPredicateThatIsAlreadyAssumedFalse = true;
-                                    } else {
-                                        recursiveFalsePredicates.add(predicate);
-                                    }
+                                    recursiveTruePredicates.add(predicate);
+                                    recursiveFalsePredicates.add(predicate);
                                 }
                             });
-                            if (hasPredicateThatIsAlreadyAssumedFalse) {
-                                return;
-                            }
                             if (declaration.incomingMedia.every(function (incomingMedia) { return recursiveTruePredicates.has(incomingMedia); })) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
@@ -240,12 +227,10 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                                     })
                                 );
                             }
-                            if (someThatWereNotAlreadyTrue) {
-                                Array.prototype.push.apply(
-                                    multipliedHypotheticalValues,
-                                    traceProp(prop, i + 1, truePredicates, recursiveFalsePredicates)
-                                );
-                            }
+                            Array.prototype.push.apply(
+                                multipliedHypotheticalValues,
+                                traceProp(prop, i + 1, truePredicates, recursiveFalsePredicates)
+                            );
                         });
                         return multipliedHypotheticalValues;
                     } else {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -1,3 +1,4 @@
+/*global Set*/
 var _ = require('lodash');
 var getCssRulesByProperty = require('./getCssRulesByProperty');
 var defaultStylesheet = require('./defaultStylesheet');
@@ -106,7 +107,9 @@ function getFontRulesWithDefaultStylesheetApplied(htmlAsset) {
 function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
     var nonInheritingTags = ['BUTTON', 'INPUT', 'OPTION', 'TEXTAREA'];
 
-    var getComputedStyle = memoizeSync(function (node, idArray) {
+    var getComputedStyle = memoizeSync(function (node, idArray, truePredicates, falsePredicates) {
+        truePredicates = truePredicates || new Set();
+        falsePredicates = falsePredicates || new Set();
         var localFontPropRules = Object.assign({}, fontPropRules);
         var props = Object.keys(fontPropRules);
         var result = {};
@@ -114,7 +117,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
         // Stop condition. We moved above <HTML>
         if (!node.tagName) {
             props.forEach(function (prop) {
-                result[prop] = [INITIAL_VALUES[prop]];
+                result[prop] = [ { value: INITIAL_VALUES[prop], truePredicates: truePredicates, falsePredicates: falsePredicates }];
             });
             return result;
         }
@@ -130,7 +133,7 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
             });
         }
 
-        function traceProp(prop, startIndex) {
+        function traceProp(prop, startIndex, truePredicates, falsePredicates) {
             startIndex = startIndex || 0;
 
             for (var i = startIndex; i < localFontPropRules[prop].length; i += 1) {
@@ -146,61 +149,85 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                 }
 
                 if (isStyleAttribute || node.matches(selectorWithoutPseudoClasses)) {
-                    var values = [declaration.value];
-
-                    if (prop === 'font-weight' && ['lighter', 'bolder'].includes(declaration.value)) {
-                        var inheritedWeight = getComputedStyle(node.parentNode, idArray.slice(0, -1))[prop];
-                        if (declaration.value === 'lighter') {
-                            values = [availableWeights[availableWeights.indexOf(inheritedWeight) - 1] || inheritedWeight];
-                        }
-
-                        if (declaration.value === 'bolder') {
-                            values = [availableWeights[availableWeights.indexOf(inheritedWeight) + 1] || inheritedWeight];
-                        }
-                    }
-
-
+                    var hypotheticalValues;
                     if (declaration.value === 'inherit' || declaration.value === 'unset') {
-                        values = getComputedStyle(node.parentNode, idArray.slice(0, -1))[prop];
-                    }
-
-                    if (declaration.value === 'initial') {
-                        values = [INITIAL_VALUES[prop]];
-                    }
-
-                    if (NAME_CONVERSIONS[prop] && NAME_CONVERSIONS[prop][declaration.value]) {
-                        values = [NAME_CONVERSIONS[prop][declaration.value]];
-                    }
-
-                    if (isStyleAttribute || selectorWithoutPseudoClasses === declaration.selector) {
-                        return values;
+                        hypotheticalValues = getComputedStyle(node.parentNode, idArray.slice(0, -1), truePredicates, falsePredicates)[prop];
                     } else {
-                        return _.uniq(values.concat(traceProp(prop, i + 1)));
+                        var value;
+                        if (declaration.value === 'initial') {
+                            value = INITIAL_VALUES[prop];
+                        } else if (NAME_CONVERSIONS[prop] && NAME_CONVERSIONS[prop][declaration.value]) {
+                            value = NAME_CONVERSIONS[prop][declaration.value];
+                        } else if (prop === 'font-weight') {
+                            if (declaration.value === 'lighter' || declaration.value === 'bolder') {
+                                var inheritedWeight = getComputedStyle(node.parentNode, idArray.slice(0, -1))[prop];
+                                if (declaration.value === 'lighter') {
+                                    value = availableWeights[availableWeights.indexOf(inheritedWeight[0]) - 1] || inheritedWeight;
+                                }
+                                if (declaration.value === 'bolder') {
+                                    value = availableWeights[availableWeights.indexOf(inheritedWeight[0]) + 1] || inheritedWeight;
+                                }
+                            } else {
+                                value = Number(declaration.value);
+                            }
+                        } else if (prop === 'font-family') {
+                            value = unquote(declaration.value);
+                        } else {
+                            value = declaration.value;
+                        }
+
+                        hypotheticalValues = [ { value: value, truePredicates: truePredicates, falsePredicates: falsePredicates } ];
                     }
 
+                    if (isStyleAttribute || selectorWithoutPseudoClasses === declaration.selector || truePredicates.has(declaration.selector)) {
+                        return hypotheticalValues;
+                    } else {
+                        // Note that all the values assume that the selector with the pseudo classes matches:
+                        hypotheticalValues.forEach(function (hypotheticalValue) {
+                            if (!hypotheticalValue.truePredicates.has(declaration.selector)) {
+                                hypotheticalValue.truePredicates = new Set(hypotheticalValue.truePredicates).add(declaration.selector); // COW
+                            }
+                        });
+                        if (!falsePredicates.has(declaration.selector)) {
+                            // In the current trace there's currently no assumption that this selector with pseudo classes
+                            // does not match. Trace that possiblity, tagging each found value with the assumption that the
+                            // selector did not match by adding it to falsePredicates:
+                            Array.prototype.push.apply(hypotheticalValues, traceProp(prop, i + 1, truePredicates, new Set(falsePredicates).add(declaration.selector)));
+                        }
+                        return hypotheticalValues;
+                    }
                 }
-
             }
 
-            if (!nonInheritingTags.includes(node.tagName)) {
-                return getComputedStyle(node.parentNode, idArray.slice(0, -1))[prop];
+            if (nonInheritingTags.indexOf(node.tagName) === -1) {
+                return getComputedStyle(node.parentNode, idArray.slice(0, -1), truePredicates, falsePredicates)[prop];
             } else {
-                return [INITIAL_VALUES[prop]];
+                return [ { value: INITIAL_VALUES[prop], truePredicates: truePredicates, falsePredicates: falsePredicates }];
             }
         }
 
         props.forEach(function (prop) {
-            result[prop] = traceProp(prop);
+            result[prop] = traceProp(prop, 0, truePredicates, falsePredicates);
         });
 
-        // Unquote font-family value if there is one
-        result['font-family'] = result['font-family'].map(unquote);
-
-        // Always return font-weight as a number
-        result['font-weight'] = result['font-weight'].map(Number);
-
-
         return result;
+    }, {
+        argumentsStringifier: function (args) {
+            var stringifiedArguments = args[1].join(',');
+            if (args[2]) {
+                stringifiedArguments += '\x1e';
+                args[2].forEach(function (assumption) {
+                    stringifiedArguments += assumption + '\x1d';
+                });
+            }
+            if (args[3]) {
+                stringifiedArguments += '\x1e';
+                args[3].forEach(function (assumption) {
+                    stringifiedArguments += assumption + '\x1d';
+                });
+            }
+            return stringifiedArguments;
+        }
     });
 
     return getComputedStyle;
@@ -252,7 +279,7 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
             var child = node.firstChild;
 
             // Inputs might have visual text, but don't have childNodes
-            if (node.tagName === 'INPUT' && visualValueInputTypes.includes(node.type || 'text')) {
+            if (node.tagName === 'INPUT' && visualValueInputTypes.indexOf(node.type || 'text') !== -1) {
                 var inputValue = (node.value || '').trim();
                 var inputPlaceholder = (node.placeholder || '').trim();
 
@@ -316,15 +343,15 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
     //     {
     //         text: 'foo',
     //         props: {
-    //             'font-family': ['a', 'b'],
-    //             'font-style': ['normal'],
-    //             'font-weight': [400, 700]
+    //             'font-family': [ { value: 'a', truePredicates: Set, falsePredicates: Set }, { value: 'b', truePredicates: Set, falsePredicates: Set }],
+    //             'font-style': [ { value: 'normal', truePredicates: Set, falsePredicates: Set } ],
+    //             'font-weight': [ { value: 400, truePredicates: Set, falsePredicates: Set }, { value: 700, truePredicates: Set, falsePredicates: Set }]
     //         }
     //     },
     //     ...
     // ]
 
-    // Expand into all permutations in case of multiple possible values:
+    // Expand into all permutations in case of multiple hypothetical values:
     function expandPermutations(styledText, propertyNames) {
         propertyNames = propertyNames || Object.keys(styledText.props);
         var permutations = [];
@@ -349,7 +376,35 @@ function getTextByFontProperties(htmlAsset, availableWeights) {
 
     var multipliedStyledTexts = _.flatten(styledTexts.map(function (styledText) {
         return expandPermutations(styledText)
-            .map(function (props) {
+            .filter(function (hypotheticalValuesByProp) {
+                var allTruePredicates = new Set();
+                var allFalsePredicates = new Set();
+                Object.keys(hypotheticalValuesByProp).forEach(function (prop) {
+                    hypotheticalValuesByProp[prop].truePredicates.forEach(function (value) {
+                        allTruePredicates.add(value);
+                    });
+                    hypotheticalValuesByProp[prop].falsePredicates.forEach(function (value) {
+                        allFalsePredicates.add(value);
+                    });
+                });
+                // This will be nicer with for...of and destructuring:
+                var allTruePredicatesIterator = allTruePredicates.values();
+                var done = false;
+                while (!done) {
+                    var next = allTruePredicatesIterator.next();
+                    done = next.done;
+                    if (!done && allFalsePredicates.has(next.value)) {
+                        return false;
+                    }
+                }
+                return true;
+            })
+            .map(function (hypotheticalValuesByProp) {
+                // Unwrap the "hypothetical value" objects:
+                var props = {};
+                Object.keys(hypotheticalValuesByProp).forEach(function (prop) {
+                    props[prop] = hypotheticalValuesByProp[prop].value;
+                });
                 return {
                     text: styledText.text,
                     props: props

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -26,6 +26,23 @@ var NAME_CONVERSIONS = {
     'font-weight': cssFontWeightNames
 };
 
+function createPredicatePermutations(predicatesToVary, i) {
+    if (typeof i !== 'number') {
+        i = 0;
+    }
+    if (i < predicatesToVary.length) {
+        var permutations = [];
+        createPredicatePermutations(predicatesToVary, i + 1).forEach(function (permutation) {
+            var permutationWithPredicateOff = Object.assign({}, permutation);
+            permutationWithPredicateOff[predicatesToVary[i]] = true;
+            permutations.push(permutation, permutationWithPredicateOff);
+        });
+        return permutations;
+    } else {
+        return [ {} ];
+    }
+}
+
 var excludedNodes = ['HEAD', 'STYLE', 'SCRIPT'];
 
 function getNodeIdArray(node) {
@@ -179,21 +196,57 @@ function getMemoizedElementStyleResolver(fontPropRules, availableWeights) {
                         hypotheticalValues = [ { value: value, truePredicates: truePredicates, falsePredicates: falsePredicates } ];
                     }
 
-                    if (isStyleAttribute || selectorWithoutPseudoClasses === declaration.selector || truePredicates.has(declaration.selector)) {
-                        return hypotheticalValues;
-                    } else {
-                        // Note that all the values assume that the selector with the pseudo classes matches:
-                        hypotheticalValues.forEach(function (hypotheticalValue) {
-                            if (!hypotheticalValue.truePredicates.has(declaration.selector)) {
-                                hypotheticalValue.truePredicates = new Set(hypotheticalValue.truePredicates).add(declaration.selector); // COW
+                    var predicatesToVary = [].concat(declaration.mediaStack);
+                    if (!isStyleAttribute && selectorWithoutPseudoClasses !== declaration.selector) {
+                        predicatesToVary.push(declaration.selector);
+                    }
+                    if (predicatesToVary.length > 0) {
+                        var multipliedHypotheticalValues = [];
+                        createPredicatePermutations(predicatesToVary).forEach(function (predicatePermutation) {
+                            if (Object.keys(predicatePermutation).length === 0) {
+                                return;
+                            }
+                            var hasPredicateThatIsAlreadyAssumedFalse = false;
+
+                            var recursiveTruePredicates = new Set(truePredicates);
+                            var recursiveFalsePredicates = new Set(falsePredicates);
+                            var someThatWereNotAlreadyTrue = false;
+                            Object.keys(predicatePermutation).forEach(function (predicate) {
+                                if (predicatePermutation[predicate]) {
+                                    if (!truePredicates.has(predicate)) {
+                                        recursiveTruePredicates.add(predicate);
+                                        someThatWereNotAlreadyTrue = true;
+                                    }
+                                    if (falsePredicates.has(predicate)) {
+                                        hasPredicateThatIsAlreadyAssumedFalse = true;
+                                    } else {
+                                        recursiveFalsePredicates.add(predicate);
+                                    }
+                                }
+                            });
+                            if (hasPredicateThatIsAlreadyAssumedFalse) {
+                                return;
+                            }
+
+                            Array.prototype.push.apply(
+                                multipliedHypotheticalValues,
+                                hypotheticalValues.map(function (hypotheticalValue) {
+                                    return {
+                                        value: hypotheticalValue.value,
+                                        truePredicates: recursiveTruePredicates,
+                                        falsePredicates: falsePredicates
+                                    };
+                                })
+                            );
+                            if (someThatWereNotAlreadyTrue) {
+                                Array.prototype.push.apply(
+                                    multipliedHypotheticalValues,
+                                    traceProp(prop, i + 1, truePredicates, recursiveFalsePredicates)
+                                );
                             }
                         });
-                        if (!falsePredicates.has(declaration.selector)) {
-                            // In the current trace there's currently no assumption that this selector with pseudo classes
-                            // does not match. Trace that possiblity, tagging each found value with the assumption that the
-                            // selector did not match by adding it to falsePredicates:
-                            Array.prototype.push.apply(hypotheticalValues, traceProp(prop, i + 1, truePredicates, new Set(falsePredicates).add(declaration.selector)));
-                        }
+                        return multipliedHypotheticalValues;
+                    } else {
                         return hypotheticalValues;
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "iconv-lite": "^0.4.15",
     "istanbul": "^0.4.1",
     "less": "2.7.2",
+    "magicpen-prism": "2.3.0",
     "mocha": "^3.0.0",
     "open": "0.0.5",
     "requirejs": "2.3.3",

--- a/test/assets/Asset.js
+++ b/test/assets/Asset.js
@@ -626,8 +626,10 @@ describe('assets/Asset', function () {
                 request: 'GET http://gofish.dk/purplealpha24bit.png',
                 response: {
                     statusCode: 200,
-                    'Content-Length': 8285,
-                    'Content-Type': 'image/png',
+                    headers: {
+                        'Content-Length': 8285,
+                        'Content-Type': 'image/png'
+                    },
                     body: fs.readFileSync(__dirname + '/../../testdata/assets/Asset/rawSrc/purplealpha24bit.png')
                 }
             });

--- a/test/relations/HtmlStyle.js
+++ b/test/relations/HtmlStyle.js
@@ -24,6 +24,29 @@ describe('relations/HtmlStyle', function () {
         assetGraph.addAsset(htmlAsset);
     }
 
+    describe('#media', function () {
+        describe('invoked as a getter', function () {
+            it('should retrieve the trimmed media attribute', function () {
+                initial('<!DOCTYPE html><html><head><style media=" projection screen ">body{color:#000};</style></head><body></body></html>');
+                expect(assetGraph.findRelations({type: 'HtmlStyle'})[0].media, 'to equal', 'projection screen');
+            });
+        });
+
+        describe('invoked as a setter', function () {
+            it('should trim and update the media attribute', function () {
+                initial('<!DOCTYPE html><html><head><style>body{color:#000};</style></head><body></body></html>');
+                assetGraph.findRelations({type: 'HtmlStyle'})[0].media = ' projection screen ';
+                expect(assetGraph.findAssets({type: 'Html'})[0].text, 'to contain', '<style media="projection screen">');
+            });
+
+            it('should remove media attribute when set to a falsy value', function () {
+                initial('<!DOCTYPE html><html><head><style media="projection">body{color:#000};</style></head><body></body></html>');
+                assetGraph.findRelations({type: 'HtmlStyle'})[0].media = undefined;
+                expect(assetGraph.findAssets({type: 'Html'})[0].text, 'to contain', '<style>');
+            });
+        });
+    });
+
     describe('#attach', function () {
         describe('when there are existing HtmlStyle relations in <head>', function () {
             beforeEach(function () {

--- a/test/unexpected-with-plugins.js
+++ b/test/unexpected-with-plugins.js
@@ -1,5 +1,6 @@
 module.exports = require('unexpected')
     .clone()
-    .installPlugin(require('unexpected-sinon'))
-    .installPlugin(require('unexpected-dom'))
-    .installPlugin(require('./unexpectedAssetGraph'));
+    .use(require('unexpected-sinon'))
+    .use(require('unexpected-dom'))
+    .use(require('./unexpectedAssetGraph'))
+    .use(require('magicpen-prism'));

--- a/test/util/fonts/gatherStylesheetsWithIncomingMedia.js
+++ b/test/util/fonts/gatherStylesheetsWithIncomingMedia.js
@@ -1,0 +1,72 @@
+var gatherStylesheetsWithIncomingMedia = require('../../../lib/util/fonts/gatherStylesheetsWithIncomingMedia');
+var expect = require('../../unexpected-with-plugins');
+var AssetGraph = require('../../../');
+
+describe('gatherStylesheetsWithIncomingMedia', function () {
+    expect = expect.clone().addAssertion('<string> to produce result satisfying <array>', function (expect, subject, value) {
+        return new AssetGraph({root: __dirname + '/../../../testdata/util/fonts/gatherStylesheetsWithIncomingMedia/' + subject + '/'})
+            .loadAssets('index.html')
+            .populate()
+            .then(function (assetGraph) {
+                return expect(gatherStylesheetsWithIncomingMedia(assetGraph, assetGraph.findAssets({type: 'Html'})[0]), 'to satisfy', value);
+            });
+    });
+
+    it('should follow inline HtmlStyle relations', function () {
+        return expect('inlineHtmlStyle', 'to produce result satisfying', [
+            { text: '\n        .a { font-weight: 500; }\n    ', incomingMedia: [] }
+        ]);
+    });
+
+    it('should support the media attribute when following an inline HtmlStyle', function () {
+        return expect('inlineHtmlStyleWithMediaAttribute', 'to produce result satisfying', [
+            { text: '\n        .a { font-weight: 500; }\n    ', incomingMedia: [ '3d-glasses' ] }
+        ]);
+    });
+
+    it('should follow non-inline HtmlStyle relations', function () {
+        return expect('htmlStyle', 'to produce result satisfying', [
+            { text: '.a { font-weight: 500; }\n', incomingMedia: [] }
+        ]);
+    });
+
+    it('should support the media attribute when following a non-inline HtmlStyle', function () {
+        return expect('htmlStyleWithMediaAttribute', 'to produce result satisfying', [
+            { text: '.a { font-weight: 500; }\n', incomingMedia: [ '3d-glasses' ] }
+        ]);
+    });
+
+    it('should list a stylesheet twice when it is being included multiple times', function () {
+        return expect('sameStylesheetIncludedTwice', 'to produce result satisfying', [
+            { text: '.a { font-weight: 600; }\n', incomingMedia: [] },
+            { text: '.b { font-weight: 500; }\n', incomingMedia: [] },
+            { text: '.a { font-weight: 600; }\n', incomingMedia: [ '3d-glasses' ] }
+        ]);
+    });
+
+    it('should pick up a media list attached to a CssImport', function () {
+        return expect('cssImportWithMedia', 'to produce result satisfying', [
+            { text: '.a { font-weight: 600; }\n', incomingMedia: [ 'projection' ] },
+            { text: '\n        @import "a.css" projection;\n    ', incomingMedia: [] }
+        ]);
+    });
+
+    it('should stack up the incoming media following HtmlStyle -> CssImport', function () {
+        return expect('cssImportWithMediaWithExistingIncomingMedia', 'to produce result satisfying', [
+            { text: '.a { font-weight: 600; }\n', incomingMedia: [ '3d-glasses', 'projection' ] },
+            { text: '\n        @import "a.css" projection;\n    ', incomingMedia: [ '3d-glasses' ] }
+        ]);
+    });
+
+    it('should not break when there is a cyclic CssImport', function () {
+        return expect('cyclicCssImport', 'to produce result satisfying', [
+            { text: '@import "";\n\n.a { font-weight: 600; }\n', incomingMedia: [] }
+        ]);
+    });
+
+    it('should not break when there are unloaded Css assets', function () {
+        return expect('unloadedCssAssets', 'to produce result satisfying', [
+            { text: '@import "notfoundeither.css";\n', incomingMedia: [] }
+        ]);
+    });
+});

--- a/test/util/fonts/getCssRulesByProperty.js
+++ b/test/util/fonts/getCssRulesByProperty.js
@@ -10,21 +10,26 @@ describe('util/fonts/getCssRulesByProperty', function () {
         expect(function () { getRules(['padding']); }, 'to throw', 'cssSource argument must be a string containing valid CSS');
     });
 
+    it('should throw when not passing an incomingMedia array as the third argument', function () {
+        expect(function () { getRules(['padding'], 'body { color: maroon; }'); }, 'to throw', 'incomingMedia argument must be an array');
+    });
+
     it('should throw when not passing a valid CSS document in cssSource', function () {
         expect(function () { getRules(['padding'], 'sdkjlasjdlk'); }, 'to throw');
     });
 
     it('should return empty arrays when no properties apply', function () {
-        expect(getRules(['padding'], 'h1 { color: red; }'), 'to exhaustively satisfy', {
+        expect(getRules(['padding'], 'h1 { color: red; }', []), 'to exhaustively satisfy', {
             padding: []
         });
     });
 
     it('should return an array of matching property values', function () {
-        expect(getRules(['color'], 'h1 { color: red; } h2 { color: blue; }'), 'to exhaustively satisfy', {
+        expect(getRules(['color'], 'h1 { color: red; } h2 { color: blue; }', []), 'to exhaustively satisfy', {
             color: [
                 {
                     selector: 'h1',
+                    incomingMedia: [],
                     specificityArray: [0, 0, 0, 1],
                     prop: 'color',
                     value: 'red',
@@ -32,6 +37,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 },
                 {
                     selector: 'h2',
+                    incomingMedia: [],
                     specificityArray: [0, 0, 0, 1],
                     prop: 'color',
                     value: 'blue',
@@ -42,10 +48,11 @@ describe('util/fonts/getCssRulesByProperty', function () {
     });
 
     it('should handle linine styles through `bogusselector`-selector', function () {
-        expect(getRules(['color'], 'bogusselector { color: red; }'), 'to exhaustively satisfy', {
+        expect(getRules(['color'], 'bogusselector { color: red; }', []), 'to exhaustively satisfy', {
             color: [
                 {
                     selector: undefined,
+                    incomingMedia: [],
                     specificityArray: [1, 0, 0, 0],
                     prop: 'color',
                     value: 'red',
@@ -58,10 +65,11 @@ describe('util/fonts/getCssRulesByProperty', function () {
     it('should memoize the results of a call', function () {
         getRules.cache.reset();
 
-        expect(getRules(['color'], 'h1 { color: red; }'), 'to exhaustively satisfy', {
+        expect(getRules(['color'], 'h1 { color: red; }', []), 'to exhaustively satisfy', {
             color: [
                 {
                     selector: 'h1',
+                    incomingMedia: [],
                     specificityArray: [0, 0, 0, 1],
                     prop: 'color',
                     value: 'red',
@@ -77,6 +85,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                     color: [
                         {
                             selector: 'h1',
+                            incomingMedia: [],
                             specificityArray: [0, 0, 0, 1],
                             prop: 'color',
                             value: 'red',
@@ -90,10 +99,11 @@ describe('util/fonts/getCssRulesByProperty', function () {
 
     describe('overridden values', function () {
         it('should return the last defined value', function () {
-            expect(getRules(['color'], 'h1 { color: red; color: blue; }'), 'to exhaustively satisfy', {
+            expect(getRules(['color'], 'h1 { color: red; color: blue; }', []), 'to exhaustively satisfy', {
                 color: [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'color',
                         value: 'red',
@@ -101,6 +111,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                     },
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'color',
                         value: 'blue',
@@ -113,7 +124,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
 
     describe('shorthand font-property', function () {
         it('should ignore invalid shorthands', function () {
-            var result = getRules(['font-family', 'font-size'], 'h1 { font: 15px; }');
+            var result = getRules(['font-family', 'font-size'], 'h1 { font: 15px; }', []);
 
             expect(result, 'to exhaustively satisfy', {
                 'font-family': [],
@@ -122,12 +133,13 @@ describe('util/fonts/getCssRulesByProperty', function () {
         });
 
         it('register the longhand value from a valid shorthand', function () {
-            var result = getRules(['font-family', 'font-size'], 'h1 { font: 15px serif; }');
+            var result = getRules(['font-family', 'font-size'], 'h1 { font: 15px serif; }', []);
 
             expect(result, 'to exhaustively satisfy', {
                 'font-family': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-family',
                         value: 'serif',
@@ -137,6 +149,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-size': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '15px',
@@ -147,12 +160,13 @@ describe('util/fonts/getCssRulesByProperty', function () {
         });
 
         it('should set initial values for requested properties which are not defined in shorthand', function () {
-            var result = getRules(['font-family', 'font-size', 'font-style', 'font-weight'], 'h1 { font: 15px serif; }');
+            var result = getRules(['font-family', 'font-size', 'font-style', 'font-weight'], 'h1 { font: 15px serif; }', []);
 
             expect(result, 'to exhaustively satisfy', {
                 'font-family': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-family',
                         value: 'serif',
@@ -162,6 +176,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-size': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '15px',
@@ -171,6 +186,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-style': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-style',
                         value: 'normal',
@@ -180,6 +196,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-weight': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-weight',
                         value: 400,
@@ -190,12 +207,13 @@ describe('util/fonts/getCssRulesByProperty', function () {
         });
 
         it('register the longhand value from a shorthand', function () {
-            var result = getRules(['font-family', 'font-size'], 'h1 { font-size: 10px; font: 15px serif; font-size: 20px }');
+            var result = getRules(['font-family', 'font-size'], 'h1 { font-size: 10px; font: 15px serif; font-size: 20px }', []);
 
             expect(result, 'to exhaustively satisfy', {
                 'font-family': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-family',
                         value: 'serif',
@@ -205,6 +223,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-size': [
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '10px',
@@ -212,6 +231,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                     },
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '15px',
@@ -219,6 +239,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                     },
                     {
                         selector: 'h1',
+                        incomingMedia: [],
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '20px',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -677,22 +677,6 @@ describe('util/fonts/getTextByFontProp', function () {
                 {
                     text: 'foo',
                     props: {
-                        'font-family': 'font1',
-                        'font-weight': 400,
-                        'font-style': 'normal'
-                    }
-                },
-                {
-                    text: 'foo',
-                    props: {
-                        'font-family': undefined,
-                        'font-weight': 700,
-                        'font-style': 'normal'
-                    }
-                },
-                {
-                    text: 'foo',
-                    props: {
                         'font-family': undefined,
                         'font-weight': 400,
                         'font-style': 'normal'

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -754,6 +754,69 @@ describe('util/fonts/getTextByFontProp', function () {
         });
     });
 
+    describe('CSS @media queries', function () {
+        it('should include the possibility of the media query matching or not matching', function () {
+            var htmlText = [
+                '<style>div { font-family: font1; font-weight: 400 } @media (max-width: 600px) { div { font-weight: 500 } }</style>',
+                '<div>foo</div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 500,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
+        it.skip('should trace two levels of media queries with the media attribute is present', function () {
+            var htmlText = [
+                '<style>div { font-family: font1; font-weight: 400 }</style>',
+                '<style media="projection">div { font-family: font2; font-weight: 800 } @media (max-width: 600px) { div { font-weight: 500 } }</style>',
+                '<div>foo</div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': 'font2',
+                        'font-weight': 800,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': 'font2',
+                        'font-weight': 500,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+    });
+
     describe('font-shorthand property', function () {
         it('should have shorthand value override previous longhand value', function () {
             var htmlText = [

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -1,8 +1,11 @@
-var expect = require('unexpected').clone();
+var expect = require('../../unexpected-with-plugins').clone();
 var AssetGraph = require('../../../lib');
 var getTextByFontProp = require('../../../lib/util/fonts/getTextByFontProperties');
 
 expect.addAssertion('<string> to [exhaustively] satisfy computed font properties <array>', function (expect, subject, result) {
+    expect.subjectOutput = function (output) {
+        output.code(subject, 'text/html');
+    };
     return new AssetGraph({})
         .loadAssets(new AssetGraph.Html({
             text: subject

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMedia/a.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMedia/a.css
@@ -1,0 +1,1 @@
+.a { font-weight: 600; }

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMedia/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMedia/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        @import "a.css" projection;
+    </style>
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMediaWithExistingIncomingMedia/a.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMediaWithExistingIncomingMedia/a.css
@@ -1,0 +1,1 @@
+.a { font-weight: 600; }

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMediaWithExistingIncomingMedia/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cssImportWithMediaWithExistingIncomingMedia/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style media='3d-glasses'>
+        @import "a.css" projection;
+    </style>
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cyclicCssImport/a.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cyclicCssImport/a.css
@@ -1,0 +1,3 @@
+@import "a.css";
+
+.a { font-weight: 600; }

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cyclicCssImport/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/cyclicCssImport/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="a.css">
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyle/a.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyle/a.css
@@ -1,0 +1,1 @@
+.a { font-weight: 500; }

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyle/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyle/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel='stylesheet' href='a.css'>
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyleWithMediaAttribute/a.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyleWithMediaAttribute/a.css
@@ -1,0 +1,1 @@
+.a { font-weight: 500; }

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyleWithMediaAttribute/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/htmlStyleWithMediaAttribute/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel='stylesheet' media='3d-glasses' href='a.css'>
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/inlineHtmlStyle/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/inlineHtmlStyle/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .a { font-weight: 500; }
+    </style>
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/inlineHtmlStyleWithMediaAttribute/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/inlineHtmlStyleWithMediaAttribute/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style media='3d-glasses'>
+        .a { font-weight: 500; }
+    </style>
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/sameStylesheetIncludedTwice/a.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/sameStylesheetIncludedTwice/a.css
@@ -1,0 +1,1 @@
+.a { font-weight: 600; }

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/sameStylesheetIncludedTwice/b.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/sameStylesheetIncludedTwice/b.css
@@ -1,0 +1,1 @@
+.b { font-weight: 500; }

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/sameStylesheetIncludedTwice/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/sameStylesheetIncludedTwice/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel='stylesheet' href='a.css'>
+    <link rel='stylesheet' href='b.css'>
+    <link rel='stylesheet' media='3d-glasses' href='a.css'>
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/unloadedCssAssets/a.css
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/unloadedCssAssets/a.css
@@ -1,0 +1,1 @@
+@import "notfoundeither.css";

--- a/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/unloadedCssAssets/index.html
+++ b/testdata/util/fonts/gatherStylesheetsWithIncomingMedia/unloadedCssAssets/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="a.css">
+    <link rel="stylesheet" href="notFound.css">
+</head>
+<body></body>
+</html>

--- a/testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/a.css
+++ b/testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/a.css
@@ -1,0 +1,3 @@
+@import "b.css" 3d-glasses;
+
+div.theclass { font-weight: 600; }

--- a/testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/b.css
+++ b/testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/b.css
@@ -1,0 +1,1 @@
+div#theid { font-weight: 700; }

--- a/testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/index.html
+++ b/testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        @import "a.css" projection;
+
+        div { font-weight: 500; }
+    </style>
+</head>
+<body>
+    <div class="theclass" id="theid">foo</div>
+</body>
+</html>


### PR DESCRIPTION
@Munter, I think I'm out of the woods now with something that's ready for an initial review.

TODO:

- [x] Figure out if we want to use `Set` instances internally for keeping track of the true/false predicates.
- [x] Maybe namespace the predicates so that selectors with pseudo classes, media lists, and media queries cannot be confused with each other.