### PR TITLE
Include list indicators in subset

### DIFF
--- a/lib/util/cssPseudoElementRegExp.js
+++ b/lib/util/cssPseudoElementRegExp.js
@@ -10,8 +10,23 @@ var pseudoElements = [
     'marker',
     'spelling-error',
     'grammar-error',
-    '-webkit-textfield-decoration-container', // Occurs in the default stylesheet we're using
-    '-internal-list-box' // Occurs in the default stylesheet we're using
+
+    // These occur in the default stylesheet we're using:
+    '-webkit-textfield-decoration-container',
+    '-internal-list-box',
+    '-webkit-color-swatch-wrapper',
+    '-webkit-media-slider-thumb',
+    '-webkit-slider-thumb',
+    '-webkit-slider-runnable-track',
+    '-webkit-media-slider-container',
+    '-webkit-slider-container',
+    '-webkit-search-results-decoration',
+    '-webkit-search-decoration',
+    '-webkit-search-cancel-button',
+    '-webkit-details-marker',
+    '-webkit-calendar-picker-indicator',
+    '-webkit-inner-spin-button',
+    '-webkit-clear-button'
 ];
 
 module.exports = new RegExp('::?(?:' + pseudoElements.join('|') + ')', 'gi');

--- a/lib/util/fonts/charactersByListStyleType.js
+++ b/lib/util/fonts/charactersByListStyleType.js
@@ -1,0 +1,19 @@
+module.exports = {
+    disc: '•',
+    circle: '', // Doesn't seem to be a glyph
+    square: '', // Doesn't seem to be a glyph
+    decimal: '0123456789',
+    'decimal-leading-zero': '0123456789',
+    'lower-roman': 'ivxlcdm',
+    'upper-roman': 'IVXLCDMↁↂↇↈ',
+    'lower-greek': '𐆊αβγδεϝζηθικλμνξοπϟρστυφχψωϡ͵μ',
+
+    'lower-latin': 'abcdefghijklmnopqrstuvwxyz',
+    'upper-latin': 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    armenian: '0աբգդեզէըթժիլխծկհձղճմյնշոչպջռսվտրցւփք',
+
+    georgian: '0აბგდევზჱთიკლმნჲოპჟრსტუჳფქღყშჩცძწჭხჴჵჯ',
+
+    'lower-alpha': 'abcdefghijklmnopqrstuvwxyz',
+    'upper-alpha': 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+};

--- a/lib/util/fonts/charactersByListStyleType.js
+++ b/lib/util/fonts/charactersByListStyleType.js
@@ -15,5 +15,6 @@ module.exports = {
     georgian: '0აბგდევზჱთიკლმნჲოპჟრსტუჳფქღყშჩცძწჭხჴჵჯ',
 
     'lower-alpha': 'abcdefghijklmnopqrstuvwxyz',
-    'upper-alpha': 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    'upper-alpha': 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    hebrew: '״׳אבגדהוזחטיכלמנסעפצקרשתףם'
 };

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -22,38 +22,130 @@ function extractQuotes(quotes, token) {
     return text;
 }
 
