### PR TITLE
Improve support for the content CSS property

### DIFF
--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -1,0 +1,37 @@
+function unescapeCssString(cssString) {
+    return cssString.replace(/\\([0-9a-f]{1,6})\s*/ig, function ($0, hexDigits) {
+        return String.fromCharCode(parseInt(hexDigits, 16));
+    })
+        .replace(/\\n/g, '\n')
+        .replace(/\\t/g, '\t')
+        .replace(/\\/g, '');
+}
+
+function extractTextFromContentPropertyValue(value, node) {
+    if (value === 'none' || value === 'normal' || typeof value === 'undefined') {
+        return '';
+    } else {
+        // <content-list> = [ <string> | contents | <image> | <quote> | <target> | <leader()> ]+
+
+        var text = '';
+        value.replace(/(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\))|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^'"]+)/g, function ($0, url, doubleQuotedString, singleQuotedString, other) {
+            if (typeof doubleQuotedString === 'string') {
+                text += unescapeCssString(doubleQuotedString);
+            } else if (typeof singleQuotedString === 'string') {
+                text += unescapeCssString(singleQuotedString);
+            } else if (url) {
+                // ignore
+            } else {
+                var matchAttr = other.trim().match(/^attr\(([\w-]+)\)$/);
+                if (matchAttr) {
+                    var attributeValue = node.getAttribute(matchAttr[1]);
+                    if (attributeValue) {
+                        text += attributeValue;
+                    }
+                }
+            }
+        });
+        return text;
+    }
+}
+module.exports = extractTextFromContentPropertyValue;

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -7,7 +7,28 @@ function unescapeCssString(cssString) {
         .replace(/\\/g, '');
 }
 
