### PR TITLE
Propagate the fulfillment/return value of the transform to the returned promise (or the callback)

### DIFF
--- a/lib/AssetGraph.js
+++ b/lib/AssetGraph.js
@@ -442,12 +442,12 @@ class AssetGraph extends EventEmitter {
     // Transforms:
     _runTransform(transform, cb) {
         const startTime = new Date();
-        const done = err => {
+        const done = (err, result) => {
             if (err) {
                 return cb(err);
             }
             this.emit('afterTransform', transform, new Date().getTime() - startTime);
-            cb(null, this);
+            cb(null, result);
         };
 
         this.emit('beforeTransform', transform);
@@ -461,20 +461,20 @@ class AssetGraph extends EventEmitter {
                     return done(err);
                 }
                 if (returnValue && typeof returnValue.then === 'function') {
-                    returnValue.then(() => done(), done);
+                    returnValue.then(result => done(null, result), done);
                 } else {
-                    done();
+                    done(null, returnValue);
                 }
             });
         } else {
             let callbackCalled = false;
             try {
-                const returnValue = transform(this, err => {
+                const returnValue = transform(this, (err, result) => {
                     if (callbackCalled) {
                         console.warn('AssetGraph._runTransform: The transform ' + transform.name + ' called the callback more than once!');
                     } else {
                         callbackCalled = true;
-                        done(err);
+                        done(err, result);
                     }
                 });
                 if (returnValue && typeof returnValue.then === 'function') {

--- a/lib/TransformQueue.js
+++ b/lib/TransformQueue.js
@@ -35,7 +35,7 @@ TransformQueue.prototype = {
         return this;
     },
 
-    run: function (cb) {
+    run: function (cb, previousResult) {
         var that = this,
             nextTransform;
         that.assetGraph.transformQueue = that; // Hack
@@ -44,7 +44,7 @@ TransformQueue.prototype = {
             nextTransform = that.transforms.shift();
         } while (!nextTransform && that.transforms.length);
         if (nextTransform) {
-            that.assetGraph._runTransform(nextTransform, function (err) {
+            that.assetGraph._runTransform(nextTransform, function (err, result) {
                 if (err) {
                     // UnexpectedError instance, avoid rendering the error message twice:
                     if (err.name !== 'UnexpectedError') {
@@ -56,11 +56,11 @@ TransformQueue.prototype = {
                         throw err;
                     }
                 } else {
-                    that.run(cb);
+                    that.run(cb, result);
                 }
             });
         } else if (cb) {
-            cb(null, that.assetGraph);
+            cb(null, previousResult);
         }
         return that;
     },

--- a/lib/transforms/subsetGoogleFonts.js
+++ b/lib/transforms/subsetGoogleFonts.js
@@ -439,7 +439,7 @@ module.exports = function (options) {
                     }
                 });
             })
-            .then(function (assetGraph) {
+            .then(function () {
                 // Undo User-Agent override
                 assetGraph.teepee.headers['User-Agent'] = assetGraphUA;
 

--- a/test/TransformQueue.js
+++ b/test/TransformQueue.js
@@ -124,6 +124,32 @@ describe('TransformQueue', function () {
                 expect(array, 'to equal', ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't']);
             });
     });
+
+    describe('when the transform returns a value', function () {
+        it('should return a promise that is fulfilled with that value', async function () {
+            const fulfillmentValue = await new AssetGraph()
+                .queue(() => 'foo');
+            expect(fulfillmentValue, 'to equal', 'foo');
+        });
+    });
+
+    describe('when the transform returns a promise', function () {
+        it('should return a promise that is fulfilled with the same value', async function () {
+            const fulfillmentValue = await new AssetGraph()
+                .queue(async () => 'foo');
+            expect(fulfillmentValue, 'to equal', 'foo');
+        });
+    });
+
+    describe('when the transform takes a callback', function () {
+        it('should return a promise that is fulfilled with the value passed to the callback', async function () {
+            const fulfillmentValue = await new AssetGraph()
+                .queue((assetGraph, cb) => {
+                    setImmediate(() => cb(null, 'foo'));
+                });
+            expect(fulfillmentValue, 'to equal', 'foo');
+        });
+    });
 });
 
 describe('error propagation', function () {

--- a/test/addAsset.js
+++ b/test/addAsset.js
@@ -76,27 +76,28 @@ describe('AssetGraph#addAsset', function () {
         expect(warnSpy, 'was not called');
     });
 
-    it('should only warn about unknown unsupported protocols', function () {
+    it('should only warn about unknown unsupported protocols', async function () {
         const warnSpy = sinon.spy().named('warn');
 
-        return new AssetGraph({root: __dirname + '/../testdata/unsupportedProtocols/'})
-            .on('warn', warnSpy)
+        const assetGraph = new AssetGraph({root: __dirname + '/../testdata/unsupportedProtocols/'});
+        assetGraph.on('warn', warnSpy);
+
+        await assetGraph
             .loadAssets('index.html')
-            .populate()
-            .then(function (assetGraph) {
-                expect(assetGraph.findRelations(), 'to satisfy', [
-                    { to: { url: 'mailto:foo@bar.com' } },
-                    { to: { url: 'tel:9876543' } },
-                    { to: { url: 'sms:9876543' } },
-                    { to: { url: 'fax:9876543' } },
-                    { to: { url: 'httpz://foo.com/' } }
+            .populate();
 
-                ]);
+        expect(assetGraph.findRelations(), 'to satisfy', [
+            { to: { url: 'mailto:foo@bar.com' } },
+            { to: { url: 'tel:9876543' } },
+            { to: { url: 'sms:9876543' } },
+            { to: { url: 'fax:9876543' } },
+            { to: { url: 'httpz://foo.com/' } }
 
-                expect(warnSpy, 'to have calls satisfying', () =>
-                    warnSpy(new Error('No resolver found for protocol: httpz\n\tIf you think this protocol should exist, please contribute it here:\n\thttps://github.com/Munter/schemes#contributing'))
-                );
-            });
+        ]);
+
+        expect(warnSpy, 'to have calls satisfying', () =>
+            warnSpy(new Error('No resolver found for protocol: httpz\n\tIf you think this protocol should exist, please contribute it here:\n\thttps://github.com/Munter/schemes#contributing'))
+        );
     });
 
     describe('with an asset config that includes the body', function () {

--- a/test/assets/Asset.js
+++ b/test/assets/Asset.js
@@ -14,13 +14,14 @@ describe('assets/Asset', function () {
             return expect(asset.loadAsync(), 'to be rejected');
         });
 
-        it('should autodetect the type of an asset with an unrecognizable file extension', function () {
-            return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/autodetectTypeWhenExtensionIsUnknown/'})
+        it('should autodetect the type of an asset with an unrecognizable file extension', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/autodetectTypeWhenExtensionIsUnknown/'});
+
+            await assetGraph
                 .loadAssets('index.html')
-                .populate()
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain asset', 'Svg');
-                });
+                .populate();
+
+            expect(assetGraph, 'to contain asset', 'Svg');
         });
     });
 
@@ -447,108 +448,113 @@ describe('assets/Asset', function () {
             expect(asset.clone.bind(asset, true), 'to throw', /incomingRelations not supported because asset/);
         });
 
-        it('should throw when cloning an asset with invalid incoming relations', function () {
-            return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/clone/cssWithInlineImage/'})
-                .loadAssets('index.css')
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain assets', 'Css', 1);
+        it('should throw when cloning an asset with invalid incoming relations', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/clone/cssWithInlineImage/'});
 
-                    var original = assetGraph.findAssets({type: 'Css'})[0];
+            await assetGraph.loadAssets('index.css');
 
-                    expect(original.clone.bind(original, [{}]), 'to throw', /Incoming relation is not a relation/);
-                });
+            expect(assetGraph, 'to contain assets', 'Css', 1);
+
+            var original = assetGraph.findAssets({type: 'Css'})[0];
+
+            expect(original.clone.bind(original, [{}]), 'to throw', /Incoming relation is not a relation/);
         });
 
-        it('should handle a test case with multiple Html assets', function () {
-            return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/clone/multipleHtmls/'})
+        it('should handle a test case with multiple Html assets', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/clone/multipleHtmls/'});
+
+            await assetGraph
                 .loadAssets('index.html')
-                .populate()
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain assets', 'Html', 3);
-                    expect(assetGraph, 'to contain asset', 'Png');
-                    expect(assetGraph, 'to contain asset', {type: 'Css', isInline: true});
+                .populate();
 
-                    var indexHtml = assetGraph.findAssets({type: 'Html'})[0],
-                        assetClone = indexHtml.clone();
-                    assetClone.url = indexHtml.url.replace(/\.html$/, '.clone.html');
+            expect(assetGraph, 'to contain assets', 'Html', 3);
+            expect(assetGraph, 'to contain asset', 'Png');
+            expect(assetGraph, 'to contain asset', {type: 'Css', isInline: true});
 
-                    expect(assetGraph, 'to contain asset', {url: /\/index\.clone\.html$/});
-                    expect(assetGraph, 'to contain relation', {from: {url: /\/index\.clone\.html$/}, to: {url: /\/anotherpage\.html$/}});
-                    expect(assetGraph, 'to contain relation', {from: {url: /\/index\.clone\.html$/}, to: {url: /\/yetanotherpage\.html$/}});
-                    expect(assetGraph, 'to contain relation', {from: {url: /\/index\.clone\.html$/}, to: {type: 'Css'}});
-                    expect(assetGraph, 'to contain asset', 'Png');
-                    expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 2);
+            const indexHtml = assetGraph.findAssets({type: 'Html'})[0];
+            const assetClone = indexHtml.clone();
+            assetClone.url = indexHtml.url.replace(/\.html$/, '.clone.html');
 
-                    var originalAndCloned = assetGraph.findAssets({url: /\/index(?:\.clone)?.html/});
-                    expect(originalAndCloned[0].text, 'to equal', originalAndCloned[1].text);
-                });
+            expect(assetGraph, 'to contain asset', {url: /\/index\.clone\.html$/});
+            expect(assetGraph, 'to contain relation', {from: {url: /\/index\.clone\.html$/}, to: {url: /\/anotherpage\.html$/}});
+            expect(assetGraph, 'to contain relation', {from: {url: /\/index\.clone\.html$/}, to: {url: /\/yetanotherpage\.html$/}});
+            expect(assetGraph, 'to contain relation', {from: {url: /\/index\.clone\.html$/}, to: {type: 'Css'}});
+            expect(assetGraph, 'to contain asset', 'Png');
+            expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 2);
+
+            const originalAndCloned = assetGraph.findAssets({url: /\/index(?:\.clone)?.html/});
+            expect(originalAndCloned[0].text, 'to equal', originalAndCloned[1].text);
         });
 
-        it('should handle a test case with a Css asset with an inline image', function () {
-            return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/clone/cssWithInlineImage/'})
+        it('should handle a test case with a Css asset with an inline image', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/clone/cssWithInlineImage/'});
+
+            await assetGraph
                 .loadAssets('index.css')
-                .populate()
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain assets', 2);
+                .populate();
 
-                    assetGraph.findAssets({type: 'Css'})[0].clone();
+            expect(assetGraph, 'to contain assets', 2);
 
-                    expect(assetGraph, 'to contain assets', 'Css', 2);
+            assetGraph.findAssets({type: 'Css'})[0].clone();
 
-                    expect(assetGraph, 'to contain assets', 'Png', 2);
-                    assetGraph.findAssets({type: 'Css'}).forEach(function (cssAsset) {
-                        expect(assetGraph, 'to contain relation', {from: cssAsset, to: {isInline: true, isImage: true}});
-                    });
-                });
+            expect(assetGraph, 'to contain assets', 'Css', 2);
+
+            expect(assetGraph, 'to contain assets', 'Png', 2);
+            assetGraph.findAssets({type: 'Css'}).forEach(function (cssAsset) {
+                expect(assetGraph, 'to contain relation', {from: cssAsset, to: {isInline: true, isImage: true}});
+            });
         });
     });
 