-function extractTextFromContentPropertyValue(value, node, quotes) {
-    if (value === 'none' || value === 'normal' || typeof value === 'undefined') {
-        return '';
-    } else {
-        // <content-list> = [ <string> | contents | <image> | <quote> | <target> | <leader()> ]+
-
-        var text = '';
-        value.replace(/(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\))|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|counter\(\s*[a-z0-9-]+\s*,\s*([a-z0-9-]+)\s*\)|([^'"]+)/g, function ($0, url, doubleQuotedString, singleQuotedString, counterStyle, other) {
-            if (typeof doubleQuotedString === 'string') {
-                text += unescapeCssString(doubleQuotedString);
-            } else if (typeof singleQuotedString === 'string') {
-                text += unescapeCssString(singleQuotedString);
-            } else if (url) {
-                // ignore
-            } else if (counterStyle) {
-                text += charactersByListStyleType[counterStyle] || '';
+function tokenizeContent(content) {
+    var tokens = [];
+    // <content-list> = [ <string> | contents | <image> | <quote> | <target> | <leader()> ]+
+    (content || 'normal').replace(/(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\))|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|counter\(\s*[a-z0-9-]+\s*,\s*([a-z0-9-]+)\s*\)|([^'"]+)/g, function ($0, url, doubleQuotedString, singleQuotedString, counterStyle, other) {
+        if (typeof doubleQuotedString === 'string') {
+            tokens.push({ type: 'string', value: unescapeCssString(doubleQuotedString) });
+        } else if (typeof singleQuotedString === 'string') {
+            tokens.push({ type: 'string', value: unescapeCssString(singleQuotedString) });
+        } else if (url) {
+            tokens.push({ type: 'url', value: url });
+        } else if (counterStyle) {
+            tokens.push({ type: 'counter', value: counterStyle });
+        } else {
+            other = other.trim();
+            if (other === 'open-quote' || other === 'close-quote') {
+                tokens.push({ type: other });
+            } else if (other === 'normal' || other === 'none') {
+                tokens.push({ type: other });
             } else {
-                other = other.trim();
-                if (other === 'open-quote' || other === 'close-quote') {
-                    text += extractQuotes(quotes, other);
+                var matchAttr = other.trim().match(/^attr\(([\w-]+)\)$/);
+                if (matchAttr) {
+                    tokens.push({ type: 'attr', value: matchAttr[1] });
                 } else {
-                    var matchAttr = other.trim().match(/^attr\(([\w-]+)\)$/);
-                    if (matchAttr) {
-                        var attributeValue = node.getAttribute(matchAttr[1]);
-                        if (attributeValue) {
-                            text += attributeValue;
-                        }
-                    }
+                    // throw new Error('Cannot parse token: ' + other);
+                    tokens.push({ type: 'string', value: other });
                 }
             }
+        }
+    });
+    return tokens;
+}
+
+function expandContent(tokens, node, quotes, hypotheticalCounterStyleByName) {
+    var text = '';
+    tokens.forEach(function (token) {
+        if (token.type === 'string') {
+            text += token.value;
+        } else if (token.type === 'counter') {
+            if (charactersByListStyleType[token.value]) {
+                text += charactersByListStyleType[token.value];
+            } else if (hypotheticalCounterStyleByName[token.value]) {
+                text += hypotheticalCounterStyleByName[token.value].value;
+            } else {
+                // Warn: Undefined counter style?
+            }
+        } else if (token.type === 'open-quote' || token.type === 'close-quote') {
+            text += extractQuotes(quotes, token.type);
+        } else if (token.type === 'attr') {
+            text += node.getAttribute(token.value) || '';
+        }
+    });
+    return text;
+}
+
+function expandHypotheticalCounterStylePermutations(hypotheticalCounterStyleValuesByName, referencedCounterStyleNames) {
+    var permutations = [];
+    var firstPropertyName = referencedCounterStyleNames[0];
+    var firstPropertyValues = hypotheticalCounterStyleValuesByName[referencedCounterStyleNames[0]];
+
+    for (var i = 0 ; i < Math.max(1, firstPropertyValues.length) ; i += 1) {
+        if (referencedCounterStyleNames.length > 1) {
+            expandHypotheticalCounterStylePermutations(hypotheticalCounterStyleValuesByName, referencedCounterStyleNames.slice(1)).forEach(function (permutation) {
+                permutation[firstPropertyName] = firstPropertyValues[i];
+                permutations.push(permutation);
+            });
+        } else {
+            var permutation = {};
+            permutation[firstPropertyName] = firstPropertyValues[i];
+            permutations.push(permutation);
+        }
+    }
+
+    return permutations;
+}
+
+function extractTextFromContentPropertyValue(value, node, hypotheticalQuotesValues, hypotheticalCounterStyleValuesByName) {
+    var tokens = tokenizeContent(value);
+    var isSeenByCounterStyle = {};
+    tokens.forEach(function (token) {
+        if (token.type === 'counter' && !charactersByListStyleType[token.value]) {
+            isSeenByCounterStyle[token.value] = true;
+        }
+    });
+    var usesQuotes = tokens.some(function (token) {
+        return token.type === 'open-quote' || token.type === 'close-quote';
+    });
+    function expandCounterStyles(quotes) {
+        var referencedCounterStyleNames = Object.keys(isSeenByCounterStyle);
+        if (referencedCounterStyleNames.length > 0) {
+            var result = [];
+            expandHypotheticalCounterStylePermutations(referencedCounterStyleNames).forEach(function (hypotheticalCounterStyleByName) {
+                var content = expandContent(tokens, node, quotes, hypotheticalCounterStyleByName);
+                if (content) {
+                    result.push({
+                        value: content,
+                        truePredicates: hypotheticalCounterStyleByName.reduce(function (acc, counterStyleName) {
+                            return Object.assign(acc, hypotheticalCounterStyleByName[counterStyleName].truePredicates);
+                        }, {}),
+                        falsePredicates: hypotheticalCounterStyleByName.reduce(function (acc, counterStyleName) {
+                            return Object.assign(acc, hypotheticalCounterStyleByName[counterStyleName].falsePredicates);
+                        }, {})
+                    });
+                }
+            });
+            return result;
+        } else {
+            return [{ value: expandContent(tokens, node, quotes), falsePredicates: {}, truePredicates: {}}];
+        }
+    }
+
+    if (usesQuotes) {
+        var result = [];
+        hypotheticalQuotesValues.forEach(function (hypotheticalQuotesValue) {
+            var expandedContentValues = expandCounterStyles(hypotheticalQuotesValue.value);
+            expandedContentValues.forEach(function (value) {
+                Object.assign(value.falsePredicates, hypotheticalQuotesValue.falsePredicates);
+                Object.assign(value.truePredicates, hypotheticalQuotesValue.truePredicates);
+            });
+            Array.prototype.push.apply(result, expandedContentValues);
         });
-        return text;
+        return result;
+    } else {
+        return expandCounterStyles();
     }
 }
+
 module.exports = extractTextFromContentPropertyValue;

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -1,11 +1,4 @@
-function unescapeCssString(cssString) {
-    return cssString.replace(/\\([0-9a-f]{1,6})\s*/ig, function ($0, hexDigits) {
-        return String.fromCharCode(parseInt(hexDigits, 16));
-    })
-        .replace(/\\n/g, '\n')
-        .replace(/\\t/g, '\t')
-        .replace(/\\/g, '');
-}
+var unescapeCssString = require('./unescapeCssString');
 
 function extractQuotes(quotes, token) {
     if (!quotes || quotes === 'none') {

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -1,5 +1,6 @@
 var unescapeCssString = require('./unescapeCssString');
 var charactersByListStyleType = require('./charactersByListStyleType');
+var getCounterCharacters = require('./getCounterCharacters');
 
 function extractQuotes(quotes, token) {
     if (!quotes || quotes === 'none') {
@@ -25,7 +26,7 @@ function extractQuotes(quotes, token) {
 function tokenizeContent(content) {
     var tokens = [];
     // <content-list> = [ <string> | contents | <image> | <quote> | <target> | <leader()> ]+
-    (content || 'normal').replace(/(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\))|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|counter\(\s*[a-z0-9-]+\s*,\s*([a-z0-9-]+)\s*\)|([^'"]+)/g, function ($0, url, doubleQuotedString, singleQuotedString, counterStyle, other) {
+    (content || 'normal').replace(/(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\))|counter\(\s*[a-z0-9-]+\s*,\s*([a-zA-Z0-9-]+)\s*\)|counters\(\s*[a-z0-9-]+\s*,\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)')\s*(?:,\s*([a-zA-Z0-9-]+)\s*)?\)|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^'"]+)/g, function ($0, url, counterStyle, doubleQuotedCountersSeparator, singleQuotedCountersSeparator, countersCounterStyle, doubleQuotedString, singleQuotedString, other) {
         if (typeof doubleQuotedString === 'string') {
             tokens.push({ type: 'string', value: unescapeCssString(doubleQuotedString) });
         } else if (typeof singleQuotedString === 'string') {
@@ -34,6 +35,10 @@ function tokenizeContent(content) {
             tokens.push({ type: 'url', value: url });
         } else if (counterStyle) {
             tokens.push({ type: 'counter', value: counterStyle });
+        } else if (typeof doubleQuotedCountersSeparator === 'string') {
+            tokens.push({ type: 'counters', separator: unescapeCssString(doubleQuotedCountersSeparator), value: countersCounterStyle || 'decimal' });
+        } else if (typeof singleQuotedCountersSeparator === 'string') {
+            tokens.push({ type: 'counters', separator: unescapeCssString(singleQuotedCountersSeparator), value: countersCounterStyle || 'decimal' });
         } else {
             other = other.trim();
             if (other === 'open-quote' || other === 'close-quote') {
@@ -59,13 +64,20 @@ function expandContent(tokens, node, quotes, hypotheticalCounterStyleByName) {
     tokens.forEach(function (token) {
         if (token.type === 'string') {
             text += token.value;
-        } else if (token.type === 'counter') {
+        } else if (token.type === 'counter' || token.type === 'counters') {
             if (charactersByListStyleType[token.value]) {
                 text += charactersByListStyleType[token.value];
             } else if (hypotheticalCounterStyleByName[token.value]) {
-                text += hypotheticalCounterStyleByName[token.value].value;
+                var counterStyles = [];
+                Object.keys(hypotheticalCounterStyleByName).forEach(function (counterStyleName) {
+                    counterStyles.push({ name: counterStyleName, predicates: hypotheticalCounterStyleByName[counterStyleName].predicates, props: hypotheticalCounterStyleByName[counterStyleName].value});
+                });
+                text += getCounterCharacters({ props: hypotheticalCounterStyleByName[token.value].value }, counterStyles);
             } else {
                 // Warn: Undefined counter style?
+            }
+            if (token.type === 'counters') {
+                text += token.separator;
             }
         } else if (token.type === 'open-quote' || token.type === 'close-quote') {
             text += extractQuotes(quotes, token.type);
@@ -101,7 +113,7 @@ function extractTextFromContentPropertyValue(value, node, hypotheticalQuotesValu
     var tokens = tokenizeContent(value);
     var isSeenByCounterStyle = {};
     tokens.forEach(function (token) {
-        if (token.type === 'counter' && !charactersByListStyleType[token.value]) {
+        if ((token.type === 'counter' || token.type === 'counters') && !charactersByListStyleType[token.value]) {
             isSeenByCounterStyle[token.value] = true;
         }
     });
@@ -112,15 +124,15 @@ function extractTextFromContentPropertyValue(value, node, hypotheticalQuotesValu
         var referencedCounterStyleNames = Object.keys(isSeenByCounterStyle);
         if (referencedCounterStyleNames.length > 0) {
             var result = [];
-            expandHypotheticalCounterStylePermutations(referencedCounterStyleNames).forEach(function (hypotheticalCounterStyleByName) {
+            expandHypotheticalCounterStylePermutations(hypotheticalCounterStyleValuesByName, referencedCounterStyleNames).forEach(function (hypotheticalCounterStyleByName) {
                 var content = expandContent(tokens, node, quotes, hypotheticalCounterStyleByName);
                 if (content) {
                     result.push({
                         value: content,
-                        truePredicates: hypotheticalCounterStyleByName.reduce(function (acc, counterStyleName) {
+                        truePredicates: Object.keys(hypotheticalCounterStyleByName).reduce(function (acc, counterStyleName) {
                             return Object.assign(acc, hypotheticalCounterStyleByName[counterStyleName].truePredicates);
                         }, {}),
-                        falsePredicates: hypotheticalCounterStyleByName.reduce(function (acc, counterStyleName) {
+                        falsePredicates: Object.keys(hypotheticalCounterStyleByName).reduce(function (acc, counterStyleName) {
                             return Object.assign(acc, hypotheticalCounterStyleByName[counterStyleName].falsePredicates);
                         }, {})
                     });

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -37,7 +37,7 @@ function extractTextFromContentPropertyValue(value, node, quotes) {
             } else if (url) {
                 // ignore
             } else if (counterStyle) {
-                text += (charactersByListStyleType[counterStyle] || '');
+                text += charactersByListStyleType[counterStyle] || '';
             } else {
                 other = other.trim();
                 if (other === 'open-quote' || other === 'close-quote') {

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -1,4 +1,5 @@
 var unescapeCssString = require('./unescapeCssString');
+var charactersByListStyleType = require('./charactersByListStyleType');
 
 function extractQuotes(quotes, token) {
     if (!quotes || quotes === 'none') {
@@ -28,13 +29,15 @@ function extractTextFromContentPropertyValue(value, node, quotes) {
         // <content-list> = [ <string> | contents | <image> | <quote> | <target> | <leader()> ]+
 
         var text = '';
-        value.replace(/(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\))|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|([^'"]+)/g, function ($0, url, doubleQuotedString, singleQuotedString, other) {
+        value.replace(/(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\))|"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|counter\(\s*[a-z0-9-]+\s*,\s*([a-z0-9-]+)\s*\)|([^'"]+)/g, function ($0, url, doubleQuotedString, singleQuotedString, counterStyle, other) {
             if (typeof doubleQuotedString === 'string') {
                 text += unescapeCssString(doubleQuotedString);
             } else if (typeof singleQuotedString === 'string') {
                 text += unescapeCssString(singleQuotedString);
             } else if (url) {
                 // ignore
+            } else if (counterStyle) {
+                text += (charactersByListStyleType[counterStyle] || '');
             } else {
                 other = other.trim();
                 if (other === 'open-quote' || other === 'close-quote') {

--- a/lib/util/fonts/getCounterCharacters.js
+++ b/lib/util/fonts/getCounterCharacters.js
@@ -1,0 +1,51 @@
+var unescapeCssString = require('./unescapeCssString');
+var unquote = require('./unquote');
+var charactersByListStyleType = require('./charactersByListStyleType');
+
+function getCounterCharacters(counterStyle, counterStyles) {
+    var text = '';
+    if (typeof counterStyle.props.symbols === 'string') {
+        counterStyle.props.symbols.replace(/"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\)|([^'" ]+))/g, function ($0, doubleQuotedString, singleQuotedString, url, other) {
+            if (typeof doubleQuotedString === 'string') {
+                text += unescapeCssString(doubleQuotedString);
+            } else if (typeof singleQuotedString === 'string') {
+                text += unescapeCssString(singleQuotedString);
+            } else if (typeof other === 'string') {
+                text += other.trim();
+            }
+        });
+    }
+    ['prefix', 'suffix'].forEach(function (propertyName) {
+        var value = counterStyle.props[propertyName];
+        if (typeof value === 'string') {
+            text += unescapeCssString(unquote(value));
+        }
+    });
+    ['additive-symbols', 'pad'].forEach(function (propertyName) {
+        var value = counterStyle.props[propertyName];
+        if (typeof value === 'string') {
+            value.replace(/\d+ (?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\)))/g, function ($0, doubleQuotedString, singleQuotedString) {
+                if (typeof doubleQuotedString === 'string') {
+                    text += unescapeCssString(doubleQuotedString);
+                } else if (typeof singleQuotedString === 'string') {
+                    text += unescapeCssString(singleQuotedString);
+                }
+            });
+        }
+    });
+    var fallback = counterStyle.props.fallback;
+    if (fallback) {
+        if (charactersByListStyleType[fallback]) {
+            text += charactersByListStyleType[fallback];
+        } else {
+            counterStyles.forEach(function (counterStyle) {
+                if (counterStyle.name === fallback) {
+                    text += getCounterCharacters(counterStyle, counterStyles);
+                }
+            });
+        }
+    }
+    return text;
+}
+
+module.exports = getCounterCharacters;

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -36,6 +36,19 @@ function eachDeclarationInParseTree(ruleOrStylesheet, declarationLambda, counter
     }(ruleOrStylesheet));
 }
 
+function makePredicates(incomingMedia, mediaQuery) {
+    var predicates = {};
+    (incomingMedia || []).forEach(function (incomingMedia) {
+        if (incomingMedia) {
+            predicates['incomingMedia:' + incomingMedia] = true;
+        }
+    });
+    if (mediaQuery) {
+        predicates['mediaQuery:' + mediaQuery] = true;
+    }
+    return predicates;
+}
+
 function getCssRulesByProperty(properties, cssSource, incomingMedia) {
     if (!Array.isArray(properties)) {
         throw new Error('properties argument must be an array');
@@ -63,10 +76,8 @@ function getCssRulesByProperty(properties, cssSource, incomingMedia) {
             specificity.calculate(node.parent.selector)
                 .forEach(function (specificityObject) {
                     var isStyleAttribute = specificityObject.selector === 'bogusselector';
-
                     rulesByProperty[node.prop].push({
-                        incomingMedia: incomingMedia,
-                        mediaQuery: mediaQuery,
+                        predicates: makePredicates(incomingMedia, mediaQuery),
                         selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
                         specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
                         prop: node.prop,
@@ -97,8 +108,7 @@ function getCssRulesByProperty(properties, cssSource, incomingMedia) {
                         var isStyleAttribute = specificityObject.selector === 'bogusselector';
 
                         rulesByProperty['list-style-type'].push({
-                            incomingMedia: incomingMedia,
-                            mediaQuery: mediaQuery,
+                            predicates: makePredicates(incomingMedia, mediaQuery),
                             selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
                             specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
                             prop: 'list-style-type',
@@ -138,7 +148,7 @@ function getCssRulesByProperty(properties, cssSource, incomingMedia) {
 
                             if (Array.isArray(rulesByProperty[prop])) {
                                 rulesByProperty[prop].push({
-                                    incomingMedia: [],
+                                    predicates: {},
                                     selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
                                     specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
                                     prop: prop,
@@ -156,8 +166,7 @@ function getCssRulesByProperty(properties, cssSource, incomingMedia) {
         });
         rulesByProperty.counterStyles.push({
             name: node.params,
-            incomingMedia: incomingMedia,
-            mediaQuery: mediaQuery,
+            predicates: makePredicates(incomingMedia, mediaQuery),
             props: props
         });
     });

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -9,12 +9,14 @@ var INITIAL_VALUES = {
     'font-style': 'normal'
 };
 
-function eachDeclarationInParseTree(ruleOrStylesheet, lambda) {
+function eachDeclarationInParseTree(ruleOrStylesheet, declarationLambda, counterStyleLambda) {
     var mediaQuery;
     (function visit(node) {
         // Check for selector. We might be in an at-rule like @font-face
         if (node.type === 'decl' && node.parent.selector) {
-            lambda(node, mediaQuery);
+            declarationLambda(node, mediaQuery);
+        } else if (node.type === 'atrule' && node.name === 'counter-style' && counterStyleLambda) {
+            counterStyleLambda(node, mediaQuery);
         }
 
         if (node.nodes) {
@@ -47,13 +49,15 @@ function getCssRulesByProperty(properties, cssSource, incomingMedia) {
 
     var parseTree = postcss.parse(cssSource);
 
-    var rulesByProperty = {};
+    var rulesByProperty = {
+        counterStyles: []
+    };
 
     properties.forEach(function (property) {
         rulesByProperty[property] = [];
     });
 
-    eachDeclarationInParseTree(parseTree, function (node, mediaQuery) {
+    eachDeclarationInParseTree(parseTree, function onCssDeclaration(node, mediaQuery) {
         if (properties.indexOf(node.prop) !== -1) {
             // Split up combined selectors as they might have different specificity
             specificity.calculate(node.parent.selector)
@@ -144,8 +148,18 @@ function getCssRulesByProperty(properties, cssSource, incomingMedia) {
                             }
                         });
                 });
-
         }
+    }, function onCounterStyle(node, mediaQuery) {
+        var props = {};
+        node.nodes.forEach(function (childNode) {
+            props[childNode.prop] = childNode.value;
+        });
+        rulesByProperty.counterStyles.push({
+            name: node.params,
+            incomingMedia: incomingMedia,
+            mediaQuery: mediaQuery,
+            props: props
+        });
     });
 
     // TODO: Collapse into a single object for duplicate values?

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -1,14 +1,13 @@
 var specificity = require('specificity');
 var postcss = require('postcss');
 var cssFontParser = require('css-font-parser');
+var charactersByListStyleType = require('./charactersByListStyleType');
 
 var INITIAL_VALUES = {
     // 'font-family': 'serif',
     'font-weight': 400,
     'font-style': 'normal'
 };
-
-var SUPPORTED_SHORTHANDS = ['font'];
 
 function eachDeclarationInParseTree(ruleOrStylesheet, lambda) {
     var mediaQuery;
@@ -71,7 +70,40 @@ function getCssRulesByProperty(properties, cssSource, incomingMedia) {
                         important: !!node.important
                     });
                 });
-        } else if (SUPPORTED_SHORTHANDS.indexOf(node.prop) !== -1) {
+        } else if (node.prop === 'list-style' && properties.indexOf('list-style-type') !== -1) { // Shorthand
+            var listStyleType;
+            node.value.replace(/"((?:[^"]|\\.)*")|'((?:[^']|\\.)*)'|([^'"]+)/, function ($0, doubleQuotedString, singleQuotedString, other) {
+                if (typeof doubleQuotedString === 'string') {
+                    listStyleType = doubleQuotedString;
+                } else if (typeof singleQuotedString === 'string') {
+                    listStyleType = singleQuotedString;
+                } else if (other) {
+                    other.trim().split(' ').forEach(function (otherFragment) {
+                        if (typeof charactersByListStyleType[otherFragment] === 'string') {
+                            listStyleType = otherFragment;
+                        }
+                    });
+                }
+            });
+
+            if (typeof listStyleType !== 'undefined') {
+                // Split up combined selectors as they might have different specificity
+                specificity.calculate(node.parent.selector)
+                    .forEach(function (specificityObject) {
+                        var isStyleAttribute = specificityObject.selector === 'bogusselector';
+
+                        rulesByProperty['list-style-type'].push({
+                            incomingMedia: incomingMedia,
+                            mediaQuery: mediaQuery,
+                            selector: isStyleAttribute ? undefined : specificityObject.selector.trim(),
+                            specificityArray: isStyleAttribute ? [1, 0, 0, 0] : specificityObject.specificityArray,
+                            prop: 'list-style-type',
+                            value: listStyleType,
+                            important: !!node.important
+                        });
+                    });
+            }
+        } else if (node.prop === 'font') { // Shorthand
             var fontProperties = cssFontParser(node.value);
 
             // If the shorthand value was invalid we get null in return

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -389,7 +389,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 Object.assign(
                     {},
                     getComputedStyle(textNodeObj.node.parentNode, textNodeObj.parentId),
-                    { content: [ { value: textNodeObj.node.textContent.trim(), truePredicates: [], falsePredicates: [] } ] }
+                    { content: [ { value: textNodeObj.node.textContent.trim(), truePredicates: {}, falsePredicates: {} } ] }
                 )
             )
         );
@@ -401,7 +401,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 Object.assign(
                     {},
                     getComputedStyle(nodeObj.node, nodeObj.id),
-                    { content: [ { value: nodeObj.text, truePredicates: [], falsePredicates: [] } ] }
+                    { content: [ { value: nodeObj.text, truePredicates: {}, falsePredicates: {} } ] }
                 )
             )
         );

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -22,6 +22,8 @@ var PROPS = [
     'display'
 ];
 
+var PROPS_AND_TEXT = ['text'].concat(PROPS);
+
 var INITIAL_VALUES = {
     // 'font-family': 'serif'
     'font-weight': 400,
@@ -432,9 +434,8 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         styledTexts.push(
             expandListIndicators(
                 Object.assign(
-                    {},
-                    getComputedStyle(textNodeObj.node.parentNode, textNodeObj.parentId),
-                    { content: [ { value: textNodeObj.node.textContent.trim(), truePredicates: {}, falsePredicates: {} } ] }
+                    { text: [ { value: textNodeObj.node.textContent.trim(), truePredicates: {}, falsePredicates: {} } ] },
+                    getComputedStyle(textNodeObj.node.parentNode, textNodeObj.parentId)
                 ),
                 fontPropRules.counterStyles
             )
@@ -445,9 +446,8 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         styledTexts.push(
             expandListIndicators(
                 Object.assign(
-                    {},
-                    getComputedStyle(nodeObj.node, nodeObj.id),
-                    { content: [ { value: nodeObj.text, truePredicates: {}, falsePredicates: {} } ] }
+                    { text: [ { value: nodeObj.text, truePredicates: {}, falsePredicates: {} } ] },
+                    getComputedStyle(nodeObj.node, nodeObj.id)
                 ),
                 fontPropRules.counterStyles
             )
@@ -469,7 +469,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 });
                 Array.prototype.push.apply(expandedContents, hypotheticalValues);
             });
-            computedStyle.content = expandedContents;
+            computedStyle.text = expandedContents;
             if (computedStyle.content.length > 0) {
                 styledTexts.push(computedStyle);
             }
@@ -517,9 +517,9 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         return expandPermutations(styledText)
             .filter(function removeImpossibleCombinations(hypotheticalValuesByProp) {
                 // Check that none of the predicates assumed true are assumed false, too:
-                return PROPS.every(function (prop) {
+                return PROPS_AND_TEXT.every(function (prop) {
                     return Object.keys(hypotheticalValuesByProp[prop].truePredicates).every(function (truePredicate) {
-                        return PROPS.every(function (otherProp) {
+                        return PROPS_AND_TEXT.every(function (otherProp) {
                             return !hypotheticalValuesByProp[otherProp].falsePredicates[truePredicate];
                         });
                     });
@@ -527,18 +527,18 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             })
             .map(function (hypotheticalValuesByProp) {
                 var props = {};
-                PROPS.forEach(function (prop) {
+                PROPS_AND_TEXT.forEach(function (prop) {
                     props[prop] = hypotheticalValuesByProp[prop].value;
                 });
                 return props;
             })
             .filter(function filterAndDeduplicate(textWithProps) {
-                if (!textWithProps.content) {
+                if (!textWithProps.text) {
                     return false;
                 }
                 // Unwrap the "hypothetical value" objects:
                 var permutationKey = '';
-                ['font-weight', 'font-style', 'font-family', 'content'].forEach(function (prop) {
+                ['font-weight', 'font-style', 'font-family', 'text'].forEach(function (prop) {
                     permutationKey += prop + '\x1d' + textWithProps[prop] + '\x1d';
                 });
 
@@ -551,8 +551,8 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             // Maybe this mapping step isn't necessary:
             .map(function (styledText) {
                 return {
-                    text: styledText.content,
-                    props: _.omit(styledText, 'content', 'quotes', 'display', 'list-style-type')
+                    text: styledText.text,
+                    props: _.omit(styledText, 'content', 'quotes', 'display', 'list-style-type', 'text')
                 };
             });
     }));

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -9,13 +9,17 @@ var stripPseudoClassesFromSelector = require('./stripPseudoClassesFromSelector')
 var gatherStylesheetsWithIncomingMedia = require('./gatherStylesheetsWithIncomingMedia');
 var getCssRulesByProperty = require('./getCssRulesByProperty');
 var extractTextFromContentPropertyValue = require('./extractTextFromContentPropertyValue');
+var charactersByListStyleType = require('./charactersByListStyleType');
+var unescapeCssString = require('./unescapeCssString');
 
 var PROPS = [
     'font-family',
     'font-style',
     'font-weight',
     'content',
-    'quotes'
+    'quotes',
+    'list-style-type',
+    'display'
 ];
 
 var INITIAL_VALUES = {
@@ -23,7 +27,9 @@ var INITIAL_VALUES = {
     'font-weight': 400,
     'font-style': 'normal',
     content: 'normal',
-    quotes: '"«" "»" "‹" "›" "‘" "’" "\'" "\'" "\\"" "\\""' // Wide default set to account for browser differences
+    quotes: '"«" "»" "‹" "›" "‘" "’" "\'" "\'" "\\"" "\\""', // Wide default set to account for browser differences
+    'list-style-type': 'none',
+    display: 'inline'
 };
 
 var NAME_CONVERSIONS = {
@@ -161,7 +167,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                     continue;
                 }
 
-                if (isStyleAttribute || node.matches(strippedSelector)) {
+                if (isStyleAttribute || node.matches(strippedSelector.replace(/ i\]/, ']'))) { // nwmatcher doesn't support the i flag in attribute selectors
                     var hypotheticalValues;
                     if (declaration.value === 'inherit' || declaration.value === 'unset') {
                         hypotheticalValues = getComputedStyle(node.parentNode, idArray.slice(0, -1), truePredicates, falsePredicates)[prop];
@@ -258,6 +264,38 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
     return getComputedStyle;
 }
 
+function expandListIndicators(computedStyle) {
+    for (var i = 0 ; i < computedStyle.display.length ; i += 1) {
+        if (computedStyle.display[i].value === 'list-item') {
+            for (var j = 0 ; j < computedStyle['list-style-type'].length ; j += 1) {
+                var listStyleType = computedStyle['list-style-type'][j].value;
+                var text;
+                if (/^['"]/.test(listStyleType)) {
+                    text = unescapeCssString(unquote(listStyleType));
+                } else {
+                    text = charactersByListStyleType[listStyleType];
+                }
+                if (text) {
+                    computedStyle.content.push({
+                        value: text,
+                        falsePredicates: Object.assign(
+                            {},
+                            computedStyle.display[i].falsePredicates,
+                            computedStyle['list-style-type'][j].falsePredicates
+                        ),
+                        truePredicates: Object.assign(
+                            {},
+                            computedStyle.display[i].truePredicates,
+                            computedStyle['list-style-type'][j].truePredicates
+                        )
+                    });
+                }
+            }
+        }
+    }
+    return _.omit(computedStyle, '');
+}
+
 // memoizedGetCssRulesByProperty is optional
 function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     if (!htmlAsset || htmlAsset.type !== 'Html'  || !htmlAsset.assetGraph) {
@@ -347,10 +385,12 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
 
     textNodes.forEach(function (textNodeObj) {
         styledTexts.push(
-            Object.assign(
-                {},
-                getComputedStyle(textNodeObj.node.parentNode, textNodeObj.parentId),
-                { content: [ { value: textNodeObj.node.textContent.trim(), truePredicates: [], falsePredicates: [] } ] }
+            expandListIndicators(
+                Object.assign(
+                    {},
+                    getComputedStyle(textNodeObj.node.parentNode, textNodeObj.parentId),
+                    { content: [ { value: textNodeObj.node.textContent.trim(), truePredicates: [], falsePredicates: [] } ] }
+                )
             )
         );
     });
@@ -358,17 +398,19 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     nonTextnodes.forEach(function (nodeObj) {
         if (nodeObj.text) {
             styledTexts.push(
-                Object.assign(
-                    {},
-                    getComputedStyle(nodeObj.node, nodeObj.id),
-                    { content: [ { value: nodeObj.text, truePredicates: [], falsePredicates: [] } ] }
+                expandListIndicators(
+                    Object.assign(
+                        {},
+                        getComputedStyle(nodeObj.node, nodeObj.id),
+                        { content: [ { value: nodeObj.text, truePredicates: [], falsePredicates: [] } ] }
+                    )
                 )
             );
         }
         ['before', 'after'].forEach(function (pseudoElement) {
             var truePredicates = {};
             truePredicates['pseudoElement:' + pseudoElement] = true;
-            var computedStyle = Object.assign({}, getComputedStyle(nodeObj.node, nodeObj.id, truePredicates));
+            var computedStyle = expandListIndicators(Object.assign({}, getComputedStyle(nodeObj.node, nodeObj.id, truePredicates)));
             var expandedContents = [];
             // Multiply the hypothetical content values with the hypothetical quotes values:
             computedStyle.content.forEach(function (hypotheticalContent) {
@@ -462,7 +504,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             .map(function (styledText) {
                 return {
                     text: styledText.content,
-                    props: _.omit(styledText, 'content', 'quotes')
+                    props: _.omit(styledText, 'content', 'quotes', 'display', 'list-style-type')
                 };
             });
     }));

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -273,6 +273,18 @@ function getCounterCharacters(counterStyle, counterStyles) {
             text += unescapeCssString(unquote(value));
         }
     });
+    ['additive-symbols', 'pad'].forEach(function (propertyName) {
+        var value = counterStyle.props[propertyName];
+        if (typeof value === 'string') {
+            value.replace(/\d+ (?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\)))/g, function ($0, doubleQuotedString, singleQuotedString) {
+                if (typeof doubleQuotedString === 'string') {
+                    text += unescapeCssString(doubleQuotedString);
+                } else if (typeof singleQuotedString === 'string') {
+                    text += unescapeCssString(singleQuotedString);
+                }
+            });
+        }
+    });
     var fallback = counterStyle.props.fallback;
     if (fallback) {
         if (charactersByListStyleType[fallback]) {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -264,6 +264,32 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
     return getComputedStyle;
 }
 
+function getCounterCharacters(counterStyle, counterStyles) {
+    var text = '';
+    if (typeof counterStyle.props.symbols === 'string') {
+        text += counterStyle.props.symbols.split(' ').join('');
+    }
+    ['prefix', 'suffix'].forEach(function (propertyName) {
+        var value = counterStyle.props[propertyName];
+        if (typeof value === 'string') {
+            text += unescapeCssString(unquote(value));
+        }
+    });
+    var fallback = counterStyle.props.fallback;
+    if (fallback) {
+        if (charactersByListStyleType[fallback]) {
+            text += charactersByListStyleType[fallback];
+        } else {
+            counterStyles.forEach(function (counterStyle) {
+                if (counterStyle.name === fallback) {
+                    text += getCounterCharacters(counterStyle, counterStyles);
+                }
+            });
+        }
+    }
+    return text;
+}
+
 function expandListIndicators(computedStyle, counterStyles) {
     for (var i = 0 ; i < computedStyle.display.length ; i += 1) {
         if (computedStyle.display[i].value === 'list-item') {
@@ -277,15 +303,7 @@ function expandListIndicators(computedStyle, counterStyles) {
                     counterStyles.forEach(function (counterStyle) {
                         if (counterStyle.name === listStyleType) {
                             found = true;
-                            if (typeof counterStyle.props.symbols === 'string') {
-                                text += counterStyle.props.symbols.split(' ').join('');
-                            }
-                            ['prefix', 'suffix'].forEach(function (propertyName) {
-                                var value = counterStyle.props[propertyName];
-                                if (typeof value === 'string') {
-                                    text += unescapeCssString(unquote(value));
-                                }
-                            });
+                            text += getCounterCharacters(counterStyle, counterStyles);
                         }
                     });
                     if (!found) {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -11,6 +11,7 @@ var getCssRulesByProperty = require('./getCssRulesByProperty');
 var extractTextFromContentPropertyValue = require('./extractTextFromContentPropertyValue');
 var charactersByListStyleType = require('./charactersByListStyleType');
 var unescapeCssString = require('./unescapeCssString');
+var getCounterCharacters = require('./getCounterCharacters');
 
 var PROPS = [
     'font-family',
@@ -260,52 +261,6 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
     });
 
     return getComputedStyle;
-}
-
-function getCounterCharacters(counterStyle, counterStyles) {
-    var text = '';
-    if (typeof counterStyle.props.symbols === 'string') {
-        counterStyle.props.symbols.replace(/"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\)|([^'" ]+))/g, function ($0, doubleQuotedString, singleQuotedString, url, other) {
-            if (typeof doubleQuotedString === 'string') {
-                text += unescapeCssString(doubleQuotedString);
-            } else if (typeof singleQuotedString === 'string') {
-                text += unescapeCssString(singleQuotedString);
-            } else if (typeof other === 'string') {
-                text += other.trim();
-            }
-        });
-    }
-    ['prefix', 'suffix'].forEach(function (propertyName) {
-        var value = counterStyle.props[propertyName];
-        if (typeof value === 'string') {
-            text += unescapeCssString(unquote(value));
-        }
-    });
-    ['additive-symbols', 'pad'].forEach(function (propertyName) {
-        var value = counterStyle.props[propertyName];
-        if (typeof value === 'string') {
-            value.replace(/\d+ (?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\)))/g, function ($0, doubleQuotedString, singleQuotedString) {
-                if (typeof doubleQuotedString === 'string') {
-                    text += unescapeCssString(doubleQuotedString);
-                } else if (typeof singleQuotedString === 'string') {
-                    text += unescapeCssString(singleQuotedString);
-                }
-            });
-        }
-    });
-    var fallback = counterStyle.props.fallback;
-    if (fallback) {
-        if (charactersByListStyleType[fallback]) {
-            text += charactersByListStyleType[fallback];
-        } else {
-            counterStyles.forEach(function (counterStyle) {
-                if (counterStyle.name === fallback) {
-                    text += getCounterCharacters(counterStyle, counterStyles);
-                }
-            });
-        }
-    }
-    return text;
 }
 
 function expandListIndicators(computedStyle, counterStyles) {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -287,24 +287,25 @@ function getCounterCharacters(counterStyle, counterStyles) {
 }
 
 function expandListIndicators(computedStyle, counterStyles) {
-    // FIXME: Dedupe this!
     for (var i = 0 ; i < computedStyle.display.length ; i += 1) {
         if (computedStyle.display[i].value === 'list-item') {
             for (var j = 0 ; j < computedStyle['list-style-type'].length ; j += 1) {
                 var listStyleType = computedStyle['list-style-type'][j].value;
+                var falsePredicates = Object.assign(
+                    {},
+                    computedStyle.display[i].falsePredicates,
+                    computedStyle['list-style-type'][j].falsePredicates
+                );
+                var truePredicates = Object.assign(
+                    {},
+                    computedStyle.display[i].truePredicates,
+                    computedStyle['list-style-type'][j].truePredicates
+                );
                 if (/^['"]/.test(listStyleType)) {
                     computedStyle.content.push({
                         value: unescapeCssString(unquote(listStyleType)),
-                        falsePredicates: Object.assign(
-                            {},
-                            computedStyle.display[i].falsePredicates,
-                            computedStyle['list-style-type'][j].falsePredicates
-                        ),
-                        truePredicates: Object.assign(
-                            {},
-                            computedStyle.display[i].truePredicates,
-                            computedStyle['list-style-type'][j].truePredicates
-                        )
+                        falsePredicates: falsePredicates,
+                        truePredicates: truePredicates
                     });
                 } else {
                     var found = false;
@@ -313,33 +314,16 @@ function expandListIndicators(computedStyle, counterStyles) {
                             found = true;
                             computedStyle.content.push({
                                 value: getCounterCharacters(counterStyle, counterStyles),
-                                falsePredicates: Object.assign(
-                                    {},
-                                    computedStyle.display[i].falsePredicates,
-                                    computedStyle['list-style-type'][j].falsePredicates
-                                ),
-                                truePredicates: Object.assign(
-                                    {},
-                                    computedStyle.display[i].truePredicates,
-                                    computedStyle['list-style-type'][j].truePredicates,
-                                    counterStyle.predicates
-                                )
+                                falsePredicates: falsePredicates,
+                                truePredicates: Object.assign({}, truePredicates, counterStyle.predicates)
                             });
                         }
                     });
                     if (!found) {
                         computedStyle.content.push({
                             value: charactersByListStyleType[listStyleType],
-                            falsePredicates: Object.assign(
-                                {},
-                                computedStyle.display[i].falsePredicates,
-                                computedStyle['list-style-type'][j].falsePredicates
-                            ),
-                            truePredicates: Object.assign(
-                                {},
-                                computedStyle.display[i].truePredicates,
-                                computedStyle['list-style-type'][j].truePredicates
-                            )
+                            falsePredicates: falsePredicates,
+                            truePredicates: truePredicates
                         });
                     }
                 }

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -265,7 +265,15 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
 function getCounterCharacters(counterStyle, counterStyles) {
     var text = '';
     if (typeof counterStyle.props.symbols === 'string') {
-        text += counterStyle.props.symbols.split(' ').join('');
+        counterStyle.props.symbols.replace(/"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(url\(\s*(?:'(?:[^']|\\')*'|"(?:[^"]|\\")*"|(?:[^'"\\]|\\.)*?\s*)\)|([^'" ]+))/g, function ($0, doubleQuotedString, singleQuotedString, url, other) {
+            if (typeof doubleQuotedString === 'string') {
+                text += unescapeCssString(doubleQuotedString);
+            } else if (typeof singleQuotedString === 'string') {
+                text += unescapeCssString(singleQuotedString);
+            } else if (typeof other === 'string') {
+                text += other.trim();
+            }
+        });
     }
     ['prefix', 'suffix'].forEach(function (propertyName) {
         var value = counterStyle.props[propertyName];
@@ -301,6 +309,7 @@ function getCounterCharacters(counterStyle, counterStyles) {
 }
 
 function expandListIndicators(computedStyle, counterStyles) {
+    computedStyle.text = computedStyle.text || [];
     for (var i = 0 ; i < computedStyle.display.length ; i += 1) {
         if (computedStyle.display[i].value === 'list-item') {
             for (var j = 0 ; j < computedStyle['list-style-type'].length ; j += 1) {
@@ -316,7 +325,7 @@ function expandListIndicators(computedStyle, counterStyles) {
                     computedStyle['list-style-type'][j].truePredicates
                 );
                 if (/^['"]/.test(listStyleType)) {
-                    computedStyle.content.push({
+                    computedStyle.text.push({
                         value: unescapeCssString(unquote(listStyleType)),
                         falsePredicates: falsePredicates,
                         truePredicates: truePredicates
@@ -326,7 +335,7 @@ function expandListIndicators(computedStyle, counterStyles) {
                     counterStyles.forEach(function (counterStyle) {
                         if (counterStyle.name === listStyleType) {
                             found = true;
-                            computedStyle.content.push({
+                            computedStyle.text.push({
                                 value: getCounterCharacters(counterStyle, counterStyles),
                                 falsePredicates: falsePredicates,
                                 truePredicates: Object.assign({}, truePredicates, counterStyle.predicates)
@@ -334,7 +343,7 @@ function expandListIndicators(computedStyle, counterStyles) {
                         }
                     });
                     if (!found) {
-                        computedStyle.content.push({
+                        computedStyle.text.push({
                             value: charactersByListStyleType[listStyleType],
                             falsePredicates: falsePredicates,
                             truePredicates: truePredicates

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -291,28 +291,14 @@ function getCounterCharacters(counterStyle, counterStyles) {
 }
 
 function expandListIndicators(computedStyle, counterStyles) {
+    // FIXME: Dedupe this!
     for (var i = 0 ; i < computedStyle.display.length ; i += 1) {
         if (computedStyle.display[i].value === 'list-item') {
             for (var j = 0 ; j < computedStyle['list-style-type'].length ; j += 1) {
                 var listStyleType = computedStyle['list-style-type'][j].value;
-                var text = '';
                 if (/^['"]/.test(listStyleType)) {
-                    text = unescapeCssString(unquote(listStyleType));
-                } else {
-                    var found = false;
-                    counterStyles.forEach(function (counterStyle) {
-                        if (counterStyle.name === listStyleType) {
-                            found = true;
-                            text += getCounterCharacters(counterStyle, counterStyles);
-                        }
-                    });
-                    if (!found) {
-                        text = charactersByListStyleType[listStyleType];
-                    }
-                }
-                if (text) {
                     computedStyle.content.push({
-                        value: text,
+                        value: unescapeCssString(unquote(listStyleType)),
                         falsePredicates: Object.assign(
                             {},
                             computedStyle.display[i].falsePredicates,
@@ -324,6 +310,49 @@ function expandListIndicators(computedStyle, counterStyles) {
                             computedStyle['list-style-type'][j].truePredicates
                         )
                     });
+                } else {
+                    var found = false;
+                    counterStyles.forEach(function (counterStyle) {
+                        if (counterStyle.name === listStyleType) {
+                            found = true;
+                            var truePredicates = {};
+                            if (counterStyle.mediaQuery) {
+                                truePredicates['mediaQuery:' + counterStyle.mediaQuery] = true;
+                            }
+                            if (counterStyle.incomingMedia) {
+                                truePredicates['incomingMedia:' + counterStyle.incomingMedia] = true;
+                            }
+                            computedStyle.content.push({
+                                value: getCounterCharacters(counterStyle, counterStyles),
+                                falsePredicates: Object.assign(
+                                    {},
+                                    computedStyle.display[i].falsePredicates,
+                                    computedStyle['list-style-type'][j].falsePredicates
+                                ),
+                                truePredicates: Object.assign(
+                                    {},
+                                    computedStyle.display[i].truePredicates,
+                                    computedStyle['list-style-type'][j].truePredicates,
+                                    truePredicates
+                                )
+                            });
+                        }
+                    });
+                    if (!found) {
+                        computedStyle.content.push({
+                            value: charactersByListStyleType[listStyleType],
+                            falsePredicates: Object.assign(
+                                {},
+                                computedStyle.display[i].falsePredicates,
+                                computedStyle['list-style-type'][j].falsePredicates
+                            ),
+                            truePredicates: Object.assign(
+                                {},
+                                computedStyle.display[i].truePredicates,
+                                computedStyle['list-style-type'][j].truePredicates
+                            )
+                        });
+                    }
                 }
             }
         }
@@ -341,6 +370,22 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
 
     var fontPropRules = getFontRulesWithDefaultStylesheetApplied(htmlAsset, memoizedGetCssRulesByProperty);
     var getComputedStyle = getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByProperty);
+
+    var hypotheticalCounterStylesByName = {};
+    fontPropRules.counterStyles.forEach(function (counterStyle) {
+        var truePredicates = {};
+        if (counterStyle.incomingMedia) {
+            truePredicates['incomingMedia:' + counterStyle.incomingMedia] = true;
+        }
+        if (counterStyle.mediaQuery) {
+            truePredicates['mediaQuery:' + counterStyle.mediaQuery] = true;
+        }
+        (hypotheticalCounterStylesByName[counterStyle.name] = hypotheticalCounterStylesByName[counterStyle.name] || []).push({
+            value: counterStyle.props,
+            falsePredicates: {},
+            truePredicates: truePredicates
+        });
+    });
 
     var document = htmlAsset.parseTree;
 
@@ -452,16 +497,12 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
             var expandedContents = [];
             // Multiply the hypothetical content values with the hypothetical quotes values:
             computedStyle.content.forEach(function (hypotheticalContent) {
-                computedStyle.quotes.forEach(function (hypotheticalQuotes) {
-                    var text = extractTextFromContentPropertyValue(hypotheticalContent.value, nodeObj.node, hypotheticalQuotes.value, fontPropRules.counterStyles);
-                    if (text) {
-                        expandedContents.push({
-                            value: text,
-                            falsePredicates: Object.assign({}, hypotheticalQuotes.falsePredicates, hypotheticalContent.falsePredicates),
-                            truePredicates: Object.assign({}, hypotheticalQuotes.truePredicates, hypotheticalContent.truePredicates)
-                        });
-                    }
+                var hypotheticalValues = extractTextFromContentPropertyValue(hypotheticalContent.value, nodeObj.node, computedStyle.quotes, hypotheticalCounterStylesByName);
+                hypotheticalValues.forEach(function (hypotheticalValue) {
+                    Object.assign(hypotheticalValue.falsePredicates, hypotheticalContent.falsePredicates);
+                    Object.assign(hypotheticalValue.truePredicates, hypotheticalContent.truePredicates);
                 });
+                Array.prototype.push.apply(expandedContents, hypotheticalValues);
             });
             computedStyle.content = expandedContents;
             if (computedStyle.content.length > 0) {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -264,16 +264,33 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
     return getComputedStyle;
 }
 
-function expandListIndicators(computedStyle) {
+function expandListIndicators(computedStyle, counterStyles) {
     for (var i = 0 ; i < computedStyle.display.length ; i += 1) {
         if (computedStyle.display[i].value === 'list-item') {
             for (var j = 0 ; j < computedStyle['list-style-type'].length ; j += 1) {
                 var listStyleType = computedStyle['list-style-type'][j].value;
-                var text;
+                var text = '';
                 if (/^['"]/.test(listStyleType)) {
                     text = unescapeCssString(unquote(listStyleType));
                 } else {
-                    text = charactersByListStyleType[listStyleType];
+                    var found = false;
+                    counterStyles.forEach(function (counterStyle) {
+                        if (counterStyle.name === listStyleType) {
+                            found = true;
+                            if (typeof counterStyle.props.symbols === 'string') {
+                                text += counterStyle.props.symbols.split(' ').join('');
+                            }
+                            ['prefix', 'suffix'].forEach(function (propertyName) {
+                                var value = counterStyle.props[propertyName];
+                                if (typeof value === 'string') {
+                                    text += unescapeCssString(unquote(value));
+                                }
+                            });
+                        }
+                    });
+                    if (!found) {
+                        text = charactersByListStyleType[listStyleType];
+                    }
                 }
                 if (text) {
                     computedStyle.content.push({
@@ -390,7 +407,8 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     {},
                     getComputedStyle(textNodeObj.node.parentNode, textNodeObj.parentId),
                     { content: [ { value: textNodeObj.node.textContent.trim(), truePredicates: {}, falsePredicates: {} } ] }
-                )
+                ),
+                fontPropRules.counterStyles
             )
         );
     });
@@ -402,18 +420,22 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     {},
                     getComputedStyle(nodeObj.node, nodeObj.id),
                     { content: [ { value: nodeObj.text, truePredicates: {}, falsePredicates: {} } ] }
-                )
+                ),
+                fontPropRules.counterStyles
             )
         );
         ['before', 'after'].forEach(function (pseudoElement) {
             var truePredicates = {};
             truePredicates['pseudoElement:' + pseudoElement] = true;
-            var computedStyle = expandListIndicators(Object.assign({}, getComputedStyle(nodeObj.node, nodeObj.id, truePredicates)));
+            var computedStyle = expandListIndicators(
+                Object.assign({}, getComputedStyle(nodeObj.node, nodeObj.id, truePredicates)),
+                fontPropRules.counterStyles
+            );
             var expandedContents = [];
             // Multiply the hypothetical content values with the hypothetical quotes values:
             computedStyle.content.forEach(function (hypotheticalContent) {
                 computedStyle.quotes.forEach(function (hypotheticalQuotes) {
-                    var text = extractTextFromContentPropertyValue(hypotheticalContent.value, nodeObj.node, hypotheticalQuotes.value);
+                    var text = extractTextFromContentPropertyValue(hypotheticalContent.value, nodeObj.node, hypotheticalQuotes.value, fontPropRules.counterStyles);
                     if (text) {
                         expandedContents.push({
                             value: text,

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -137,8 +137,10 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
 
             for (var i = startIndex; i < localFontPropRules[prop].length; i += 1) {
                 var declaration = localFontPropRules[prop][i];
-                // Skip to the next rule if we are doing a trace where one of the incoming media attributes are already assumed false:
-                if (declaration.incomingMedia.some(function (incomingMedia) { return falsePredicates['incomingMedia:' + incomingMedia]; })) {
+                // Skip to the next rule if we are doing a trace where one of predicates is already assumed false:
+                if (Object.keys(declaration.predicates).some(function (predicate) {
+                    return falsePredicates[predicate];
+                })) {
                     continue;
                 }
 
@@ -199,16 +201,10 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                         hypotheticalValues = [ { value: value, truePredicates: truePredicates, falsePredicates: falsePredicates } ];
                     }
 
-                    var predicatesToVary = [];
+                    var predicatesToVary = Object.keys(declaration.predicates);
                     if (!isStyleAttribute && hasPseudoClasses) {
                         predicatesToVary.push('selectorWithPseudoClasses:' + declaration.selector);
                     }
-                    if (declaration.mediaQuery) {
-                        predicatesToVary.push('mediaQuery:' + declaration.mediaQuery);
-                    }
-                    Array.prototype.push.apply(predicatesToVary, declaration.incomingMedia.map(function (incomingMedia) {
-                        return 'incomingMedia:' + incomingMedia;
-                    }));
                     if (predicatesToVary.length > 0) {
                         var multipliedHypotheticalValues = [];
                         createPredicatePermutations(predicatesToVary).forEach(function (predicatePermutation) {
@@ -216,7 +212,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                                 return;
                             }
                             var truePredicatesForThisPermutation = Object.assign({}, truePredicates, predicatePermutation);
-                            if (declaration.incomingMedia.every(function (incomingMedia) { return truePredicatesForThisPermutation['incomingMedia:' + incomingMedia]; })) {
+                            if (Object.keys(declaration.predicates).every(function (predicate) { return truePredicatesForThisPermutation[predicate]; })) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
                                     hypotheticalValues.map(function (hypotheticalValue) {
@@ -315,13 +311,6 @@ function expandListIndicators(computedStyle, counterStyles) {
                     counterStyles.forEach(function (counterStyle) {
                         if (counterStyle.name === listStyleType) {
                             found = true;
-                            var truePredicates = {};
-                            if (counterStyle.mediaQuery) {
-                                truePredicates['mediaQuery:' + counterStyle.mediaQuery] = true;
-                            }
-                            if (counterStyle.incomingMedia) {
-                                truePredicates['incomingMedia:' + counterStyle.incomingMedia] = true;
-                            }
                             computedStyle.content.push({
                                 value: getCounterCharacters(counterStyle, counterStyles),
                                 falsePredicates: Object.assign(
@@ -333,7 +322,7 @@ function expandListIndicators(computedStyle, counterStyles) {
                                     {},
                                     computedStyle.display[i].truePredicates,
                                     computedStyle['list-style-type'][j].truePredicates,
-                                    truePredicates
+                                    counterStyle.predicates
                                 )
                             });
                         }
@@ -373,17 +362,9 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
 
     var hypotheticalCounterStylesByName = {};
     fontPropRules.counterStyles.forEach(function (counterStyle) {
-        var truePredicates = {};
-        if (counterStyle.incomingMedia) {
-            truePredicates['incomingMedia:' + counterStyle.incomingMedia] = true;
-        }
-        if (counterStyle.mediaQuery) {
-            truePredicates['mediaQuery:' + counterStyle.mediaQuery] = true;
-        }
         (hypotheticalCounterStylesByName[counterStyle.name] = hypotheticalCounterStylesByName[counterStyle.name] || []).push({
             value: counterStyle.props,
-            falsePredicates: {},
-            truePredicates: truePredicates
+            predicates: counterStyle.predicates
         });
     });
 

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -396,17 +396,15 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     });
 
     nonTextnodes.forEach(function (nodeObj) {
-        if (nodeObj.text) {
-            styledTexts.push(
-                expandListIndicators(
-                    Object.assign(
-                        {},
-                        getComputedStyle(nodeObj.node, nodeObj.id),
-                        { content: [ { value: nodeObj.text, truePredicates: [], falsePredicates: [] } ] }
-                    )
+        styledTexts.push(
+            expandListIndicators(
+                Object.assign(
+                    {},
+                    getComputedStyle(nodeObj.node, nodeObj.id),
+                    { content: [ { value: nodeObj.text, truePredicates: [], falsePredicates: [] } ] }
                 )
-            );
-        }
+            )
+        );
         ['before', 'after'].forEach(function (pseudoElement) {
             var truePredicates = {};
             truePredicates['pseudoElement:' + pseudoElement] = true;
@@ -468,8 +466,8 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         return permutations;
     }
 
+    var seenPermutationByKey = {};
     var multipliedStyledTexts = _.flatten(styledTexts.map(function (styledText) {
-        var seenPermutationByKey = {};
         return expandPermutations(styledText)
             .filter(function removeImpossibleCombinations(hypotheticalValuesByProp) {
                 // Check that none of the predicates assumed true are assumed false, too:
@@ -488,12 +486,16 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 });
                 return props;
             })
-            .filter(function deduplicate(textWithProps) {
+            .filter(function filterAndDeduplicate(textWithProps) {
+                if (!textWithProps.content) {
+                    return false;
+                }
                 // Unwrap the "hypothetical value" objects:
                 var permutationKey = '';
-                PROPS.forEach(function (prop) {
+                ['font-weight', 'font-style', 'font-family', 'content'].forEach(function (prop) {
                     permutationKey += prop + '\x1d' + textWithProps[prop] + '\x1d';
                 });
+
                 // Deduplicate:
                 if (!seenPermutationByKey[permutationKey]) {
                     seenPermutationByKey[permutationKey] = true;

--- a/lib/util/fonts/unescapeCssString.js
+++ b/lib/util/fonts/unescapeCssString.js
@@ -1,0 +1,10 @@
+function unescapeCssString(cssString) {
+    return cssString.replace(/\\([0-9a-f]{1,6})\s*/ig, function ($0, hexDigits) {
+        return String.fromCharCode(parseInt(hexDigits, 16));
+    })
+        .replace(/\\n/g, '\n')
+        .replace(/\\t/g, '\t')
+        .replace(/\\/g, '');
+}
+
+module.exports = unescapeCssString;

--- a/test/util/fonts/extractTextFromContentPropertyValue.js
+++ b/test/util/fonts/extractTextFromContentPropertyValue.js
@@ -1,10 +1,16 @@
 var extractTextFromContentPropertyValue = require('../../../lib/util/fonts/extractTextFromContentPropertyValue');
 var sinon = require('sinon');
 var expect = require('../../unexpected-with-plugins').clone()
-    .addAssertion('<array> to come out as <string>', function (expect, subject, value) {
-        expect(extractTextFromContentPropertyValue(subject[0], subject[1]), 'to equal', value);
+    .addAssertion('<array> to come out as <string|array>', function (expect, subject, value) {
+        expect.errorMode = 'nested';
+        var result = extractTextFromContentPropertyValue(subject[0], subject[1]);
+        if (typeof value === 'string') {
+            expect(result, 'to satisfy', [{value: value}]);
+        } else {
+            expect(result, 'to equal', value);
+        }
     })
-    .addAssertion('<string> to come out as <string>', function (expect, subject, value) {
+    .addAssertion('<string> to come out as <string|array>', function (expect, subject, value) {
         expect([subject], 'to come out as', value);
     });
 

--- a/test/util/fonts/getCssRulesByProperty.js
+++ b/test/util/fonts/getCssRulesByProperty.js
@@ -31,7 +31,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
             color: [
                 {
                     selector: 'h1',
-                    incomingMedia: [],
+                    predicates: {},
                     specificityArray: [0, 0, 0, 1],
                     prop: 'color',
                     value: 'red',
@@ -39,7 +39,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 },
                 {
                     selector: 'h2',
-                    incomingMedia: [],
+                    predicates: {},
                     specificityArray: [0, 0, 0, 1],
                     prop: 'color',
                     value: 'blue',
@@ -55,7 +55,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
             color: [
                 {
                     selector: undefined,
-                    incomingMedia: [],
+                    predicates: {},
                     specificityArray: [1, 0, 0, 0],
                     prop: 'color',
                     value: 'red',
@@ -72,7 +72,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 color: [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'color',
                         value: 'red',
@@ -80,7 +80,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                     },
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'color',
                         value: 'blue',
@@ -110,7 +110,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-family': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-family',
                         value: 'serif',
@@ -120,7 +120,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-size': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '15px',
@@ -138,7 +138,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-family': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-family',
                         value: 'serif',
@@ -148,7 +148,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-size': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '15px',
@@ -158,7 +158,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-style': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-style',
                         value: 'normal',
@@ -168,7 +168,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-weight': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-weight',
                         value: 400,
@@ -186,7 +186,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-family': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-family',
                         value: 'serif',
@@ -196,7 +196,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                 'font-size': [
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '10px',
@@ -204,7 +204,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                     },
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '15px',
@@ -212,7 +212,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
                     },
                     {
                         selector: 'h1',
-                        incomingMedia: [],
+                        predicates: {},
                         specificityArray: [0, 0, 0, 1],
                         prop: 'font-size',
                         value: '20px',

--- a/test/util/fonts/getCssRulesByProperty.js
+++ b/test/util/fonts/getCssRulesByProperty.js
@@ -20,12 +20,14 @@ describe('util/fonts/getCssRulesByProperty', function () {
 
     it('should return empty arrays when no properties apply', function () {
         expect(getRules(['padding'], 'h1 { color: red; }', []), 'to exhaustively satisfy', {
+            counterStyles: [],
             padding: []
         });
     });
 
     it('should return an array of matching property values', function () {
         expect(getRules(['color'], 'h1 { color: red; } h2 { color: blue; }', []), 'to exhaustively satisfy', {
+            counterStyles: [],
             color: [
                 {
                     selector: 'h1',
@@ -49,6 +51,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
 
     it('should handle inline styles through `bogusselector`-selector', function () {
         expect(getRules(['color'], 'bogusselector { color: red; }', []), 'to exhaustively satisfy', {
+            counterStyles: [],
             color: [
                 {
                     selector: undefined,
@@ -65,6 +68,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
     describe('overridden values', function () {
         it('should return the last defined value', function () {
             expect(getRules(['color'], 'h1 { color: red; color: blue; }', []), 'to exhaustively satisfy', {
+                counterStyles: [],
                 color: [
                     {
                         selector: 'h1',
@@ -92,6 +96,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
             var result = getRules(['font-family', 'font-size'], 'h1 { font: 15px; }', []);
 
             expect(result, 'to exhaustively satisfy', {
+                counterStyles: [],
                 'font-family': [],
                 'font-size': []
             });
@@ -101,6 +106,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
             var result = getRules(['font-family', 'font-size'], 'h1 { font: 15px serif; }', []);
 
             expect(result, 'to exhaustively satisfy', {
+                counterStyles: [],
                 'font-family': [
                     {
                         selector: 'h1',
@@ -128,6 +134,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
             var result = getRules(['font-family', 'font-size', 'font-style', 'font-weight'], 'h1 { font: 15px serif; }', []);
 
             expect(result, 'to exhaustively satisfy', {
+                counterStyles: [],
                 'font-family': [
                     {
                         selector: 'h1',
@@ -175,6 +182,7 @@ describe('util/fonts/getCssRulesByProperty', function () {
             var result = getRules(['font-family', 'font-size'], 'h1 { font-size: 10px; font: 15px serif; font-size: 20px }', []);
 
             expect(result, 'to exhaustively satisfy', {
+                counterStyles: [],
                 'font-family': [
                     {
                         selector: 'h1',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -923,6 +923,32 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
+        it('should support content: counter() with an explicit list-style', function () {
+            var htmlText = [
+                '<style>div:after { content: counter(section, upper-roman); font-family: font1; }</style>',
+                '<div>foo</div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'IVXLCDMↁↂↇↈ',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
         it('should support content: attr(...) mixed with quoted strings', function () {
             var htmlText = [
                 '<style>div:after { content: "baz" attr(data-foo) "yadda"; font-family: font1; }</style>',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -949,6 +949,35 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
+        describe('with a custom @counter-style', function () {
+            it('include all the symbols of the counter when it is referenced', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ }</style>',
+                    '<style>div { font-family: font1; display: list-item; list-style-type: circled-alpha; }</style>',
+                    '<div>foo</div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'foo',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    },
+                    {
+                        text: 'ⒶⒷⒸ',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+        });
+
         it('should support content: attr(...) mixed with quoted strings', function () {
             var htmlText = [
                 '<style>div:after { content: "baz" attr(data-foo) "yadda"; font-family: font1; }</style>',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -1193,6 +1193,49 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 }
             ]);
         });
+
+        it('should combine with conditionals', function () {
+            var htmlText = [
+                '<style>li { list-style-type: decimal; font-weight: 400 }</style>',
+                '<style>@media 3dglasses { li { list-style-type: upper-roman; } } </style>',
+                '<li>Hello</li>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'Hello',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'Hello',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'IVXLCDMↁↂↇↈ',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: '0123456789',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
     });
 
     describe('CSS pseudo selectors', function () {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -1090,6 +1090,111 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
         });
     });
 
+    describe('with display:list-item', function () {
+        it('should include the default list indicators in the subset', function () {
+            var htmlText = [
+                '<ol><li>foo</li></ol>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: '0123456789',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
+        it('should include the indicators when display:list-item and list-style-type are applied to an element', function () {
+            var htmlText = [
+                '<style>div { display: list-item; list-style-type: upper-roman; }</style>',
+                '<div>foo</div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'IVXLCDMↁↂↇↈ',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
+        it('should support list-style-type provided as a string', function () {
+            var htmlText = [
+                '<style>div { display: list-item; list-style-type: \'yeah\'; }</style>',
+                '<div>foo</div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'yeah',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
+        it('should include the indicators when display:list-item and list-style are applied to an element', function () {
+            var htmlText = [
+                '<style>div { display: list-item; list-style: upper-roman inside; }</style>',
+                '<div>foo</div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'IVXLCDMↁↂↇↈ',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+    });
+
     describe('CSS pseudo selectors', function () {
         it('should handle stand alone pseudo selector', function () {
             var htmlText = [

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -850,22 +850,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     }
                 },
                 {
-                    text: 'h1',
-                    props: {
-                        'font-family': undefined,
-                        'font-weight': 700,
-                        'font-style': 'normal'
-                    }
-                },
-                {
-                    text: 'after',
-                    props: {
-                        'font-family': 'font1',
-                        'font-weight': 700,
-                        'font-style': 'normal'
-                    }
-                },
-                {
                     text: 'after',
                     props: {
                         'font-family': 'font1',
@@ -968,22 +952,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ].join('\n');
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
-                {
-                    text: 'text',
-                    props: {
-                        'font-family': undefined,
-                        'font-weight': 400,
-                        'font-style': 'normal'
-                    }
-                },
-                {
-                    text: 'text',
-                    props: {
-                        'font-family': undefined,
-                        'font-weight': 400,
-                        'font-style': 'normal'
-                    }
-                },
                 {
                     text: 'text',
                     props: {
@@ -1194,6 +1162,24 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
+        it('should include the indicators even with the display:list-item does not have text', function () {
+            var htmlText = [
+                '<style>div { display: list-item; list-style: upper-roman inside; }</style>',
+                '<div></div>'
+            ].join('\n');
+
+            return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                {
+                    text: 'IVXLCDMↁↂↇↈ',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                }
+            ]);
+        });
+
         it('should combine with conditionals', function () {
             var htmlText = [
                 '<style>li { list-style-type: decimal; font-weight: 400 }</style>',
@@ -1202,14 +1188,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ].join('\n');
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
-                {
-                    text: 'Hello',
-                    props: {
-                        'font-family': undefined,
-                        'font-weight': 400,
-                        'font-style': 'normal'
-                    }
-                },
                 {
                     text: 'Hello',
                     props: {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -1014,27 +1014,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
                 return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                     {
-                        text: 'ⒶⒷⒸⒹⒺⒻ',
-                        props: {
-                            'font-family': 'font1',
-                            'font-weight': 400,
-                            'font-style': 'normal'
-                        }
-                    }
-                ]);
-            });
-
-            it.skip('should exclude impossible combinations when tracing conditional @counter-style declarations', function () {
-                var htmlText = [
-                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ }</style>',
-                    '<style>li { font-family: font1; list-style-type: circled-alpha; }</style>',
-                    '<style>@media 3dglasses { @c<ounter-style circled-alpha { system: fixed; symbols: Ⓓ Ⓔ Ⓕ } }</style>',
-                    '<style>@media 3dglasses { li { font-family: font2; list-style-type: circled-alpha; } }</style>',
-                    '<ol><li></li></ol>'
-                ].join('\n');
-
-                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
-                    {
                         text: 'ⒶⒷⒸ',
                         props: {
                             'font-family': 'font1',
@@ -1045,7 +1024,46 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     {
                         text: 'ⒹⒺⒻ',
                         props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should exclude impossible combinations when tracing conditional @counter-style declarations', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ }</style>',
+                    '<style>li { font-family: font1; list-style-type: circled-alpha; }</style>',
+                    '<style>@media 3dglasses { @counter-style circled-alpha { system: fixed; symbols: Ⓓ Ⓔ Ⓕ } }</style>',
+                    '<style>@media 3dglasses { li { font-family: font2; list-style-type: circled-alpha; } }</style>',
+                    '<ol><li></li></ol>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    // Would be nice to avoid this first one, since all the @media 3dglasses {...} will
+                    // kick in together, but that would require a more advanced predicate handling:
+                    {
+                        text: 'ⒶⒷⒸ',
+                        props: {
                             'font-family': 'font2',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    },
+                    {
+                        text: 'ⒹⒺⒻ',
+                        props: {
+                            'font-family': 'font2',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    },
+                    {
+                        text: 'ⒶⒷⒸ',
+                        props: {
+                            'font-family': 'font1',
                             'font-weight': 400,
                             'font-style': 'normal'
                         }

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -977,6 +977,25 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 ]);
             });
 
+            it('should support the full syntax of the symbols property', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: \'a\' b "c" url(foo.svg) "\\64" "\\"" \'\\\'\'; }</style>',
+                    '<style>li { font-family: font1; display: list-item; list-style-type: circled-alpha; }</style>',
+                    '<ol><li></li></ol>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'abcd"\'',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
             it('should include all characters of the fallback counter, if given', function () {
                 var htmlText = [
                     '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ; fallback: upper-roman }</style>',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -949,6 +949,83 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
+        describe('with content: counters()', function () {
+            it('should support the 2 argument form without an explicit counter style', function () {
+                var htmlText = [
+                    '<style>div:after { content: counters(section, "."); font-family: font1; }</style>',
+                    '<div></div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: '0123456789.',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should support the 3 argument form with a built-in counter-style', function () {
+                var htmlText = [
+                    '<style>div:after { content: counters(section, ".", upper-roman); font-family: font1; }</style>',
+                    '<div></div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'IVXLCDMↁↂↇↈ.',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should support the 3 argument form with a custom @counter-style', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ }</style>',
+                    '<style>div:after { content: counters(section, ".", circled-alpha); font-family: font1; }</style>',
+                    '<div></div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'ⒶⒷⒸ.',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should support the 3 argument form with a custom @counter-style that references other counters', function () {
+                var htmlText = [
+                    '<style>@counter-style foobar { system: fixed; symbols: "foo" "bar" }</style>',
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ; fallback: foobar }</style>',
+                    '<style>div:after { content: counters(section, ".", circled-alpha); font-family: font1; }</style>',
+                    '<div></div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'ⒶⒷⒸ.',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+        });
+
         describe('with @counter-style rules', function () {
             it('should include all the symbols of the counter when it is referenced by a list-style-type declaration', function () {
                 var htmlText = [

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -996,6 +996,25 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 ]);
             });
 
+            it('should pickup the text from all @counter-style properties', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ; additive-symbols: 3 url(symbol.png), 2 "0"; prefix: "p"; suffix: "s"; pad: 5 "q"; }</style>',
+                    '<style>li { font-family: font1; list-style-type: circled-alpha; }</style>',
+                    '<ol><li></li></ol>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'ⒶⒷⒸps0q',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
             it('should include all characters of the fallback counter, if given', function () {
                 var htmlText = [
                     '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ; fallback: upper-roman }</style>',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -949,8 +949,8 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
-        describe('with a custom @counter-style', function () {
-            it('include all the symbols of the counter when it is referenced', function () {
+        describe('with @counter-style rules', function () {
+            it('should include all the symbols of the counter when it is referenced by a list-style-type declaration', function () {
                 var htmlText = [
                     '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ }</style>',
                     '<style>div { font-family: font1; display: list-item; list-style-type: circled-alpha; }</style>',
@@ -970,6 +970,82 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                         text: 'ⒶⒷⒸ',
                         props: {
                             'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should include all characters of the fallback counter, if given', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ; fallback: upper-roman }</style>',
+                    '<style>div { font-family: font1; display: list-item; list-style-type: circled-alpha; }</style>',
+                    '<div>foo</div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'foo',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    },
+                    {
+                        text: 'ⒶⒷⒸIVXLCDMↁↂↇↈ',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it('should trace conditional @counter-style declarations', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ }</style>',
+                    '<style>@media 3dglasses { @counter-style circled-alpha { system: fixed; symbols: Ⓓ Ⓔ Ⓕ } }</style>',
+                    '<style>li { font-family: font1; list-style-type: circled-alpha; }</style>',
+                    '<ol><li></li></ol>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'ⒶⒷⒸⒹⒺⒻ',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    }
+                ]);
+            });
+
+            it.skip('should exclude impossible combinations when tracing conditional @counter-style declarations', function () {
+                var htmlText = [
+                    '<style>@counter-style circled-alpha { system: fixed; symbols: Ⓐ Ⓑ Ⓒ }</style>',
+                    '<style>li { font-family: font1; list-style-type: circled-alpha; }</style>',
+                    '<style>@media 3dglasses { @c<ounter-style circled-alpha { system: fixed; symbols: Ⓓ Ⓔ Ⓕ } }</style>',
+                    '<style>@media 3dglasses { li { font-family: font2; list-style-type: circled-alpha; } }</style>',
+                    '<ol><li></li></ol>'
+                ].join('\n');
+
+                return expect(htmlText, 'to exhaustively satisfy computed font properties', [
+                    {
+                        text: 'ⒶⒷⒸ',
+                        props: {
+                            'font-family': 'font1',
+                            'font-weight': 400,
+                            'font-style': 'normal'
+                        }
+                    },
+                    {
+                        text: 'ⒹⒺⒻ',
+                        props: {
+                            'font-family': 'font2',
                             'font-weight': 400,
                             'font-style': 'normal'
                         }


### PR DESCRIPTION
- [x] Disregard `symbols: url(gold-medal.svg) url(silver-medal.svg) url(bronze-medal.svg);` in `@counter-style` rules.
- [x] Support additional properties `@counter-style foo { pad: 'something'; additive-symbols: ... }`
- [x] Separate `content` values from `text` again. Now that the `content` support is quite advanced, it no longer makes sense to shoehorn `node.textContent` into it.