-function extractTextFromContentPropertyValue(value, node) {
+function extractQuotes(quotes, token) {
+    if (!quotes || quotes === 'none') {
+        return '';
+    }
+    var text = '';
+    var num = 0;
+    // Tokenize the quotes attribute into quoted strings, eg.: '>>' '<<'
+    quotes.replace(/"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'/g, function ($0, doubleQuotedString, singleQuotedString) {
+        if ((token === 'open-quote' && num % 2 === 0) || (token === 'close-quote' && num % 2 === 1)) {
+            if (typeof doubleQuotedString === 'string') {
+                text += unescapeCssString(doubleQuotedString);
+            } else {
+                // typeof singleQuotedString === 'string'
+                text += unescapeCssString(singleQuotedString);
+            }
+        }
+        num += 1;
+    });
+    return text;
+}
+
+function extractTextFromContentPropertyValue(value, node, quotes) {
     if (value === 'none' || value === 'normal' || typeof value === 'undefined') {
         return '';
     } else {
@@ -22,11 +43,16 @@ function extractTextFromContentPropertyValue(value, node) {
             } else if (url) {
                 // ignore
             } else {
-                var matchAttr = other.trim().match(/^attr\(([\w-]+)\)$/);
-                if (matchAttr) {
-                    var attributeValue = node.getAttribute(matchAttr[1]);
-                    if (attributeValue) {
-                        text += attributeValue;
+                other = other.trim();
+                if (other === 'open-quote' || other === 'close-quote') {
+                    text += extractQuotes(quotes, other);
+                } else {
+                    var matchAttr = other.trim().match(/^attr\(([\w-]+)\)$/);
+                    if (matchAttr) {
+                        var attributeValue = node.getAttribute(matchAttr[1]);
+                        if (attributeValue) {
+                            text += attributeValue;
+                        }
                     }
                 }
             }

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -10,7 +10,7 @@ var gatherStylesheetsWithIncomingMedia = require('./gatherStylesheetsWithIncomin
 var getCssRulesByProperty = require('./getCssRulesByProperty');
 var extractTextFromContentPropertyValue = require('./extractTextFromContentPropertyValue');
 
-var FONT_PROPS = [
+var PROPS = [
     'font-family',
     'font-style',
     'font-weight',
@@ -52,7 +52,7 @@ var excludedNodes = ['HEAD', 'STYLE', 'SCRIPT'];
 function getFontRulesWithDefaultStylesheetApplied(htmlAsset, memoizedGetCssRulesByProperty) {
     var fontPropRules = [{ text: defaultStylesheet, incomingMedia: [] }].concat(gatherStylesheetsWithIncomingMedia(htmlAsset.assetGraph, htmlAsset))
         .map(function (stylesheetAndIncomingMedia) {
-            return memoizedGetCssRulesByProperty(FONT_PROPS, stylesheetAndIncomingMedia.text, stylesheetAndIncomingMedia.incomingMedia);
+            return memoizedGetCssRulesByProperty(PROPS, stylesheetAndIncomingMedia.text, stylesheetAndIncomingMedia.incomingMedia);
         })
         .reduce(function (rules, current) {
             // Input:
@@ -109,14 +109,14 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
 
         // Stop condition. We moved above <HTML>
         if (!node.tagName) {
-            FONT_PROPS.forEach(function (prop) {
+            PROPS.forEach(function (prop) {
                 result[prop] = [ { value: INITIAL_VALUES[prop], truePredicates: truePredicates, falsePredicates: falsePredicates }];
             });
             return result;
         }
 
         if (node.getAttribute('style')) {
-            var attributeStyles = memoizedGetCssRulesByProperty(FONT_PROPS, 'bogusselector { ' + node.getAttribute('style') + ' }', []);
+            var attributeStyles = memoizedGetCssRulesByProperty(PROPS, 'bogusselector { ' + node.getAttribute('style') + ' }', []);
 
             Object.keys(attributeStyles).forEach(function (prop) {
                 if (attributeStyles[prop].length > 0) {
@@ -241,7 +241,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
             }
         }
 
-        FONT_PROPS.forEach(function (prop) {
+        PROPS.forEach(function (prop) {
             result[prop] = traceProp(prop, 0, truePredicates, falsePredicates);
         });
         return result;
@@ -431,9 +431,9 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         return expandPermutations(styledText)
             .filter(function removeImpossibleCombinations(hypotheticalValuesByProp) {
                 // Check that none of the predicates assumed true are assumed false, too:
-                return FONT_PROPS.every(function (prop) {
+                return PROPS.every(function (prop) {
                     return Object.keys(hypotheticalValuesByProp[prop].truePredicates).every(function (truePredicate) {
-                        return FONT_PROPS.every(function (otherProp) {
+                        return PROPS.every(function (otherProp) {
                             return !hypotheticalValuesByProp[otherProp].falsePredicates[truePredicate];
                         });
                     });
@@ -441,7 +441,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             })
             .map(function (hypotheticalValuesByProp) {
                 var props = {};
-                FONT_PROPS.forEach(function (prop) {
+                PROPS.forEach(function (prop) {
                     props[prop] = hypotheticalValuesByProp[prop].value;
                 });
                 return props;
@@ -449,7 +449,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             .filter(function deduplicate(textWithProps) {
                 // Unwrap the "hypothetical value" objects:
                 var permutationKey = '';
-                FONT_PROPS.forEach(function (prop) {
+                PROPS.forEach(function (prop) {
                     permutationKey += prop + '\x1d' + textWithProps[prop] + '\x1d';
                 });
                 // Deduplicate:

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -14,14 +14,16 @@ var FONT_PROPS = [
     'font-family',
     'font-style',
     'font-weight',
-    'content'
+    'content',
+    'quotes'
 ];
 
 var INITIAL_VALUES = {
     // 'font-family': 'serif'
     'font-weight': 400,
     'font-style': 'normal',
-    content: 'normal'
+    content: 'normal',
+    quotes: '"«" "»" "‹" "›" "‘" "’" "\'" "\'" "\\"" "\\""' // Wide default set to account for browser differences
 };
 
 var NAME_CONVERSIONS = {
@@ -367,11 +369,21 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             var truePredicates = {};
             truePredicates['pseudoElement:' + pseudoElement] = true;
             var computedStyle = Object.assign({}, getComputedStyle(nodeObj.node, nodeObj.id, truePredicates));
-            computedStyle.content = computedStyle.content.map(function (content) {
-                return Object.assign({}, content, { value: extractTextFromContentPropertyValue(content.value, nodeObj.node) });
-            }).filter(function (content) {
-                return content.value;
+            var expandedContents = [];
+            // Multiply the hypothetical content values with the hypothetical quotes values:
+            computedStyle.content.forEach(function (hypotheticalContent) {
+                computedStyle.quotes.forEach(function (hypotheticalQuotes) {
+                    var text = extractTextFromContentPropertyValue(hypotheticalContent.value, nodeObj.node, hypotheticalQuotes.value);
+                    if (text) {
+                        expandedContents.push({
+                            value: text,
+                            falsePredicates: Object.assign({}, hypotheticalQuotes.falsePredicates, hypotheticalContent.falsePredicates),
+                            truePredicates: Object.assign({}, hypotheticalQuotes.truePredicates, hypotheticalContent.truePredicates)
+                        });
+                    }
+                });
             });
+            computedStyle.content = expandedContents;
             if (computedStyle.content.length > 0) {
                 styledTexts.push(computedStyle);
             }
@@ -450,7 +462,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             .map(function (styledText) {
                 return {
                     text: styledText.content,
-                    props: _.omit(styledText, 'content')
+                    props: _.omit(styledText, 'content', 'quotes')
                 };
             });
     }));

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -8,6 +8,7 @@ var cssPseudoElementRegExp = require('../cssPseudoElementRegExp');
 var stripPseudoClassesFromSelector = require('./stripPseudoClassesFromSelector');
 var gatherStylesheetsWithIncomingMedia = require('./gatherStylesheetsWithIncomingMedia');
 var getCssRulesByProperty = require('./getCssRulesByProperty');
+var extractTextFromContentPropertyValue = require('./extractTextFromContentPropertyValue');
 
 var FONT_PROPS = [
     'font-family',
@@ -20,7 +21,7 @@ var INITIAL_VALUES = {
     // 'font-family': 'serif'
     'font-weight': 400,
     'font-style': 'normal',
-    content: undefined
+    content: 'normal'
 };
 
 var NAME_CONVERSIONS = {
@@ -137,10 +138,12 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                 var isStyleAttribute = declaration.specificityArray[0] === 1;
                 var strippedSelector = !isStyleAttribute && stripPseudoClassesFromSelector(declaration.selector);
                 var hasPseudoClasses = strippedSelector !== declaration.selector;
+                var hasPseudoElement = false;
 
                 if (!isStyleAttribute) {
                     var matchPseudoElement = strippedSelector.match(/^(.*?)::?(before|after)$/);
                     if (matchPseudoElement) {
+                        hasPseudoElement = true;
                         // The selector ends with :before or :after
                         if (truePredicates['pseudoElement:' + matchPseudoElement[2]]) {
                             strippedSelector = matchPseudoElement[1];
@@ -180,7 +183,8 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                             }
                         } else if (prop === 'font-family') {
                             value = unquote(declaration.value);
-                        } else {
+                        } else if (prop !== 'content' || hasPseudoElement) {
+                            // content: ... is not inherited, has to be applied directly to the pseudo element
                             value = declaration.value;
                         }
 
@@ -364,21 +368,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             truePredicates['pseudoElement:' + pseudoElement] = true;
             var computedStyle = Object.assign({}, getComputedStyle(nodeObj.node, nodeObj.id, truePredicates));
             computedStyle.content = computedStyle.content.map(function (content) {
-                if (content.value) {
-                    var matchAttr = content.value.match(/^attr\(([\w-]+)\)$/);
-                    var text;
-                    if (matchAttr) {
-                        var attributeValue = nodeObj.node.getAttribute(matchAttr[1]);
-                        if (attributeValue) {
-                            text = attributeValue;
-                        }
-                    } else {
-                        text = unquote(content.value);
-                    }
-                    return Object.assign({}, content, { value: text });
-                } else {
-                    return content;
-                }
+                return Object.assign({}, content, { value: extractTextFromContentPropertyValue(content.value, nodeObj.node) });
             }).filter(function (content) {
                 return content.value;
             });

--- a/test/util/fonts/extractTextFromContentPropertyValue.js
+++ b/test/util/fonts/extractTextFromContentPropertyValue.js
@@ -1,0 +1,55 @@
+var extractTextFromContentPropertyValue = require('../../../lib/util/fonts/extractTextFromContentPropertyValue');
+var sinon = require('sinon');
+var expect = require('../../unexpected-with-plugins').clone()
+    .addAssertion('<array> to come out as <string>', function (expect, subject, value) {
+        expect(extractTextFromContentPropertyValue(subject[0], subject[1]), 'to equal', value);
+    })
+    .addAssertion('<string> to come out as <string>', function (expect, subject, value) {
+        expect([subject], 'to come out as', value);
+    });
+
+describe('extractTextFromContentPropertyValue', function () {
+    it('should return empty string for none', function () {
+        expect('none', 'to come out as', '');
+    });
+
+    it('should return empty string for normal', function () {
+        expect('none', 'to come out as', '');
+    });
+
+    it('should decode a single quoted string', function () {
+        expect('\'foo\'', 'to come out as', 'foo');
+    });
+
+    it('should decode a double quoted string', function () {
+        expect('"foo"', 'to come out as', 'foo');
+    });
+
+    it('should support an escaped single quote in a single quoted string', function () {
+        expect('\'fo\\\'o\'', 'to come out as', 'fo\'o');
+    });
+
+    it('should support an escaped double quote in a double quoted string', function () {
+        expect('"fo\\"o"', 'to come out as', 'fo"o');
+    });
+
+    it('should support escaped hex digits', function () {
+        expect('"foo\\263a"', 'to come out as', 'foo☺');
+    });
+
+    it('should ignore a single whitespace after escaped hex digits', function () {
+        expect('"f\\263a oo"', 'to come out as', 'f☺oo');
+    });
+
+    it('should ignore an image', function () {
+        expect('url("foo.png")', 'to come out as', '');
+    });
+
+    it('should support attr(...) tokens', function () {
+        var fakeNode = { getAttribute: sinon.stub().named('getAttribute').returns('bar') };
+        expect(['attr(data-foo)', fakeNode], 'to come out as', 'bar');
+        expect(fakeNode, 'to have calls satisfying', function () {
+            fakeNode.getAttribute('data-foo');
+        });
+    });
+});

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -939,7 +939,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
-        it('should support content: attr(...) mixes with quoted strings', function () {
+        it('should support content: attr(...) mixed with quoted strings', function () {
             var htmlText = [
                 '<style>div:after { content: "baz" attr(data-foo) "yadda"; font-family: font1; }</style>',
                 '<div data-foo="bar"></div>'

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -686,6 +686,99 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             return expect(htmlText, 'to exhaustively satisfy computed font properties', []);
         });
 
+        describe('with quotes', function () {
+            it('should include all start quote characters when open-quote is part of the content value', function () {
+                var htmlText = [
+                    '<style>div:after { quotes: "<" ">"; }</style>',
+                    '<style>div:after { content: open-quote; font-family: font1 !important; }</style>',
+                    '<div></div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: '<',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should include all end quote characters when close-quote is part of the content value', function () {
+                var htmlText = [
+                    '<style>div:after { quotes: "<" ">" "[" "]"; }</style>',
+                    '<style>div:after { content: close-quote; font-family: font1 !important; }</style>',
+                    '<div></div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: '>]',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should handle hypothetical values of quotes', function () {
+                var htmlText = [
+                    '<style>div:after { quotes: "<" ">"; }</style>',
+                    '<style>@media 3dglasses { div:after { quotes: "(" ")"; } }</style>',
+                    '<style>div:after { content: open-quote; font-family: font1 !important; }</style>',
+                    '<div></div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: '(',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    },
+                    {
+                        text: '<',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should assume a conservative set of the most common quote characters when the quotes property is not explicitly given', function () {
+                var htmlText = [
+                    '<q></q>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: '«‹‘\'"',
+                        props: {
+                            'font-family': undefined,
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    },
+                    {
+                        text: '»›’\'"',
+                        props: {
+                            'font-family': undefined,
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+        });
+
         it('should override re-definition of prop on :after pseudo-element', function () {
             var htmlText = [
                 '<style>h1::after { content: "after"; font-family: font1; }</style>',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -676,6 +676,16 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             return expect(htmlText, 'to exhaustively satisfy computed font properties', []);
         });
 
+        it('should not inherit the content property', function () {
+            var htmlText = [
+                '<style>h1 { content: "foo" }</style>',
+                '<style>h1:after { font-family: font1 !important; }</style>',
+                '<h1></h1>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', []);
+        });
+
         it('should override re-definition of prop on :after pseudo-element', function () {
             var htmlText = [
                 '<style>h1::after { content: "after"; font-family: font1; }</style>',
@@ -827,6 +837,24 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
                     text: 'bar',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
+        it('should support content: attr(...) mixes with quoted strings', function () {
+            var htmlText = [
+                '<style>div:after { content: "baz" attr(data-foo) "yadda"; font-family: font1; }</style>',
+                '<div data-foo="bar"></div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'bazbaryadda',
                     props: {
                         'font-family': 'font1',
                         'font-weight': 400,


### PR DESCRIPTION
Prereq: https://github.com/assetgraph/assetgraph/pull/774

* Do not inherit the property value from the parent
* Support singlequoted and doublequoted CSS strings with escaped values
* Support `<content-list>`, ie. two or more values in a sequence
  https://developer.mozilla.org/en-US/docs/Web/CSS/content#Formal_syntax

Still TODO:
- [ ] `<counter>`
- [x] open-quote, close-quote