-    it('should handle a test case with Html assets with meta tags specifying iso-8859-1', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/encoding/'})
-            .loadAssets('iso-8859-1.html', 'iso-8859-1-simple-meta.html')
-            .populate()
-            .then(function (assetGraph) {
-                assetGraph.findAssets().forEach(function (asset) {
-                    expect(asset.text, 'to contain', 'æøåÆØÅ');
-                });
+    it('should handle a test case with Html assets with meta tags specifying iso-8859-1', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/encoding/'});
 
-                expect(assetGraph.findAssets()[0].parseTree.body.firstChild.nodeValue, 'to begin with', 'æøåÆØÅ');
-                expect(assetGraph.findAssets()[0].rawSrc.toString('binary'), 'to contain', '\u00e6\u00f8\u00e5\u00c6\u00d8\u00c5');
-            });
+        await assetGraph
+            .loadAssets('iso-8859-1.html', 'iso-8859-1-simple-meta.html')
+            .populate();
+
+        assetGraph.findAssets().forEach(function (asset) {
+            expect(asset.text, 'to contain', 'æøåÆØÅ');
+        });
+
+        expect(assetGraph.findAssets()[0].parseTree.body.firstChild.nodeValue, 'to begin with', 'æøåÆØÅ');
+        expect(assetGraph.findAssets()[0].rawSrc.toString('binary'), 'to contain', '\u00e6\u00f8\u00e5\u00c6\u00d8\u00c5');
     });
 
