### PR TITLE
Support :after { content: attr(...); }

### DIFF
--- a/lib/util/fonts/getPseudoElements.js
+++ b/lib/util/fonts/getPseudoElements.js
@@ -58,21 +58,25 @@ function getPseudoElements(htmlAsset) {
 
             Array.prototype.forEach.call(parentNodes, function (parentNode) {
                 var clonedPseudoNode = node.cloneNode(true);
+                var text;
                 if (matchAttr) {
                     var attributeValue = parentNode.getAttribute(matchAttr[1]);
                     if (attributeValue) {
-                        clonedPseudoNode.appendChild(document.createTextNode(attributeValue));
+                        text = attributeValue;
                     }
                 } else if (content) {
-                    clonedPseudoNode.appendChild(document.createTextNode(unquote(content)));
+                    text = unquote(content);
                 }
+                if (text) {
+                    clonedPseudoNode.appendChild(document.createTextNode(text));
 
-                // Fake the parent node
-                Object.defineProperty(clonedPseudoNode, 'parentNode', {
-                    get: function () { return parentNode; }
-                });
+                    // Fake the parent node
+                    Object.defineProperty(clonedPseudoNode, 'parentNode', {
+                        get: function () { return parentNode; }
+                    });
 
-                nodes.push(clonedPseudoNode);
+                    nodes.push(clonedPseudoNode);
+                }
             });
         });
 

--- a/lib/util/fonts/getPseudoElements.js
+++ b/lib/util/fonts/getPseudoElements.js
@@ -53,9 +53,6 @@ function getPseudoElements(htmlAsset) {
             node.setAttribute('style', inlineStyle);
             var content = propsBySelector[selector].content;
             var matchAttr = content && content.match(/^attr\(([\w-]+)\)$/);
-            if (content && !matchAttr) {
-            }
-
             var parentSelector = selector.replace(cssPseudoElementRegExp, '');
             var parentNodes = document.querySelectorAll(parentSelector) || [];
 

--- a/lib/util/fonts/getPseudoElements.js
+++ b/lib/util/fonts/getPseudoElements.js
@@ -51,12 +51,24 @@ function getPseudoElements(htmlAsset) {
                 .join('; ');
 
             node.setAttribute('style', inlineStyle);
-            node.appendChild(document.createTextNode(unquote(propsBySelector[selector].content)));
+            var content = propsBySelector[selector].content;
+            var matchAttr = content && content.match(/^attr\(([\w-]+)\)$/);
+            if (content && !matchAttr) {
+            }
 
             var parentSelector = selector.replace(cssPseudoElementRegExp, '');
+            var parentNodes = document.querySelectorAll(parentSelector) || [];
 
-            Array.prototype.forEach.call(document.querySelectorAll(parentSelector) || [], function (parentNode) {
+            Array.prototype.forEach.call(parentNodes, function (parentNode) {
                 var clonedPseudoNode = node.cloneNode(true);
+                if (matchAttr) {
+                    var attributeValue = parentNode.getAttribute(matchAttr[1]);
+                    if (attributeValue) {
+                        clonedPseudoNode.appendChild(document.createTextNode(attributeValue));
+                    }
+                } else if (content) {
+                    clonedPseudoNode.appendChild(document.createTextNode(unquote(content)));
+                }
 
                 // Fake the parent node
                 Object.defineProperty(clonedPseudoNode, 'parentNode', {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -487,16 +487,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 '<h1></h1>'
             ].join('\n');
 
-            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
-                {
-                    text: '',
-                    props: {
-                        'font-family': 'font1',
-                        'font-weight': 700,
-                        'font-style': 'normal'
-                    }
-                }
-            ]);
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', []);
         });
 
         it('should override re-definition of prop on :after pseudo-element', function () {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -481,6 +481,24 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
+        it('should support :after without content', function () {
+            var htmlText = [
+                '<style>h1:after { font-family: font1 !important; }</style>',
+                '<h1></h1>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: '',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 700,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
         it('should override re-definition of prop on :after pseudo-element', function () {
             var htmlText = [
                 '<style>h1::after { content: "after"; font-family: font1; }</style>',
@@ -617,6 +635,24 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     props: {
                         'font-family': 'font1',
                         'font-weight': 600,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
+        it('should support content: attr(...)', function () {
+            var htmlText = [
+                '<style>div:after { content: attr(data-foo); font-family: font1; }</style>',
+                '<div data-foo="bar"></div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'bar',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 400,
                         'font-style': 'normal'
                     }
                 }


### PR DESCRIPTION
Also, don't break when there's no content attribute in a pseudo element rule (produced a styledText entry with text: 'undefined' before).