### PR TITLE
Subsetting: Track the predicates via a single object instead of (true|false)Predicates

### DIFF
--- a/lib/util/fonts/combinePredicates.js
+++ b/lib/util/fonts/combinePredicates.js
@@ -1,8 +1,7 @@
 // Object.assign-like function that turns the values into nulls in case of mismatches
-function combinePredicates() { // ...
+function combinePredicates(predicatesArray) { // ...
     var combinedPredicates = {};
-    for (var i = 0 ; i < arguments.length ; i += 1) {
-        var predicates = arguments[i];
+    predicatesArray.forEach(function (predicates) {
         Object.keys(predicates).forEach(function (predicate) {
             var value = predicates[predicate];
             if (typeof combinedPredicates[predicate] === 'undefined') {
@@ -11,7 +10,7 @@ function combinePredicates() { // ...
                 combinedPredicates[predicate] = null; // Conflict marker
             }
         });
-    }
+    });
     return combinedPredicates;
 }
 

--- a/lib/util/fonts/combinePredicates.js
+++ b/lib/util/fonts/combinePredicates.js
@@ -1,0 +1,18 @@
+// Object.assign-like function that turns the values into nulls in case of mismatches
+function combinePredicates() { // ...
+    var combinedPredicates = {};
+    for (var i = 0 ; i < arguments.length ; i += 1) {
+        var predicates = arguments[i];
+        Object.keys(predicates).forEach(function (predicate) {
+            var value = predicates[predicate];
+            if (typeof combinedPredicates[predicate] === 'undefined') {
+                combinedPredicates[predicate] = value;
+            } else if (combinedPredicates[predicate] !== value) {
+                combinedPredicates[predicate] = null; // Conflict marker
+            }
+        });
+    }
+    return combinedPredicates;
+}
+
+module.exports = combinePredicates;

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -2,6 +2,7 @@ var unescapeCssString = require('./unescapeCssString');
 var counterRendererByListStyleType = require('./counterRendererByListStyleType');
 var getCounterCharacters = require('./getCounterCharacters');
 var expandPermutations = require('../expandPermutations');
+var combinePredicates = require('./combinePredicates');
 
 function extractQuotes(quotes, token) {
     if (!quotes || quotes === 'none') {
@@ -125,18 +126,15 @@ function extractTextFromContentPropertyValue(value, node, hypotheticalQuotesValu
                 if (content) {
                     result.push({
                         value: content,
-                        truePredicates: Object.keys(hypotheticalCounterStyleByName).reduce(function (acc, counterStyleName) {
-                            return Object.assign(acc, hypotheticalCounterStyleByName[counterStyleName].truePredicates);
-                        }, {}),
-                        falsePredicates: Object.keys(hypotheticalCounterStyleByName).reduce(function (acc, counterStyleName) {
-                            return Object.assign(acc, hypotheticalCounterStyleByName[counterStyleName].falsePredicates);
-                        }, {})
+                        predicates: combinePredicates.apply(null, Object.keys(hypotheticalCounterStyleByName).map(function (counterStyleName) {
+                            return hypotheticalCounterStyleByName[counterStyleName].predicates;
+                        }))
                     });
                 }
             });
             return result;
         } else {
-            return [{ value: expandContent(tokens, node, quotes, hypotheticalCounterStyleValuesByName, possibleCounterValuesByName), falsePredicates: {}, truePredicates: {}}];
+            return [{ value: expandContent(tokens, node, quotes, hypotheticalCounterStyleValuesByName, possibleCounterValuesByName), predicates: {}}];
         }
     }
 
@@ -145,8 +143,7 @@ function extractTextFromContentPropertyValue(value, node, hypotheticalQuotesValu
         hypotheticalQuotesValues.forEach(function (hypotheticalQuotesValue) {
             var expandedContentValues = expandCounterStyles(hypotheticalQuotesValue.value);
             expandedContentValues.forEach(function (value) {
-                Object.assign(value.falsePredicates, hypotheticalQuotesValue.falsePredicates);
-                Object.assign(value.truePredicates, hypotheticalQuotesValue.truePredicates);
+                value.predicates = combinePredicates(value.predicates, hypotheticalQuotesValue.predicates);
             });
             Array.prototype.push.apply(result, expandedContentValues);
         });

--- a/lib/util/fonts/extractTextFromContentPropertyValue.js
+++ b/lib/util/fonts/extractTextFromContentPropertyValue.js
@@ -126,7 +126,7 @@ function extractTextFromContentPropertyValue(value, node, hypotheticalQuotesValu
                 if (content) {
                     result.push({
                         value: content,
-                        predicates: combinePredicates.apply(null, Object.keys(hypotheticalCounterStyleByName).map(function (counterStyleName) {
+                        predicates: combinePredicates(Object.keys(hypotheticalCounterStyleByName).map(function (counterStyleName) {
                             return hypotheticalCounterStyleByName[counterStyleName].predicates;
                         }))
                     });
@@ -143,7 +143,7 @@ function extractTextFromContentPropertyValue(value, node, hypotheticalQuotesValu
         hypotheticalQuotesValues.forEach(function (hypotheticalQuotesValue) {
             var expandedContentValues = expandCounterStyles(hypotheticalQuotesValue.value);
             expandedContentValues.forEach(function (value) {
-                value.predicates = combinePredicates(value.predicates, hypotheticalQuotesValue.predicates);
+                value.predicates = combinePredicates([value.predicates, hypotheticalQuotesValue.predicates]);
             });
             Array.prototype.push.apply(result, expandedContentValues);
         });

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -13,6 +13,7 @@ var counterRendererByListStyleType = require('./counterRendererByListStyleType')
 var unescapeCssString = require('./unescapeCssString');
 var getCounterCharacters = require('./getCounterCharacters');
 var expandPermutations = require('../expandPermutations');
+var combinePredicates = require('./combinePredicates');
 
 var FONT_PROPS = [
     'font-family',
@@ -91,6 +92,15 @@ function createPredicatePermutations(predicatesToVary, predicates, i) {
     }
 }
 
+function invertPredicates(predicates) {
+    var invertedPredicates = {};
+    Object.keys(predicates).forEach(function (predicate) {
+        var value = predicates[predicate];
+        invertedPredicates[predicate] = typeof value === 'boolean' ? !value : value;
+    });
+    return invertedPredicates;
+}
+
 var excludedNodes = ['HEAD', 'STYLE', 'SCRIPT'];
 
 function getFontRulesWithDefaultStylesheetApplied(htmlAsset, memoizedGetCssRulesByProperty) {
@@ -149,16 +159,15 @@ function getFontRulesWithDefaultStylesheetApplied(htmlAsset, memoizedGetCssRules
 function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByProperty) {
     var nonInheritingTags = ['BUTTON', 'INPUT', 'OPTION', 'TEXTAREA'];
 
-    var getComputedStyle = memoizeSync(function (node, idArray, truePredicates, falsePredicates) {
-        truePredicates = truePredicates || {};
-        falsePredicates = falsePredicates || {};
+    var getComputedStyle = memoizeSync(function (node, idArray, predicates) {
+        predicates = predicates || {};
         var localFontPropRules = Object.assign({}, fontPropRules);
         var result = {};
 
         // Stop condition. We moved above <HTML>
         if (!node.tagName) {
             ALL_PROPS_TO_TRACE.forEach(function (prop) {
-                result[prop] = [ { value: INITIAL_VALUES[prop], truePredicates: truePredicates, falsePredicates: falsePredicates }];
+                result[prop] = [ { value: INITIAL_VALUES[prop], predicates: predicates }];
             });
             return result;
         }
@@ -174,7 +183,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
             });
         }
 
-        function traceProp(prop, startIndex, truePredicates, falsePredicates) {
+        function traceProp(prop, startIndex, predicates) {
             startIndex = startIndex || 0;
 
             for (var i = startIndex; i < localFontPropRules[prop].length; i += 1) {
@@ -182,11 +191,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                 // Skip to the next rule if we are doing a trace where one of true predicates is already assumed false,
                 // or one of the false predicates is already assumed true:
                 if (Object.keys(declaration.predicates).some(function (predicate) {
-                    if (declaration.predicates[predicate]) {
-                        return falsePredicates[predicate];
-                    } else {
-                        return truePredicates[predicate];
-                    }
+                    return typeof predicates[predicate] === 'boolean' && declaration.predicates[predicate] !== predicates[predicate];
                 })) {
                     continue;
                 }
@@ -202,7 +207,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                     if (matchPseudoElement) {
                         hasPseudoElement = true;
                         // The selector ends with :before or :after
-                        if (truePredicates['pseudoElement:' + matchPseudoElement[2]]) {
+                        if (predicates['pseudoElement:' + matchPseudoElement[2]]) {
                             strippedSelector = matchPseudoElement[1];
                         } else {
                             // We're not currently tracing this pseudo element, skip this rule
@@ -216,14 +221,14 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                     continue;
                 }
 
-                if (!INHERITED[prop] && !hasPseudoElement && Object.keys(truePredicates).some(function (predicate) { return truePredicates[predicate] && /^pseudoElement:/.test(predicate); })) {
+                if (!INHERITED[prop] && !hasPseudoElement && Object.keys(predicates).some(function (predicate) { return predicates[predicate] && /^pseudoElement:/.test(predicate); })) {
                     continue;
                 }
 
                 if (isStyleAttribute || node.matches(strippedSelector.replace(/ i\]/, ']'))) { // nwmatcher doesn't support the i flag in attribute selectors
                     var hypotheticalValues;
                     if (declaration.value === 'inherit' || declaration.value === 'unset') {
-                        hypotheticalValues = getComputedStyle(node.parentNode, idArray.slice(0, -1), truePredicates, falsePredicates)[prop];
+                        hypotheticalValues = getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates)[prop];
                     } else {
                         var value;
                         if (declaration.value === 'initial') {
@@ -232,7 +237,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                             value = NAME_CONVERSIONS[prop][declaration.value];
                         } else if (prop === 'font-weight') {
                             if (declaration.value === 'lighter' || declaration.value === 'bolder') {
-                                var inheritedWeight = getComputedStyle(node.parentNode, idArray.slice(0, -1), truePredicates, falsePredicates)[prop][0].value;
+                                var inheritedWeight = getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates)[prop][0].value;
                                 if (declaration.value === 'lighter' || declaration.value === 'bolder') {
                                     value = inheritedWeight + '+' + declaration.value;
                                 }
@@ -246,7 +251,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                             value = declaration.value;
                         }
 
-                        hypotheticalValues = [ { value: value, truePredicates: truePredicates, falsePredicates: falsePredicates } ];
+                        hypotheticalValues = [ { value: value, predicates: predicates } ];
                     }
 
                     var predicatesToVary = Object.keys(declaration.predicates);
@@ -260,40 +265,24 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                             if (predicatePermutationKeys.length === 0) {
                                 return;
                             }
-                            var truePredicatesForThisPermutation = Object.assign({}, truePredicates);
-                            var falsePredicatesForThisPermutation = Object.assign({}, falsePredicates);
-                            var truePredicatesOtherwise = Object.assign({}, truePredicates);
-                            var falsePredicatesOtherwise = Object.assign({}, falsePredicates);
-                            predicatePermutationKeys.forEach(function (predicate) {
-                                if (predicatePermutation[predicate]) {
-                                    truePredicatesForThisPermutation[predicate] = true;
-                                    falsePredicatesOtherwise[predicate] = true;
-                                } else {
-                                    falsePredicatesForThisPermutation[predicate] = true;
-                                    truePredicatesOtherwise[predicate] = true;
-                                }
-                            });
+                            var predicatesForThisPermutation = combinePredicates(predicates, predicatePermutation);
+                            var predicatesOtherwise = combinePredicates(predicates, invertPredicates(predicatePermutation));
                             if (Object.keys(declaration.predicates).every(function (predicate) {
-                                if (declaration.predicates[predicate]) {
-                                    return truePredicatesForThisPermutation[predicate];
-                                } else {
-                                    return falsePredicatesForThisPermutation[predicate];
-                                }
+                                return declaration.predicates[predicate] === predicatesForThisPermutation[predicate];
                             })) {
                                 Array.prototype.push.apply(
                                     multipliedHypotheticalValues,
                                     hypotheticalValues.map(function (hypotheticalValue) {
                                         return {
                                             value: hypotheticalValue.value,
-                                            truePredicates: truePredicatesForThisPermutation,
-                                            falsePredicates: falsePredicatesForThisPermutation
+                                            predicates: predicatesForThisPermutation
                                         };
                                     })
                                 );
                             }
                             Array.prototype.push.apply(
                                 multipliedHypotheticalValues,
-                                traceProp(prop, i + 1, truePredicatesOtherwise, falsePredicatesOtherwise)
+                                traceProp(prop, i + 1, predicatesOtherwise)
                             );
                         });
                         return multipliedHypotheticalValues;
@@ -304,22 +293,23 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
             }
 
             if (nonInheritingTags.indexOf(node.tagName) === -1) {
-                return getComputedStyle(node.parentNode, idArray.slice(0, -1), truePredicates, falsePredicates)[prop];
+                return getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates)[prop];
             } else {
-                return [ { value: INITIAL_VALUES[prop], truePredicates: truePredicates, falsePredicates: falsePredicates }];
+                return [ { value: INITIAL_VALUES[prop], predicates: predicates }];
             }
         }
 
         ALL_PROPS_TO_TRACE.forEach(function (prop) {
-            result[prop] = traceProp(prop, 0, truePredicates, falsePredicates);
+            result[prop] = traceProp(prop, 0, predicates);
         });
         return result;
     }, {
         argumentsStringifier: function (args) {
             return (
                 args[1].join(',') + '\x1e' +
-                (args[2] ? Object.keys(args[2]).join('\x1d') : '') + '\x1e' +
-                (args[3] ? Object.keys(args[3]).join('\x1d') : '')
+                (args[2] ? Object.keys(args[2]).map(function (key) {
+                    return key + '\x1d' + args[2][key];
+                }).join('\x1d') : '')
             );
         }
     });
@@ -378,14 +368,7 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
                                 values.forEach(function (value) {
                                     (extraValuesByProp[prop] = extraValuesByProp[prop] || []).push({
                                         value: value,
-                                        truePredicates: Object.assign(
-                                            {},
-                                            permutation['animation-name'].truePredicates
-                                        ),
-                                        falsePredicates: Object.assign(
-                                            {},
-                                            permutation['animation-name'].falsePredicates
-                                        )
+                                        predicates: permutation['animation-name'].predicates
                                     });
                                 });
                             });
@@ -407,8 +390,8 @@ function expandTransitions(computedStyle) {
     });
     if (fontWeightTransitions.length > 0) {
         var hypotheticalFontWeightValuesInPseudoClassStates = computedStyle['font-weight'].filter(function (hypotheticalValue) {
-            return Object.keys(hypotheticalValue.truePredicates).some(function (predicate) {
-                return /^selectorWithPseudoClasses:/.test(predicate);
+            return Object.keys(hypotheticalValue.predicates).some(function (predicate) {
+                return hypotheticalValue.predicates[predicate] && /^selectorWithPseudoClasses:/.test(predicate);
             });
         });
         if (hypotheticalFontWeightValuesInPseudoClassStates.length > 0) {
@@ -422,27 +405,17 @@ function expandTransitions(computedStyle) {
 
                         hypotheticalFontWeightValuesInPseudoClassStates.forEach(function (hypotheticalFontWeightValueInPseudoClassStates) {
                             computedStyle['font-weight'].forEach(function (hypotheticalFontWeightValue) {
-                                // Explicitly don't include hypotheticalFontWeightValueInPseudoClassStates.truePredicates
-                                var truePredicates = Object.assign(
-                                    {},
-                                    transitionDuration.truePredicates,
-                                    fontWeightTransition.truePredicates,
-                                    hypotheticalFontWeightValue.truePredicates
-                                );
-                                // Explicitly don't include hypotheticalFontWeightValueInPseudoClassStates.falsePredicates
-                                var falsePredicates = Object.assign(
-                                    {},
-                                    transitionDuration.falsePredicates,
-                                    fontWeightTransition.falsePredicates,
-                                    hypotheticalFontWeightValue.falsePredicates
-                                );
                                 var fontWeight1 = cssFontWeightNames[hypotheticalFontWeightValue.value] || parseInt(hypotheticalFontWeightValue.value, 10);
                                 var fontWeight2 = cssFontWeightNames[hypotheticalFontWeightValueInPseudoClassStates.value] || parseInt(hypotheticalFontWeightValueInPseudoClassStates.value, 10);
                                 for (var fontWeight = Math.min(fontWeight1, fontWeight2) + 100 ; fontWeight < Math.max(fontWeight1, fontWeight2) ; fontWeight += 100) {
                                     extraHypotheticalFontWeightValues.push({
                                         value: fontWeight,
-                                        truePredicates: truePredicates,
-                                        falsePredicates: falsePredicates
+                                        // Explicitly don't include hypotheticalFontWeightValueInPseudoClassStates.predicates
+                                        predicates: combinePredicates(
+                                            transitionDuration.predicates,
+                                            fontWeightTransition.predicates,
+                                            hypotheticalFontWeightValue.predicates
+                                        )
                                     });
                                 }
                             });
@@ -466,21 +439,14 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
         if (/\blist-item\b/.test(computedStyle.display[i].value)) {
             for (var j = 0 ; j < computedStyle['list-style-type'].length ; j += 1) {
                 var listStyleType = computedStyle['list-style-type'][j].value;
-                var falsePredicates = Object.assign(
-                    {},
-                    computedStyle.display[i].falsePredicates,
-                    computedStyle['list-style-type'][j].falsePredicates
-                );
-                var truePredicates = Object.assign(
-                    {},
-                    computedStyle.display[i].truePredicates,
-                    computedStyle['list-style-type'][j].truePredicates
+                var predicates = combinePredicates(
+                    computedStyle.display[i].predicates,
+                    computedStyle['list-style-type'][j].predicates
                 );
                 if (/^['"]/.test(listStyleType)) {
                     computedStyle.text.push({
                         value: unescapeCssString(unquote(listStyleType)),
-                        falsePredicates: falsePredicates,
-                        truePredicates: truePredicates
+                        predicates: predicates
                     });
                 } else {
                     var found = false;
@@ -489,8 +455,7 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
                             found = true;
                             computedStyle.text.push({
                                 value: getCounterCharacters(counterStyle, counterStyles, possibleListItemNumbers),
-                                falsePredicates: falsePredicates,
-                                truePredicates: Object.assign({}, truePredicates, counterStyle.predicates)
+                                predicates: combinePredicates(predicates, counterStyle.predicates)
                             });
                         }
                     });
@@ -499,8 +464,7 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
                             value: possibleListItemNumbers
                                 .map(listItemNumber => counterRendererByListStyleType[listStyleType](listItemNumber) + '.')
                                 .join(''),
-                            falsePredicates: falsePredicates,
-                            truePredicates: truePredicates
+                            predicates: predicates
                         });
                     }
                 }
@@ -512,7 +476,7 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
 
 // memoizedGetCssRulesByProperty is optional
 function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
-    if (!htmlAsset || htmlAsset.type !== 'Html'  || !htmlAsset.assetGraph) {
+    if (!htmlAsset || htmlAsset.type !== 'Html' || !htmlAsset.assetGraph) {
         throw new Error('htmlAsset must be a Html-asset and be in an assetGraph');
     }
 
@@ -663,7 +627,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 styledTexts.push(
                     expandComputedStyle(
                         Object.assign(
-                            { text: [ { value: textContent, truePredicates: {}, falsePredicates: {} } ] },
+                            { text: [ { value: textContent, predicates: {} } ] },
                             getComputedStyle(node.parentNode, idArray.slice(0, -1))
                         )
                     )
@@ -729,7 +693,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     styledTexts.push(
                         expandComputedStyle(
                             Object.assign(
-                                { text: [ { value: inputValue, truePredicates: {}, falsePredicates: {} } ] },
+                                { text: [ { value: inputValue, predicates: {} } ] },
                                 getComputedStyle(node, idArray)
                             )
                         )
@@ -740,7 +704,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     styledTexts.push(
                         expandComputedStyle(
                             Object.assign(
-                                { text: [ { value: inputPlaceholder, truePredicates: {}, falsePredicates: {} } ] },
+                                { text: [ { value: inputPlaceholder, predicates: {} } ] },
                                 getComputedStyle(node, idArray)
                             )
                         )
@@ -750,7 +714,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 styledTexts.push(
                     adjustPossibleCountersAndListItemNumbers(expandComputedStyle(
                         Object.assign(
-                            { text: [ { value: '', truePredicates: {}, falsePredicates: {} } ] },
+                            { text: [ { value: '', predicates: {} } ] },
                             getComputedStyle(node, idArray)
                         )
                     ), conditionalCommentStack.length > 0)
@@ -759,16 +723,15 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 possibleNextListItemNumberStack.push([1]);
 
                 ['before', 'after'].forEach(function (pseudoElementName) {
-                    var truePredicates = {};
-                    truePredicates['pseudoElement:' + pseudoElementName] = true;
-                    var computedStyle = expandComputedStyle(Object.assign({}, getComputedStyle(node, idArray, truePredicates)));
+                    var predicates = {};
+                    predicates['pseudoElement:' + pseudoElementName] = true;
+                    var computedStyle = expandComputedStyle(Object.assign({}, getComputedStyle(node, idArray, predicates)));
                     var expandedContents = [];
                     // Multiply the hypothetical content values with the hypothetical quotes values:
                     computedStyle.content.forEach(function (hypotheticalContent) {
                         var hypotheticalValues = extractTextFromContentPropertyValue(hypotheticalContent.value, node, computedStyle.quotes, hypotheticalCounterStylesByName, possibleCounterValuesByName);
                         hypotheticalValues.forEach(function (hypotheticalValue) {
-                            Object.assign(hypotheticalValue.falsePredicates, hypotheticalContent.falsePredicates);
-                            Object.assign(hypotheticalValue.truePredicates, hypotheticalContent.truePredicates);
+                            hypotheticalValue.predicates = combinePredicates(hypotheticalValue.predicates, hypotheticalContent.predicates);
                         });
                         Array.prototype.push.apply(expandedContents, hypotheticalValues);
                     });
@@ -795,9 +758,9 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     //     {
     //         text: 'foo',
     //         props: {
-    //             'font-family': [ { value: 'a', truePredicates: {...}, falsePredicates: {...} }, { value: 'b', truePredicates: {...}, falsePredicates: {...} }],
-    //             'font-style': [ { value: 'normal', truePredicates: {...}, falsePredicates: {...} } ],
-    //             'font-weight': [ { value: 400, truePredicates: {...}, falsePredicates: {...} }, { value: 700, truePredicates: {...}, falsePredicates: {...} }]
+    //             'font-family': [ { value: 'a', predicates: {...} }, { value: 'b', predicates: {...} }],
+    //             'font-style': [ { value: 'normal', predicates: {...} } ],
+    //             'font-weight': [ { value: 400, predicates: {...} }, { value: 700, predicates: {...} }]
     //         }
     //     },
     //     ...
@@ -807,12 +770,14 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     var multipliedStyledTexts = _.flatten(styledTexts.map(function (styledText) {
         return expandPermutations(styledText)
             .filter(function removeImpossibleCombinations(hypotheticalValueByProp) {
-                // Check that none of the predicates assumed true are assumed false, too:
                 return ALL_PROPS_TO_TRACE_AND_TEXT.every(function (prop) {
-                    return Object.keys(hypotheticalValueByProp[prop].truePredicates).every(function (truePredicate) {
-                        return ALL_PROPS_TO_TRACE_AND_TEXT.every(function (otherProp) {
-                            return !hypotheticalValueByProp[otherProp].falsePredicates[truePredicate];
-                        });
+                    return Object.keys(hypotheticalValueByProp[prop].predicates).every(function (predicate) {
+                        var predicateValue = hypotheticalValueByProp[prop].predicates[predicate];
+                        return predicateValue !== null && (predicateValue === false ||
+                            ALL_PROPS_TO_TRACE_AND_TEXT.every(function (otherProp) {
+                                return hypotheticalValueByProp[otherProp].predicates[predicate] !== false;
+                            }));
+
                     });
                 });
             })

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -265,8 +265,8 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                             if (predicatePermutationKeys.length === 0) {
                                 return;
                             }
-                            var predicatesForThisPermutation = combinePredicates(predicates, predicatePermutation);
-                            var predicatesOtherwise = combinePredicates(predicates, invertPredicates(predicatePermutation));
+                            var predicatesForThisPermutation = combinePredicates([predicates, predicatePermutation]);
+                            var predicatesOtherwise = combinePredicates([predicates, invertPredicates(predicatePermutation)]);
                             if (Object.keys(declaration.predicates).every(function (predicate) {
                                 return declaration.predicates[predicate] === predicatesForThisPermutation[predicate];
                             })) {
@@ -411,11 +411,11 @@ function expandTransitions(computedStyle) {
                                     extraHypotheticalFontWeightValues.push({
                                         value: fontWeight,
                                         // Explicitly don't include hypotheticalFontWeightValueInPseudoClassStates.predicates
-                                        predicates: combinePredicates(
+                                        predicates: combinePredicates([
                                             transitionDuration.predicates,
                                             fontWeightTransition.predicates,
                                             hypotheticalFontWeightValue.predicates
-                                        )
+                                        ])
                                     });
                                 }
                             });
@@ -439,10 +439,10 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
         if (/\blist-item\b/.test(computedStyle.display[i].value)) {
             for (var j = 0 ; j < computedStyle['list-style-type'].length ; j += 1) {
                 var listStyleType = computedStyle['list-style-type'][j].value;
-                var predicates = combinePredicates(
+                var predicates = combinePredicates([
                     computedStyle.display[i].predicates,
                     computedStyle['list-style-type'][j].predicates
-                );
+                ]);
                 if (/^['"]/.test(listStyleType)) {
                     computedStyle.text.push({
                         value: unescapeCssString(unquote(listStyleType)),
@@ -455,7 +455,7 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
                             found = true;
                             computedStyle.text.push({
                                 value: getCounterCharacters(counterStyle, counterStyles, possibleListItemNumbers),
-                                predicates: combinePredicates(predicates, counterStyle.predicates)
+                                predicates: combinePredicates([predicates, counterStyle.predicates])
                             });
                         }
                     });
@@ -731,7 +731,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     computedStyle.content.forEach(function (hypotheticalContent) {
                         var hypotheticalValues = extractTextFromContentPropertyValue(hypotheticalContent.value, node, computedStyle.quotes, hypotheticalCounterStylesByName, possibleCounterValuesByName);
                         hypotheticalValues.forEach(function (hypotheticalValue) {
-                            hypotheticalValue.predicates = combinePredicates(hypotheticalValue.predicates, hypotheticalContent.predicates);
+                            hypotheticalValue.predicates = combinePredicates([hypotheticalValue.predicates, hypotheticalContent.predicates]);
                         });
                         Array.prototype.push.apply(expandedContents, hypotheticalValues);
                     });


### PR DESCRIPTION
This makes the predicates-math a bit clearer and changes to the same representation as the `predicates` property of the stylesheets info objects returned by `gatherStylesheetsWithIncomingMedia` and that of the declaration objects returned by `getCssRulesByProperty`.