-    it('should handle a Css asset with @charset declaration of iso-8859-1', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/encoding/'})
+    it('should handle a Css asset with @charset declaration of iso-8859-1', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/encoding/'});
+
+        await assetGraph
             .loadAssets('iso-8859-1.css')
-            .populate()
-            .then(function (assetGraph) {
-                expect(assetGraph.findAssets()[0].text, 'to contain', 'æøå');
-                expect(assetGraph.findAssets({})[0].parseTree.nodes[3].nodes, 'to satisfy', { 0: { prop: 'foo', value: 'æøå' } });
-            });
+            .populate();
+
+        expect(assetGraph.findAssets()[0].text, 'to contain', 'æøå');
+        expect(assetGraph.findAssets({})[0].parseTree.nodes[3].nodes, 'to satisfy', { 0: { prop: 'foo', value: 'æøå' } });
     });
 
     describe('#inline()', function () {
-        it('should handle a test case with an Html asset that has an external Css asset in a conditional comment', function () {
-            new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/inline/'})
+        it('should handle a test case with an Html asset that has an external Css asset in a conditional comment', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/inline/'});
+
+            await assetGraph
                 .loadAssets('index.html')
-                .populate()
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain assets', 4);
-                    expect(assetGraph, 'to contain assets', 'Html', 2);
-                    expect(assetGraph, 'to contain asset', 'Css');
-                    expect(assetGraph, 'to contain asset', 'Png');
+                .populate();
 
-                    assetGraph.findRelations({type: 'HtmlStyle'})[0].inline();
+            expect(assetGraph, 'to contain assets', 4);
+            expect(assetGraph, 'to contain assets', 'Html', 2);
+            expect(assetGraph, 'to contain asset', 'Css');
+            expect(assetGraph, 'to contain asset', 'Png');
 
-                    expect(assetGraph, 'to contain asset', {type: 'Css', isInline: true});
-                    expect(assetGraph.findRelations({type: 'CssImage'})[0].href, 'to equal', 'some/directory/foo.png');
+            assetGraph.findRelations({type: 'HtmlStyle'})[0].inline();
 
-                    var text = assetGraph.findAssets({type: 'Html'})[0].text,
-                        matches = text.match(/url\((.*?foo\.png)\)/g);
-                    expect(matches, 'to be an array');
-                    expect(matches[1], 'to equal', 'url(some\/directory\/foo.png)');
-                    expect(matches, 'to have length', 2);
-                });
+            expect(assetGraph, 'to contain asset', {type: 'Css', isInline: true});
+            expect(assetGraph.findRelations({type: 'CssImage'})[0].href, 'to equal', 'some/directory/foo.png');
+
+            const text = assetGraph.findAssets({type: 'Html'})[0].text;
+            const matches = text.match(/url\((.*?foo\.png)\)/g);
+            expect(matches, 'to be an array');
+            expect(matches[1], 'to equal', 'url(some\/directory\/foo.png)');
+            expect(matches, 'to have length', 2);
         });
     });
 
@@ -818,78 +824,80 @@ describe('assets/Asset', function () {
             expect(() => barTxt.url = 'https://example.com/foo.txt', 'to throw', 'https://example.com/foo.txt already exists in the graph, cannot update url');
         });
 
-        it('should handle a test case with 3 assets', function () {
-            return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/setAssetUrl/simple/'})
+        it('should handle a test case with 3 assets', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/setAssetUrl/simple/'});
+
+            await assetGraph
                 .loadAssets('index.html')
-                .populate()
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain assets', 3);
-                    expect(assetGraph, 'to contain assets', 'Html', 2);
-                    expect(assetGraph, 'to contain asset', 'Png');
+                .populate();
 
-                    const initialHtml = assetGraph.findAssets({type: 'Html'})[0];
-                    initialHtml.url = urlTools.resolveUrl(assetGraph.root, 'bogus/index.html');
+            expect(assetGraph, 'to contain assets', 3);
+            expect(assetGraph, 'to contain assets', 'Html', 2);
+            expect(assetGraph, 'to contain asset', 'Png');
 
-                    let relativeUrl = assetGraph.findRelations({type: 'HtmlAnchor'})[0].node.getAttribute('href');
-                    expect(relativeUrl, 'to equal', '../otherpage.html');
+            const initialHtml = assetGraph.findAssets({type: 'Html'})[0];
+            initialHtml.url = urlTools.resolveUrl(assetGraph.root, 'bogus/index.html');
 
-                    const otherHtml = assetGraph.findAssets({type: 'Html'})[1];
-                    otherHtml.url = urlTools.resolveUrl(assetGraph.root, 'fluff/otherpage.html');
+            let relativeUrl = assetGraph.findRelations({type: 'HtmlAnchor'})[0].node.getAttribute('href');
+            expect(relativeUrl, 'to equal', '../otherpage.html');
 
-                    relativeUrl = assetGraph.findRelations({type: 'HtmlAnchor'})[0].node.getAttribute('href');
-                    expect(relativeUrl, 'to equal', '../fluff/otherpage.html');
+            const otherHtml = assetGraph.findAssets({type: 'Html'})[1];
+            otherHtml.url = urlTools.resolveUrl(assetGraph.root, 'fluff/otherpage.html');
 
-                    relativeUrl = assetGraph.findRelations({type: 'HtmlImage'})[0].node.getAttribute('src');
-                    expect(relativeUrl, 'to equal', '../foo.png');
-                });
+            relativeUrl = assetGraph.findRelations({type: 'HtmlAnchor'})[0].node.getAttribute('href');
+            expect(relativeUrl, 'to equal', '../fluff/otherpage.html');
+
+            relativeUrl = assetGraph.findRelations({type: 'HtmlImage'})[0].node.getAttribute('src');
+            expect(relativeUrl, 'to equal', '../foo.png');
         });
 
