### PR TITLE
Automatically detach incoming relations when an asset is removed

### DIFF
--- a/lib/AssetGraph.js
+++ b/lib/AssetGraph.js
@@ -223,49 +223,70 @@ class AssetGraph extends EventEmitter {
     }
 
     /**
-     * assetGraph.removeAsset(asset[, detachIncomingRelations])
+     * assetGraph.removeAsset(asset])
      * ========================================================
      *
      * Remove an asset from the graph. Also removes the incoming and
      * outgoing relations of the asset.
      *
      * @param {Asset} asset The asset to remove.
-     * @param {Boolean} detachIncomingRelations Whether to also detach the incoming relations before removal (defaults to false).
      * @return {AssetGraph} The AssetGraph instance (chaining-friendly).
      */
-    removeAsset(asset, detachIncomingRelations) {
+    removeAsset(asset) {
         if (!this.idIndex[asset.id]) {
             throw new Error('AssetGraph.removeAsset: ' + asset + ' not in graph');
         }
         if (asset._outgoingRelations) {
-            for (const outgoingRelation of [].concat(asset.outgoingRelations)) {
+            const outgoingRelations = [].concat(asset._outgoingRelations);
+            // Remove the outgoing relations as to not trigger the
+            // "<relation> will be detached..." warning in the recursive
+            // removeAsset calls:
+            asset._outgoingRelations = undefined;
+
+            for (const outgoingRelation of outgoingRelations) {
                 if (outgoingRelation.to.isAsset && outgoingRelation.to.isInline) {
                     // Remove inline asset
                     this.removeAsset(outgoingRelation.to);
                 }
             }
+            // Put back the outgoing relations so that the relations are still
+            // in a resolved state, even though the asset is no longer in the
+            // graph. This is debatable since we don't really want to support
+            // assets living outside of the context of an AssetGraph instance,
+            // but not doing it makes a test fail here:
+            //   https://github.com/assetgraph/assetgraph/blob/348b8740941effc93106abe84f9225cccf10470d/test/assets/Asset.js#L691-L695
+            // ... so let's consider whether to nuke that test at some point.
+            asset._outgoingRelations = outgoingRelations;
         }
-        for (const incomingRelation of this.findRelations({to: asset})) {
-            if (detachIncomingRelations) {
+        let stillAttachedIncomingRelations = false;
+        for (const incomingRelation of asset.incomingRelations) {
+            this.warn(new Error(`${incomingRelation.toString()} will be detached as a result of removing ${asset.urlOrDescription} from the graph`));
+            try {
                 incomingRelation.detach();
-            } else {
+            } catch (e) {
                 incomingRelation.remove();
+                stillAttachedIncomingRelations = true;
             }
         }
-        if (!this._assets.delete(asset)) {
-            throw new Error('removeAsset: ' + asset + ' not in graph');
-        }
-        this.idIndex[asset.id] = undefined;
-        const url = asset.url;
-        if (url) {
-            if (this._urlIndex[url]) {
-                delete this._urlIndex[url];
-            } else {
-                throw new Error(`Internal error: ${url} not in _urlIndex`);
+        if (stillAttachedIncomingRelations) {
+            this.warn(new Error(`Leaving ${asset.urlOrDescription} unloaded in the graph, some incoming relations could not be detached`));
+            asset.unload();
+        } else {
+            if (!this._assets.delete(asset)) {
+                throw new Error('removeAsset: ' + asset + ' not in graph');
             }
+            this.idIndex[asset.id] = undefined;
+            const url = asset.url;
+            if (url) {
+                if (this._urlIndex[url]) {
+                    delete this._urlIndex[url];
+                } else {
+                    throw new Error(`Internal error: ${url} not in _urlIndex`);
+                }
+            }
+            asset.assetGraph = undefined;
+            this.emit('removeAsset', asset);
         }
-        asset.assetGraph = undefined;
-        this.emit('removeAsset', asset);
         return this;
     }
 

--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -560,14 +560,18 @@ class Asset extends EventEmitter {
         if (this._outgoingRelations) {
             // Remove inline assets and outgoing relations:
             if (this.assetGraph && this.isPopulated) {
-                for (const outgoingRelation of [].concat(this.outgoingRelations)) {
-                    if (outgoingRelation.to.isAsset && outgoingRelation.to.isInline) {
+                const outgoingRelations = [].concat(this._outgoingRelations);
+
+                // Avoid triggering warnings about these relations being auto-detached:
+                this._outgoingRelations = undefined;
+
+                for (const outgoingRelation of outgoingRelations) {
+                    if (outgoingRelation.hrefType === 'inline') {
                         // Remove inline asset
                         this.assetGraph.removeAsset(outgoingRelation.to);
                     }
                 }
             }
-            this._outgoingRelations = undefined;
         }
         this.isPopulated = undefined;
         this._rawSrc = undefined;
@@ -977,21 +981,19 @@ class Asset extends EventEmitter {
         }
         const clone = new this.constructor(constructorOptions);
 
-        if (this.assetGraph) {
-            this.assetGraph.addAsset(clone);
-            if (!this.isInline) {
-                clone.externalize(this.url);
+        this.assetGraph.addAsset(clone);
+        if (!this.isInline) {
+            clone.externalize(this.url);
+        }
+        if (incomingRelations) {
+            if (!Array.isArray(incomingRelations)) {
+                incomingRelations = [incomingRelations];
             }
-            if (incomingRelations) {
-                if (incomingRelations.isRelation) {
-                    incomingRelations = [incomingRelations];
+            for (const incomingRelation of incomingRelations) {
+                if (!incomingRelation || !incomingRelation.isRelation) {
+                    throw new Error('asset.clone(): Incoming relation is not a relation: ' + incomingRelation.toString());
                 }
-                for (const incomingRelation of incomingRelations) {
-                    if (!incomingRelation || !incomingRelation.isRelation) {
-                        throw new Error('asset.clone(): Incoming relation is not a relation: ' + incomingRelation.toString());
-                    }
-                    incomingRelation._to = clone;
-                }
+                incomingRelation.to = clone;
             }
         }
         return clone;

--- a/lib/transforms/convertStylesheetsToInlineStyles.js
+++ b/lib/transforms/convertStylesheetsToInlineStyles.js
@@ -31,8 +31,9 @@ module.exports = (queryObj, media) => {
                     if (includeMedia(relationMedia)) {
                         return true;
                     } else {
-                        if (assetGraph.findRelations({to: relation.to}).length === 1) {
-                            assetGraph.removeAsset(relation.to, true);
+                        relation.detach();
+                        if (relation.to.incomingRelations.length === 0) {
+                            assetGraph.removeAsset(relation.to);
                         }
                     }
                 }
@@ -88,10 +89,9 @@ module.exports = (queryObj, media) => {
                             }
                         }
                     });
-                    if (assetGraph.findRelations({to: cssAsset}).length === 1) {
-                        assetGraph.removeAsset(cssAsset, true);
-                    } else {
-                        incomingRelation.detach();
+                    incomingRelation.detach();
+                    if (cssAsset.incomingRelations.length === 0) {
+                        assetGraph.removeAsset(cssAsset);
                     }
                 }
             });

--- a/lib/transforms/removeEmptyJavaScripts.js
+++ b/lib/transforms/removeEmptyJavaScripts.js
@@ -23,7 +23,7 @@ module.exports = queryObj => {
                 }
             }
             if (everyIncomingRelationRemoved) {
-                assetGraph.removeAsset(asset, true);
+                assetGraph.removeAsset(asset);
             }
         }
     };

--- a/lib/transforms/removeEmptyStylesheets.js
+++ b/lib/transforms/removeEmptyStylesheets.js
@@ -23,7 +23,7 @@ module.exports = queryObj => {
                 }
             }
             if (everyIncomingRelationRemoved) {
-                assetGraph.removeAsset(asset, true);
+                assetGraph.removeAsset(asset);
             }
         }
     };

--- a/lib/transforms/splitCssIfIeLimitIsReached.js
+++ b/lib/transforms/splitCssIfIeLimitIsReached.js
@@ -103,10 +103,15 @@ module.exports = (queryObj, options) => {
                             to: replacement
                         }, 'before', oldRelation);
                     }
+                    oldRelation.from.removeRelation(oldRelation);
                 }
 
