### PR TITLE
Turn Relation#to into a setter and try to DTRT when it's updated

### DIFF
--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -720,7 +720,7 @@ class Asset extends EventEmitter {
             outgoingRelation = new AssetGraph[type](outgoingRelation);
             if (outgoingRelation.to && this.assetGraph) {
                 // Implicitly create the target asset:
-                outgoingRelation.to = this.assetGraph.addAsset(outgoingRelation.to, outgoingRelation);
+                outgoingRelation._to = this.assetGraph.addAsset(outgoingRelation.to, outgoingRelation);
                 const targetType = outgoingRelation.targetType;
                 if (targetType && !outgoingRelation.to._isCompatibleWith(targetType)) {
                     this.assetGraph.warn(new Error(`${outgoingRelation.to.urlOrDescription} used as both ${targetType} and ${outgoingRelation.to.type}`));
@@ -846,7 +846,6 @@ class Asset extends EventEmitter {
     set incomingRelations(incomingRelations) {
         for (const relation of incomingRelations) {
             relation.to = this;
-            relation.refreshHref();
         }
     }
 
@@ -890,7 +889,6 @@ class Asset extends EventEmitter {
         newAsset = this.assetGraph.addAsset(newAsset);
         for (const incomingRelation of this.incomingRelations) {
             incomingRelation.to = newAsset;
-            incomingRelation.refreshHref();
         }
         this.assetGraph.removeAsset(this);
         if (this.url) {
@@ -984,8 +982,7 @@ class Asset extends EventEmitter {
                     if (!incomingRelation || !incomingRelation.isRelation) {
                         throw new Error('asset.clone(): Incoming relation is not a relation: ' + incomingRelation.toString());
                     }
-                    incomingRelation.to = clone;
-                    incomingRelation.refreshHref();
+                    incomingRelation._to = clone;
                 }
             }
         }

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -44,6 +44,10 @@ class Relation {
             this._hrefType = config.hrefType;
             config.hrefType = undefined;
         }
+        if (config.to) {
+            this._to = config.to;
+            config.to = undefined;
+        }
         extendDefined(this, config);
         this.id = '' + _.uniqueId();
     }
@@ -56,13 +60,19 @@ class Relation {
      */
 
     /**
-     * relation.to (Asset or asset config object)
-     * ==========================================
+     * relation.to (Asset)
+     * ===================
      *
-     * The target asset of the relation. If the relation hasn't yet
-     * been resolved, it can also be a relative url string or an asset
-     * configuration object.
+     * The target asset of the relation.
      */
+    get to() {
+        return this._to;
+    }
+
+    set to(to) {
+        this._to = this.from.assetGraph.addAsset(to, this);
+        this.refreshHref();
+    }
 
     /**
      * relation.href (getter/setter)

--- a/lib/transforms/inlineCssImagesWithLegacyFallback.js
+++ b/lib/transforms/inlineCssImagesWithLegacyFallback.js
@@ -117,7 +117,6 @@ module.exports = (queryObj, options) => {
                 if (existingAsset && existingAsset !== cssImage.to) {
                     potentiallyOrphanedAssets.add(cssImage.to);
                     cssImage.to = existingAsset;
-                    cssImage.refreshHref(); // Avoid by turning Relation#to into a getter/setter?
                 } else {
                     cssImage.to.url = strippedUrl;
                 }

--- a/lib/transforms/mergeIdenticalAssets.js
+++ b/lib/transforms/mergeIdenticalAssets.js
@@ -19,7 +19,6 @@ module.exports = queryObj => {
                             incomingRelation.detach();
                         } else {
                             incomingRelation.to = identicalAsset;
-                            incomingRelation.refreshHref();
                         }
                     }
                     assetGraph.removeAsset(asset);

--- a/test/relations/Relation.js
+++ b/test/relations/Relation.js
@@ -470,4 +470,73 @@ describe('relations/Relation', function () {
             });
         });
     });
+
+    describe('#to', function () {
+        describe('when used as a setter', function () {
+            describe('when an asset config is passed', function () {
+                it('should add the target asset to the graph', function () {
+                    const assetGraph = new AssetGraph();
+                    const htmlAsset = assetGraph.addAsset({
+                        type: 'Html',
+                        url: 'https://example.com/',
+                        text: `
+                            <!DOCTYPE html>
+                            <html>
+                                <head></head>
+                                <body>
+                                    <a href="https://example.com/other.html">Link</a>
+                                </body>
+                            </html>
+                        `
+                    });
+
+                    htmlAsset.outgoingRelations[0].to = 'https://blah.com/whataboutthis/';
+
+                    expect(htmlAsset.text, 'to contain', '<a href="https://blah.com/whataboutthis/">');
+
+                    expect(assetGraph, 'to contain asset', {
+                        type: 'Asset',
+                        url: 'https://blah.com/whataboutthis/'
+                    });
+
+                    htmlAsset.outgoingRelations[0].to = {
+                        url: 'https://whatdoyouknow.com/whataboutthis/'
+                    };
+
+                    expect(assetGraph, 'to contain asset', {
+                        type: 'Asset',
+                        url: 'https://whatdoyouknow.com/whataboutthis/'
+                    });
+                });
+            });
+
+            describe('when an existing asset is passed', function () {
+                it('should automatically refresh the href of the relation', function () {
+                    const assetGraph = new AssetGraph();
+                    const htmlAsset = assetGraph.addAsset({
+                        type: 'Html',
+                        url: 'https://example.com/',
+                        text: `
+                            <!DOCTYPE html>
+                            <html>
+                                <head></head>
+                                <body>
+                                    <a href="https://example.com/other.html">Link</a>
+                                </body>
+                            </html>
+                        `
+                    });
+
+                    const imageAsset = assetGraph.addAsset({
+                        type: 'Png',
+                        url: 'https://example.com/images/foo.png'
+                    });
+
+                    htmlAsset.outgoingRelations[0].to = imageAsset;
+
+                    expect(htmlAsset.text, 'to contain', '<a href="https://example.com/images/foo.png">');
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
The benefits of this are described pretty well by the enclosed tests -- look for the places where a relation's `to` property is being updated and the subsequent automatic adding of the target asset to the graph and the refreshing of the relation's href.