-        it('should handle a test case with an Html asset that has multiple levels of inline assets', function () {
-            return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/setAssetUrl/multipleLevelsOfInline/'})
+        it('should handle a test case with an Html asset that has multiple levels of inline assets', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/setAssetUrl/multipleLevelsOfInline/'});
+
+            await assetGraph
                 .loadAssets('index.html')
-                .populate()
-                .queue(function (assetGraph) {
-                    expect(assetGraph, 'to contain asset', 'Css');
-                    expect(assetGraph, 'to contain asset', {type: 'Html', isInline: true});
-                    expect(assetGraph, 'to contain asset', {type: 'Html', isInline: false});
-                })
-                .moveAssets({type: 'Html', isInline: false}, function (asset, assetGraph) {
-                    return urlTools.resolveUrl(assetGraph.root, 'subdir/index.html');
-                })
-                .then(function (assetGraph) {
-                    expect(assetGraph.findRelations({type: 'CssImage'})[0].propertyNode.value, 'to equal', 'url(../foo.png)');
-                });
+                .populate();
+
+            expect(assetGraph, 'to contain asset', 'Css');
+            expect(assetGraph, 'to contain asset', {type: 'Html', isInline: true});
+            expect(assetGraph, 'to contain asset', {type: 'Html', isInline: false});
+
+            await assetGraph.moveAssets({type: 'Html', isInline: false}, function (asset, assetGraph) {
+                return urlTools.resolveUrl(assetGraph.root, 'subdir/index.html');
+            });
+
+            expect(assetGraph.findRelations({type: 'CssImage'})[0].propertyNode.value, 'to equal', 'url(../foo.png)');
         });
 
-        it('should handle a test case with a single Html file', function () {
-            return new AssetGraph({root: 'file:///foo/bar/quux'})
-                .loadAssets(new AssetGraph.Html({
-                    url: 'file:///foo/bar/quux/baz/index.html',
-                    text: '<!DOCTYPE html><html></html>'
-                }))
-                .then(function (assetGraph) {
-                    assetGraph.findAssets()[0].url = 'otherdir/index.html';
-                    expect(assetGraph.findAssets()[0].url, 'to equal', 'file:///foo/bar/quux/baz/otherdir/index.html');
+        it('should handle a test case with a single Html file', async function () {
+            const assetGraph = new AssetGraph({root: 'file:///foo/bar/quux'});
 
-                    assetGraph.findAssets()[0].url = '/hey/index.html';
-                    expect(assetGraph.findAssets()[0].url, 'to equal', 'file:///foo/bar/quux/hey/index.html');
+            await assetGraph.loadAssets(new AssetGraph.Html({
+                url: 'file:///foo/bar/quux/baz/index.html',
+                text: '<!DOCTYPE html><html></html>'
+            }));
 
-                    assetGraph.findAssets()[0].url = '//hey.com/there/index.html';
-                    expect(assetGraph.findAssets()[0].url, 'to equal', 'http://hey.com/there/index.html');
+            assetGraph.findAssets()[0].url = 'otherdir/index.html';
+            expect(assetGraph.findAssets()[0].url, 'to equal', 'file:///foo/bar/quux/baz/otherdir/index.html');
 
-                    assetGraph.findAssets()[0].url = 'you/go/index.html';
-                    expect(assetGraph.findAssets()[0].url, 'to equal', 'http://hey.com/there/you/go/index.html');
+            assetGraph.findAssets()[0].url = '/hey/index.html';
+            expect(assetGraph.findAssets()[0].url, 'to equal', 'file:///foo/bar/quux/hey/index.html');
 
-                    assetGraph.findAssets()[0].url = '/and/then/here.html';
-                    expect(assetGraph.findAssets()[0].url, 'to equal', 'http://hey.com/and/then/here.html');
+            assetGraph.findAssets()[0].url = '//hey.com/there/index.html';
+            expect(assetGraph.findAssets()[0].url, 'to equal', 'http://hey.com/there/index.html');
 
-                    assetGraph.findAssets()[0].url = '//example.com/then/here.html';
-                    expect(assetGraph.findAssets()[0].url, 'to equal', 'http://example.com/then/here.html');
+            assetGraph.findAssets()[0].url = 'you/go/index.html';
+            expect(assetGraph.findAssets()[0].url, 'to equal', 'http://hey.com/there/you/go/index.html');
 
-                    assetGraph.findAssets()[0].url = 'https://example2.com/then/here.html';
-                    assetGraph.findAssets()[0].url = '//example.com/then/here.html';
-                    expect(assetGraph.findAssets()[0].url, 'to equal', 'https://example.com/then/here.html');
-                });
+            assetGraph.findAssets()[0].url = '/and/then/here.html';
+            expect(assetGraph.findAssets()[0].url, 'to equal', 'http://hey.com/and/then/here.html');
+
+            assetGraph.findAssets()[0].url = '//example.com/then/here.html';
+            expect(assetGraph.findAssets()[0].url, 'to equal', 'http://example.com/then/here.html');
+
+            assetGraph.findAssets()[0].url = 'https://example2.com/then/here.html';
+            assetGraph.findAssets()[0].url = '//example.com/then/here.html';
+            expect(assetGraph.findAssets()[0].url, 'to equal', 'https://example.com/then/here.html');
         });
 
         it('should throw when trying to set an url on a non-externalizable asset', function () {
@@ -983,31 +991,34 @@ describe('assets/Asset', function () {
         });
     });
 
-    it('should consider a fragment part of the relation href, not the asset url', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/fragment/'})
+    it('should consider a fragment part of the relation href, not the asset url', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/assets/Asset/fragment/'});
+
+        await assetGraph
             .loadAssets('index.html')
-            .populate()
-            .then(function (assetGraph) {
-                expect(assetGraph, 'to contain assets', 2);
-                expect(assetGraph, 'to contain asset', {url: /\/otherpage\.html$/});
-                expect(assetGraph, 'to contain relation', {href: 'otherpage.html#fragment1'});
-                expect(assetGraph, 'to contain relation', {href: 'otherpage.html#fragment2'});
+            .populate();
 
-                expect(assetGraph, 'to contain relation', {href: '#selffragment'});
+        expect(assetGraph, 'to contain assets', 2);
+        expect(assetGraph, 'to contain asset', {url: /\/otherpage\.html$/});
+        expect(assetGraph, 'to contain relation', {href: 'otherpage.html#fragment1'});
+        expect(assetGraph, 'to contain relation', {href: 'otherpage.html#fragment2'});
 
-                assetGraph.findAssets({fileName: 'otherpage.html'})[0].url = 'http://example.com/';
+        expect(assetGraph, 'to contain relation', {href: '#selffragment'});
 
-                expect(assetGraph, 'to contain relation', {href: 'http://example.com/#fragment1'});
-                expect(assetGraph, 'to contain relation', {href: 'http://example.com/#fragment2'});
+        assetGraph.findAssets({fileName: 'otherpage.html'})[0].url = 'http://example.com/';
 
-                assetGraph.findAssets({fileName: 'index.html'})[0].url = 'http://example.com/yaddayadda.html';
-                expect(assetGraph, 'to contain relation', {href: '#selffragment'});
-            });
+        expect(assetGraph, 'to contain relation', {href: 'http://example.com/#fragment1'});
+        expect(assetGraph, 'to contain relation', {href: 'http://example.com/#fragment2'});
+
+        assetGraph.findAssets({fileName: 'index.html'})[0].url = 'http://example.com/yaddayadda.html';
+        expect(assetGraph, 'to contain relation', {href: '#selffragment'});
     });
 
     describe('#unload()', function () {
-        it('should clear inline assets from the graph', function () {
-            return new AssetGraph()
+        it('should clear inline assets from the graph', async function () {
+            const assetGraph = new AssetGraph();
+
+            await assetGraph
                 .loadAssets({
                     url: 'file://' + process.cwd() + '/foo/bar.html',
                     text:
@@ -1029,19 +1040,20 @@ describe('assets/Asset', function () {
                         '</head>\n' +
                         '</html>'
                 })
-                .populate()
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain assets', 5);
-                    assetGraph.findAssets({type: 'Html'})[0].unload();
-                    expect(assetGraph.findAssets({type: 'Html'})[0], 'to satisfy', { isPopulated: expect.it('to be falsy') });
-                    expect(assetGraph, 'to contain assets', 1);
-                });
+                .populate();
+
+            expect(assetGraph, 'to contain assets', 5);
+            assetGraph.findAssets({type: 'Html'})[0].unload();
+            expect(assetGraph.findAssets({type: 'Html'})[0], 'to satisfy', { isPopulated: expect.it('to be falsy') });
+            expect(assetGraph, 'to contain assets', 1);
         });
     });
 
     describe('text setter', function () {
-        it('should clear inline assets when the text of an asset is overridden', function () {
-            return new AssetGraph()
+        it('should clear inline assets when the text of an asset is overridden', async function () {
+            const assetGraph = new AssetGraph();
+
+            await assetGraph
                 .loadAssets({
                     url: 'file://' + process.cwd() + '/foo/bar.html',
                     text:
@@ -1063,12 +1075,11 @@ describe('assets/Asset', function () {
                         '</head>\n' +
                         '</html>'
                 })
-                .populate()
-                .then(function (assetGraph) {
-                    expect(assetGraph, 'to contain assets', 5);
-                    assetGraph.findAssets({type: 'Svg'})[0].text = '<?xml version="1.0" encoding="UTF-8"?>\n<svg></svg>';
-                    expect(assetGraph, 'to contain assets', 3);
-                });
+                .populate();
+
+            expect(assetGraph, 'to contain assets', 5);
+            assetGraph.findAssets({type: 'Svg'})[0].text = '<?xml version="1.0" encoding="UTF-8"?>\n<svg></svg>';
+            expect(assetGraph, 'to contain assets', 3);
         });
     });
 

--- a/test/relations/HtmlAlternateLink.js
+++ b/test/relations/HtmlAlternateLink.js
@@ -3,15 +3,16 @@ var expect = require('../unexpected-with-plugins'),
     AssetGraph = require('../../lib/AssetGraph');
 
 describe('relations/HtmlAlternateLink', function () {
-    it('should handle a simple test case', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlAlternateLink/'})
+    it('should handle a simple test case', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlAlternateLink/'});
+
+        await assetGraph
             .loadAssets('index.html')
-            .populate()
-            .then(function (assetGraph) {
-                expect(assetGraph, 'to contain relations', 'HtmlAlternateLink', 4);
-                expect(assetGraph, 'to contain assets', 'Rss', 2);
-                expect(assetGraph, 'to contain asset', 'Atom');
-                expect(assetGraph, 'to contain asset', 'Xml');
-            });
+            .populate();
+
+        expect(assetGraph, 'to contain relations', 'HtmlAlternateLink', 4);
+        expect(assetGraph, 'to contain assets', 'Rss', 2);
+        expect(assetGraph, 'to contain asset', 'Atom');
+        expect(assetGraph, 'to contain asset', 'Xml');
     });
 });

--- a/test/relations/HtmlIFrameSrcDoc.js
+++ b/test/relations/HtmlIFrameSrcDoc.js
@@ -3,25 +3,26 @@ var expect = require('../unexpected-with-plugins'),
     AssetGraph = require('../../lib/AssetGraph');
 
 describe('relations/HtmlIFrameSrcDoc', function () {
-    it('should handle a test case with an existing <iframe srcdoc=...> element', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlIFrameSrcDoc/'})
+    it('should handle a test case with an existing <iframe srcdoc=...> element', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/relations/HtmlIFrameSrcDoc/'});
+
+        await assetGraph
             .loadAssets('index.html')
             .populate({
                 followRelations: {to: {url: /^file:/}}
-            })
-            .then(function (assetGraph) {
-                expect(assetGraph, 'to contain assets', 'Html', 3);
-                expect(assetGraph, 'to contain asset', {type: 'Html', isInline: true});
-                expect(assetGraph, 'to contain relation', 'HtmlIFrame');
-                expect(assetGraph, 'to contain relation', 'HtmlIFrameSrcDoc');
-                expect(assetGraph, 'to contain relations', 'HtmlAnchor', 2);
-
-                var asset = assetGraph.findRelations({type: 'HtmlIFrameSrcDoc'})[0].to,
-                    document = asset.parseTree;
-                document.firstChild.appendChild(document.createTextNode('Hello from the outside!'));
-                asset.markDirty();
-
-                expect(assetGraph.findAssets({url: /\/index\.html$/})[0].text, 'to match', /Hello from the outside!/);
             });
+
+        expect(assetGraph, 'to contain assets', 'Html', 3);
+        expect(assetGraph, 'to contain asset', {type: 'Html', isInline: true});
+        expect(assetGraph, 'to contain relation', 'HtmlIFrame');
+        expect(assetGraph, 'to contain relation', 'HtmlIFrameSrcDoc');
+        expect(assetGraph, 'to contain relations', 'HtmlAnchor', 2);
+
+        const asset = assetGraph.findRelations({type: 'HtmlIFrameSrcDoc'})[0].to;
+        const document = asset.parseTree;
+        document.firstChild.appendChild(document.createTextNode('Hello from the outside!'));
+        asset.markDirty();
+
+        expect(assetGraph.findAssets({url: /\/index\.html$/})[0].text, 'to match', /Hello from the outside!/);
     });
 });

--- a/test/relations/HtmlMetaRefresh.js
+++ b/test/relations/HtmlMetaRefresh.js
@@ -4,7 +4,7 @@ var expect = require('../unexpected-with-plugins'),
     http = require('http');
 
 describe('relations/HtmlMetaRefresh', function () {
-    it('should handle a basic test case', function () {
+    it('should handle a basic test case', async function () {
         let serverAddress;
         let rootUrl;
         const server = http.createServer(function (req, res) {
@@ -27,13 +27,14 @@ describe('relations/HtmlMetaRefresh', function () {
         serverAddress = server.address();
         rootUrl = 'http://' + (serverAddress.address === '::' ? 'localhost' : serverAddress.address) + ':' + serverAddress.port + '/';
 
-        return new AssetGraph({root: rootUrl})
+        const assetGraph = new AssetGraph({root: rootUrl});
+
+        await assetGraph
             .loadAssets('/metaRefresh')
-            .populate()
-            .then(function (assetGraph) {
-                expect(assetGraph, 'to contain assets', 'Html', 2);
-                expect(assetGraph, 'to contain relations', 'HtmlMetaRefresh', 1);
-                server.close();
-            });
+            .populate();
+
+        expect(assetGraph, 'to contain assets', 'Html', 2);
+        expect(assetGraph, 'to contain relations', 'HtmlMetaRefresh', 1);
+        server.close();
     });
 });

--- a/test/transforms/moveAssetsInOrder.js
+++ b/test/transforms/moveAssetsInOrder.js
@@ -24,16 +24,13 @@ describe('transforms/moveAssetsInOrder', function () {
             .run(done);
     });
 
-    it('should throw an error when encountering circular references', function (done) {
-        new AssetGraph({root: 'testdata/transforms/moveAssetsInOrder/'})
+    it('should throw an error when encountering circular references', async function () {
+        const assetGraph = new AssetGraph({root: 'testdata/transforms/moveAssetsInOrder/'});
+
+        await assetGraph
             .loadAssets('circular.html')
-            .populate()
-            .run(function (error, assetGraph) {
+            .populate();
 
-                expect(assetGraph.moveAssetsInOrder({ type: 'Css' }, '/css/').run, 'to throw');
-
-                done();
-            });
-
+        expect(assetGraph.moveAssetsInOrder({ type: 'Css' }, '/css/').run, 'to throw');
     });
 });

--- a/test/transforms/splitCssIfIeLimitIsReached.js
+++ b/test/transforms/splitCssIfIeLimitIsReached.js
@@ -4,251 +4,262 @@ const AssetGraph = require('../../lib/AssetGraph');
 const _ = require('lodash');
 
 describe('transforms/splitCssIfIeLimitIsReached', function () {
-    it('should handle a simple Css test case', function () {
+    it('should handle a simple Css test case', async function () {
         const infos = [];
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
-            .on('info', function (err) {
-                infos.push(err);
-            })
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        assetGraph.on('info', function (err) {
+            infos.push(err);
+        });
+
+        await assetGraph
             .loadAssets('index.html')
-            .populate()
-            .queue(assetGraph => {
-                const cssAssets = assetGraph.findAssets({type: 'Css'});
-                expect(cssAssets, 'to have length', 1);
-                assetGraph._parseTreeBefore = cssAssets[0].parseTree;
+            .populate();
 
-                expect(assetGraph.findAssets({type: 'Css'})[0].parseTree.nodes, 'to have length', 4096);
-            })
-            .splitCssIfIeLimitIsReached()
-            .then(assetGraph => {
-                expect(infos, 'to have length', 1);
+        let cssAssets = assetGraph.findAssets({type: 'Css'});
+        expect(cssAssets, 'to have length', 1);
+        assetGraph._parseTreeBefore = cssAssets[0].parseTree;
 
-                expect(assetGraph, 'to contain assets', 'Css', 2);
+        expect(assetGraph.findAssets({type: 'Css'})[0].parseTree.nodes, 'to have length', 4096);
 
-                expect(assetGraph.findAssets({ type: 'Css' }).map(
-                    cssAsset => cssAsset.parseTree.nodes.length
-                ).reduce(
-                    (prev, current) => prev + current,
-                    0
-                ), 'to equal', 4096);
+        await assetGraph.splitCssIfIeLimitIsReached();
 
-                // Each Css asset should be smaller than the original
-                for (const cssAsset of assetGraph.findAssets({type: 'Css'})) {
-                    expect(cssAsset.parseTree.nodes.length, 'to be less than', assetGraph._parseTreeBefore.nodes.length);
-                }
+        expect(infos, 'to have length', 1);
 
-                const cssAfter = new AssetGraph.Css({
-                    text: assetGraph.findAssets({type: 'Css'}).map(function (cssAsset) {
-                        return cssAsset.text;
-                    }).join('')
-                }).parseTree.toString();
+        expect(assetGraph, 'to contain assets', 'Css', 2);
 
-                expect(assetGraph._parseTreeBefore.toString(), 'to equal', cssAfter + '\n');
+        expect(assetGraph.findAssets({ type: 'Css' }).map(
+            cssAsset => cssAsset.parseTree.nodes.length
+        ).reduce(
+            (prev, current) => prev + current,
+            0
+        ), 'to equal', 4096);
 
-                const cssAssets = assetGraph.findAssets({
-                    type: 'Css'
-                });
-                const pngRelations = assetGraph.findRelations({
-                    to: {
-                        type: 'Png'
-                    }
-                });
+        // Each Css asset should be smaller than the original
+        for (const cssAsset of assetGraph.findAssets({type: 'Css'})) {
+            expect(cssAsset.parseTree.nodes.length, 'to be less than', assetGraph._parseTreeBefore.nodes.length);
+        }
 
-                expect(pngRelations, 'to have length', 1);
-                expect(pngRelations[0].from, 'to be', cssAssets[1]);
-            });
+        const cssAfter = new AssetGraph.Css({
+            text: assetGraph.findAssets({type: 'Css'}).map(function (cssAsset) {
+                return cssAsset.text;
+            }).join('')
+        }).parseTree.toString();
+
+        expect(assetGraph._parseTreeBefore.toString(), 'to equal', cssAfter + '\n');
+
+        cssAssets = assetGraph.findAssets({
+            type: 'Css'
+        });
+        const pngRelations = assetGraph.findRelations({
+            to: {
+                type: 'Png'
+            }
+        });
+
+        expect(pngRelations, 'to have length', 1);
+        expect(pngRelations[0].from, 'to be', cssAssets[1]);
     });
 
-    it('should handle a real life huge Css test case', function () {
+    it('should handle a real life huge Css test case', async function () {
         const infos = [];
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
-            .on('info', function (err) {
-                infos.push(err);
-            })
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        assetGraph.on('info', function (err) {
+            infos.push(err);
+        });
+        await assetGraph
             .loadAssets('falcon.html')
-            .populate()
-            .queue(assetGraph => {
-                const cssAssets = assetGraph.findAssets({type: 'Css'});
-                expect(cssAssets, 'to have length', 1);
+            .populate();
 
-                assetGraph._parseTreeBefore = cssAssets[0].parseTree;
+        let cssAssets = assetGraph.findAssets({type: 'Css'});
+        expect(cssAssets, 'to have length', 1);
 
-                const rules = assetGraph.findAssets({ type: 'Css' })[0].parseTree.nodes.length;
-                assetGraph.__rules = rules;
-                expect(rules, 'to equal', 6039);
+        assetGraph._parseTreeBefore = cssAssets[0].parseTree;
 
-                for (const extension of ['png', 'gif', 'svg', 'ttf', 'eot', 'woff']) {
-                    expect(assetGraph, 'to contain asset', {
-                        url: new RegExp('\\.' + extension + '(?:$|#)')
-                    }, 1);
-                }
+        let rules = assetGraph.findAssets({ type: 'Css' })[0].parseTree.nodes.length;
+        assetGraph.__rules = rules;
+        expect(rules, 'to equal', 6039);
 
-                expect(assetGraph, 'to contain assets', {url: /fake\./}, 7);
-            })
-            .splitCssIfIeLimitIsReached()
-            .then(assetGraph => {
-                expect(infos, 'to have length', 1);
-                expect(assetGraph, 'to contain assets', 'Css', 3);
+        for (const extension of ['png', 'gif', 'svg', 'ttf', 'eot', 'woff']) {
+            expect(assetGraph, 'to contain asset', {
+                url: new RegExp('\\.' + extension + '(?:$|#)')
+            }, 1);
+        }
 
-                expect(assetGraph.findAssets({type: 'Css'}).map(
-                    cssAsset => cssAsset.parseTree.nodes.length
-                ).reduce(
-                    (prev, current) => prev + current,
-                    0
-                ), 'to equal', 6039);
+        expect(assetGraph, 'to contain assets', {url: /fake\./}, 7);
 
-                const cssAssets = assetGraph.findAssets({type: 'Css'});
-                const parseTreeBefore = assetGraph._parseTreeBefore;
-                const rules = [2796, 2544, 699];
-                let sum = 0;
+        await assetGraph.splitCssIfIeLimitIsReached();
 
-                for (const [i, cssAsset] of cssAssets.entries()) {
-                    const assetRules = cssAsset.parseTree.nodes;
-                    expect(assetRules.length, 'to be less than', parseTreeBefore.nodes.length);
-                    expect(assetRules.length, 'to equal', rules[i]);
-                    sum += assetRules.length;
-                }
+        expect(infos, 'to have length', 1);
+        expect(assetGraph, 'to contain assets', 'Css', 3);
 
-                expect(sum, 'to equal', assetGraph.__rules);
+        expect(assetGraph.findAssets({type: 'Css'}).map(
+            cssAsset => cssAsset.parseTree.nodes.length
+        ).reduce(
+            (prev, current) => prev + current,
+            0
+        ), 'to equal', 6039);
 
-                const text = assetGraph.findAssets({type: 'Css'}).map(
-                    cssAsset => cssAsset.text
-                ).join('\n');
-                const parseTreeAfter = new AssetGraph.Css({ text }).parseTree;
+        cssAssets = assetGraph.findAssets({type: 'Css'});
+        const parseTreeBefore = assetGraph._parseTreeBefore;
+        rules = [2796, 2544, 699];
+        let sum = 0;
 
-                expect(assetGraph._parseTreeBefore.toString().replace(/\n+/g, '\n'), 'to equal', (parseTreeAfter.toString() + '\n').replace(/\n+/g, '\n'));
+        for (const [i, cssAsset] of cssAssets.entries()) {
+            const assetRules = cssAsset.parseTree.nodes;
+            expect(assetRules.length, 'to be less than', parseTreeBefore.nodes.length);
+            expect(assetRules.length, 'to equal', rules[i]);
+            sum += assetRules.length;
+        }
 
-                for (const extension of ['png', 'gif', 'svg', 'ttf', 'eot', 'woff']) {
-                    expect(assetGraph, 'to contain asset', {
-                        url: new RegExp('\\.' + extension + '(?:$|#)')
-                    });
-                }
+        expect(sum, 'to equal', assetGraph.__rules);
+
+        const text = assetGraph.findAssets({type: 'Css'}).map(
+            cssAsset => cssAsset.text
+        ).join('\n');
+        const parseTreeAfter = new AssetGraph.Css({ text }).parseTree;
+
+        expect(assetGraph._parseTreeBefore.toString().replace(/\n+/g, '\n'), 'to equal', (parseTreeAfter.toString() + '\n').replace(/\n+/g, '\n'));
+
+        for (const extension of ['png', 'gif', 'svg', 'ttf', 'eot', 'woff']) {
+            expect(assetGraph, 'to contain asset', {
+                url: new RegExp('\\.' + extension + '(?:$|#)')
             });
+        }
     });
 
-    it('should handle a test case with an inline stylesheet', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
+    it('should handle a test case with an inline stylesheet', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        await assetGraph
             .loadAssets('inline.html')
-            .populate()
-            .queue(assetGraph => {
-                expect(assetGraph, 'to contain assets', 2);
-                expect(assetGraph, 'to contain asset', 'Html');
-                expect(assetGraph, 'to contain asset', 'Css');
-            })
-            .splitCssIfIeLimitIsReached({}, {rulesPerStylesheetLimit: 2})
-            .then(assetGraph => {
-                expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 3);
-                expect(assetGraph, 'to contain relations', 'HtmlStyle', 3);
-                expect(_.map(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
-                    [
-                        '\n          .a {color: #aaa;}\n          .b {color: #bbb;}',
-                        '\n          .c {color: #ccc;}\n          .d {color: #ddd;}',
-                        '\n          .e {color: #eee;}'
-                    ]
-                );
-                const htmlAsset = assetGraph.findAssets({type: 'Html'})[0];
-                expect(htmlAsset.text.match(/<style>/g), 'to have length', 3);
-            });
+            .populate();
+
+        expect(assetGraph, 'to contain assets', 2);
+        expect(assetGraph, 'to contain asset', 'Html');
+        expect(assetGraph, 'to contain asset', 'Css');
+
+        await assetGraph.splitCssIfIeLimitIsReached({}, {rulesPerStylesheetLimit: 2});
+
+        expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 3);
+        expect(assetGraph, 'to contain relations', 'HtmlStyle', 3);
+        expect(_.map(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
+            [
+                '\n          .a {color: #aaa;}\n          .b {color: #bbb;}',
+                '\n          .c {color: #ccc;}\n          .d {color: #ddd;}',
+                '\n          .e {color: #eee;}'
+            ]
+        );
+        const htmlAsset = assetGraph.findAssets({type: 'Html'})[0];
+        expect(htmlAsset.text.match(/<style>/g), 'to have length', 3);
     });
 
-    it('should handle a test case with an inline stylesheet that has rules in media queries', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
+    it('should handle a test case with an inline stylesheet that has rules in media queries', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        await assetGraph
             .loadAssets('inlineWithMedia.html')
-            .populate()
-            .queue(assetGraph => {
-                expect(assetGraph, 'to contain assets', 2);
-                expect(assetGraph, 'to contain asset', 'Html');
-                expect(assetGraph, 'to contain asset', 'Css');
-            })
-            .splitCssIfIeLimitIsReached({}, {rulesPerStylesheetLimit: 3})
-            .then(assetGraph => {
-                expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 4);
-                expect(assetGraph, 'to contain relations', 'HtmlStyle', 4);
-                expect(_.map(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
-                    [
-                        '\n          @media screen {\n              .a, .quux, .baz {color: #aaa;}\n          }',
-                        '\n          .b {color: #bbb;}\n          .c {color: #ccc;}',
-                        '\n          @media print {\n             .d {color: #ddd;}\n             .e {color: #eee;}\n             .f {color: #fff;}\n          }',
-                        '\n          .hey {color: #000;}\n          .there {color: #fff;}'
-                    ]
-                );
+            .populate();
 
-                const htmlAsset = assetGraph.findAssets({type: 'Html'})[0];
-                expect(htmlAsset.text.match(/<style>/g), 'to have length', 4);
-            });
+        expect(assetGraph, 'to contain assets', 2);
+        expect(assetGraph, 'to contain asset', 'Html');
+        expect(assetGraph, 'to contain asset', 'Css');
+
+        await assetGraph.splitCssIfIeLimitIsReached({}, {rulesPerStylesheetLimit: 3});
+
+        expect(assetGraph, 'to contain assets', {type: 'Css', isInline: true}, 4);
+        expect(assetGraph, 'to contain relations', 'HtmlStyle', 4);
+        expect(_.map(assetGraph.findAssets({type: 'Css'}), 'text'), 'to equal',
+            [
+                '\n          @media screen {\n              .a, .quux, .baz {color: #aaa;}\n          }',
+                '\n          .b {color: #bbb;}\n          .c {color: #ccc;}',
+                '\n          @media print {\n             .d {color: #ddd;}\n             .e {color: #eee;}\n             .f {color: #fff;}\n          }',
+                '\n          .hey {color: #000;}\n          .there {color: #fff;}'
+            ]
+        );
+
+        const htmlAsset = assetGraph.findAssets({type: 'Html'})[0];
+        expect(htmlAsset.text.match(/<style>/g), 'to have length', 4);
     });
 
-    it('should leave a big stylesheet alone if minimumIeVersion is 10', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
+    it('should leave a big stylesheet alone if minimumIeVersion is 10', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        await assetGraph
             .loadAssets({
                 type: 'Html',
                 url: 'http://example.com/foo.html',
                 text: '<!DOCTYPE html><html><body><style>' + new Array(5000).join('body {color: red;}') + '</style></body></html>'
             })
-            .populate()
-            .queue(assetGraph => {
-                expect(assetGraph, 'to contain assets', 2);
-                expect(assetGraph, 'to contain asset', 'Html');
-                expect(assetGraph, 'to contain asset', 'Css');
-            })
-            .splitCssIfIeLimitIsReached({}, {minimumIeVersion: 10})
-            .then(assetGraph => {
-                expect(assetGraph, 'to contain asset', 'Css');
-            });
+            .populate();
+
+        expect(assetGraph, 'to contain assets', 2);
+        expect(assetGraph, 'to contain asset', 'Html');
+        expect(assetGraph, 'to contain asset', 'Css');
+
+        await assetGraph.splitCssIfIeLimitIsReached({}, {minimumIeVersion: 10});
+
+        expect(assetGraph, 'to contain asset', 'Css');
     });
 
-    it('should split an enourmous stylesheet if minimumIeVersion is 10', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
+    it('should split an enourmous stylesheet if minimumIeVersion is 10', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        await assetGraph
             .loadAssets({
                 type: 'Html',
                 url: 'http://example.com/foo.html',
                 text: '<!DOCTYPE html><html><body><style>' + new Array(65536).join('body {color: red;}') + '</style></body></html>'
             })
-            .populate()
-            .queue(assetGraph => {
-                expect(assetGraph, 'to contain assets', 2);
-                expect(assetGraph, 'to contain asset', 'Html');
-                expect(assetGraph, 'to contain asset', 'Css');
-            })
-            .splitCssIfIeLimitIsReached({}, {minimumIeVersion: 10})
-            .then(assetGraph => {
-                expect(assetGraph, 'to contain assets', 'Css', 2);
-            });
+            .populate();
+
+        expect(assetGraph, 'to contain assets', 2);
+        expect(assetGraph, 'to contain asset', 'Html');
+        expect(assetGraph, 'to contain asset', 'Css');
+
+        await assetGraph.splitCssIfIeLimitIsReached({}, {minimumIeVersion: 10});
+
+        expect(assetGraph, 'to contain assets', 'Css', 2);
     });
 
-    it('should leave an enourmous stylesheet alone if minimumIeVersion is null', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
+    it('should leave an enourmous stylesheet alone if minimumIeVersion is null', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        await assetGraph
             .loadAssets({
                 type: 'Html',
                 url: 'http://example.com/foo.html',
                 text: '<!DOCTYPE html><html><body><style>' + new Array(65536).join('body {color: red;}') + '</style></body></html>'
             })
-            .populate()
-            .queue(assetGraph => {
-                expect(assetGraph, 'to contain assets', 2);
-                expect(assetGraph, 'to contain asset', 'Html');
-                expect(assetGraph, 'to contain asset', 'Css');
-            })
-            .splitCssIfIeLimitIsReached({}, {minimumIeVersion: null})
-            .queue(function (assetGraph) {
-                expect(assetGraph, 'to contain asset', 'Css');
-            });
+            .populate();
+
+        expect(assetGraph, 'to contain assets', 2);
+        expect(assetGraph, 'to contain asset', 'Html');
+        expect(assetGraph, 'to contain asset', 'Css');
+
+        await assetGraph.splitCssIfIeLimitIsReached({}, {minimumIeVersion: null});
+
+        expect(assetGraph, 'to contain asset', 'Css');
     });
 
-    it('should split a big stylesheet alone if minimumIeVersion is 9', function () {
-        return new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'})
+    it('should split a big stylesheet alone if minimumIeVersion is 9', async function () {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/splitCssIfIeLimitIsReached/'});
+
+        await assetGraph
             .loadAssets({
                 type: 'Html',
                 url: 'http://example.com/foo.html',
                 text: '<!DOCTYPE html><html><body><style>' + new Array(5000).join('body {color: red;}') + '</style></body></html>'
             })
-            .populate()
-            .queue(assetGraph => {
-                expect(assetGraph, 'to contain assets', 2);
-                expect(assetGraph, 'to contain asset', 'Html');
-                expect(assetGraph, 'to contain asset', 'Css');
-            })
-            .splitCssIfIeLimitIsReached({}, {minimumIeVersion: 9})
-            .queue(assetGraph => expect(assetGraph, 'to contain assets', 'Css', 2));
+            .populate();
+
+        expect(assetGraph, 'to contain assets', 2);
+        expect(assetGraph, 'to contain asset', 'Html');
+        expect(assetGraph, 'to contain asset', 'Css');
+
+        await assetGraph.splitCssIfIeLimitIsReached({}, {minimumIeVersion: 9});
+
+        expect(assetGraph, 'to contain assets', 'Css', 2);
     });
 });

--- a/test/util/fonts/gatherStylesheetsWithIncomingMedia.js
+++ b/test/util/fonts/gatherStylesheetsWithIncomingMedia.js
@@ -4,13 +4,14 @@ const AssetGraph = require('../../../');
 const sinon = require('sinon');
 
 describe('gatherStylesheetsWithIncomingMedia', function () {
-    const expect = unexpected.clone().addAssertion('<string> to produce result satisfying <array>', function (expect, subject, value) {
-        return new AssetGraph({root: __dirname + '/../../../testdata/util/fonts/gatherStylesheetsWithIncomingMedia/' + subject + '/'})
+    const expect = unexpected.clone().addAssertion('<string> to produce result satisfying <array>', async (expect, subject, value) => {
+        const assetGraph = new AssetGraph({root: __dirname + '/../../../testdata/util/fonts/gatherStylesheetsWithIncomingMedia/' + subject + '/'});
+
+        await assetGraph
             .loadAssets('index.html')
-            .populate()
-            .then(function (assetGraph) {
-                return expect(gatherStylesheetsWithIncomingMedia(assetGraph, assetGraph.findAssets({type: 'Html'})[0]), 'to satisfy', value);
-            });
+            .populate();
+
+        return expect(gatherStylesheetsWithIncomingMedia(assetGraph, assetGraph.findAssets({type: 'Html'})[0]), 'to satisfy', value);
     });
 
     it('should follow inline HtmlStyle relations', function () {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -2,19 +2,20 @@ var expect = require('../../unexpected-with-plugins').clone();
 var AssetGraph = require('../../../');
 var getTextByFontProp = require('../../../lib/util/fonts/getTextByFontProperties');
 
-expect.addAssertion('<string> to [exhaustively] satisfy computed font properties <array>', function (expect, subject, result) {
+expect.addAssertion('<string> to [exhaustively] satisfy computed font properties <array>', async function (expect, subject, result) {
     expect.subjectOutput = function (output) {
         output.code(subject, 'text/html');
     };
-    return new AssetGraph({})
+    const assetGraph = new AssetGraph();
+
+    await assetGraph
         .loadAssets({
             type: 'Html',
             text: subject
         })
-        .populate({ followRelations: { crossorigin: false } })
-        .then(function (assetGraph) {
-            expect(getTextByFontProp(assetGraph.findAssets({type: 'Html'})[0]), 'to [exhaustively] satisfy', result);
-        });
+        .populate({ followRelations: { crossorigin: false } });
+
+    expect(getTextByFontProp(assetGraph.findAssets({type: 'Html'})[0]), 'to [exhaustively] satisfy', result);
 });
 
 describe('lib/util/fonts/getTextByFontProperties', function () {
@@ -1885,17 +1886,18 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
             ]);
         });
 
-        it('should trace multiple levels of @import tagged with media lists', function () {
-            return new AssetGraph({root: __dirname + '/../../../testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/'})
+        it('should trace multiple levels of @import tagged with media lists', async function () {
+            const assetGraph = new AssetGraph({root: __dirname + '/../../../testdata/util/fonts/getTextByFontProperties/nestedCssImportWithMedia/'});
+
+            await assetGraph
                 .loadAssets('index.html')
-                .populate()
-                .then(function (assetGraph) {
-                    expect(getTextByFontProp(assetGraph.findAssets({type: 'Html'})[0]), 'to exhaustively satisfy', [
-                        { text: 'foo', props: { 'font-family': undefined, 'font-weight': 500, 'font-style': 'normal' } },
-                        { text: 'foo', props: { 'font-family': undefined, 'font-weight': 600, 'font-style': 'normal' } },
-                        { text: 'foo', props: { 'font-family': undefined, 'font-weight': 700, 'font-style': 'normal' } }
-                    ]);
-                });
+                .populate();
+
+            expect(getTextByFontProp(assetGraph.findAssets({type: 'Html'})[0]), 'to exhaustively satisfy', [
+                { text: 'foo', props: { 'font-family': undefined, 'font-weight': 500, 'font-style': 'normal' } },
+                { text: 'foo', props: { 'font-family': undefined, 'font-weight': 600, 'font-style': 'normal' } },
+                { text: 'foo', props: { 'font-family': undefined, 'font-weight': 700, 'font-style': 'normal' } }
+            ]);
         });
     });
 


### PR DESCRIPTION
As discussed on the gitter channel today.

It's one of the items here: https://github.com/assetgraph/assetgraph/issues/767

semver-major because the fulfillment value used to be the AssetGraph instance.