-                // Remove all traces of the oiginal to large Css asset
-                assetGraph.removeAsset(largeAsset, true);
+                // Remove all traces of the original to large Css asset
+                // We're reusing the parseTree of largeAsset, so make sure that
+                // the relations don't get detached from it as a side effect
+                // of AssetGraph#removeAsset:
+                largeAsset.outgoingRelations = [];
+                assetGraph.removeAsset(largeAsset);
             }
         }
     };

--- a/test/transforms/serializeSourceMaps.js
+++ b/test/transforms/serializeSourceMaps.js
@@ -120,7 +120,7 @@ describe('transforms/serializeSourceMaps', function () {
                         source: assetGraph.root + 'bogus.js'
                     }).body[0]);
                     myScript.markDirty();
-                    var clonedMyScript = myScript.clone();
+                    var clonedMyScript = myScript.clone(myScript.incomingRelations);
                     assetGraph.removeAsset(myScript);
                     clonedMyScript.url = assetGraph.root + 'clonedMyScript.js';
                 })


### PR DESCRIPTION
This is a spinoff from #761, namely this idea:

* Disallow removing assets that have incoming relations -- leave them in the graph (maybe .unload() them instead). The benefit is that relations won't have a "dangling" state where they don't point to an instantiated asset, thus simplifying the model a lot. Peter: Consider just detaching all incoming relations when an asset is removed.