### PR TITLE
Javascript font preloading

### DIFF
--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -15,6 +15,12 @@ var getCssRulesByProperty = require('../util/fonts/getCssRulesByProperty');
 
 var googleFontsCssUrlRegex = /^(?:https?:)?\/\/fonts\.googleapis\.com\/css/;
 
+var initialFontPropertyValues = {
+    'font-style': 'normal',
+    'font-weight': 400,
+    'font-stretch': 'normal'
+};
+
 function cssQuoteIfNecessary(value) {
     if (/^\w+$/.test(value)) {
         return value;
@@ -552,18 +558,60 @@ module.exports = function (options) {
                         var subsetFontUsages = fontUsages.filter(function (fontUsage) { return fontUsage.subsets; });
                         var unsubsettedFontUsages = fontUsages.filter(function (fontUsage) { return subsetFontUsages.indexOf(fontUsage) === -1; });
 
-                        unsubsettedFontUsages.forEach(function (fontUsage) {
-                            var fontAsset = assetGraph.findAssets({ url: fontUsage.props.src })[0];
+                        if (unsubsettedFontUsages.length > 0) {
+                            // Insert <link rel="preload">
+                            var preloadRelations = unsubsettedFontUsages.map(function (fontUsage) {
+                                var fontAsset = assetGraph.findAssets({ url: fontUsage.props.src })[0];
 
-                            // Always preload unsubsetted font files, they might be any format, so can't be clever here
-                            var preloadRelation = new AssetGraph.HtmlPreloadLink({
-                                hrefType: 'rootRelative',
-                                to: fontAsset,
-                                as: 'font'
+                                // Always preload unsubsetted font files, they might be any format, so can't be clever here
+                                return new AssetGraph.HtmlPreloadLink({
+                                    hrefType: 'rootRelative',
+                                    to: fontAsset,
+                                    as: 'font'
+                                });
                             });
 
-                            preloadRelation.attach(htmlAsset, 'before', insertionPoint);
-                        });
+                            preloadRelations.forEach(function (rel) {
+                                rel.attach(htmlAsset, 'before', insertionPoint);
+                            });
+
+                            // Generate JS fallback for browser that don't support <link rel="preload">
+                            var preloadData = unsubsettedFontUsages.map(function (fontUsage, idx) {
+                                var preloadRelation = preloadRelations[idx];
+
+                                var formatMap = {
+                                    '.woff': 'woff',
+                                    '.woff2': 'woff2',
+                                    '.ttf': 'truetype',
+                                    '.svg': 'svg',
+                                    '.eot': 'embedded-opentype'
+                                };
+                                var name = fontUsage.props['font-family'];
+                                var url = 'url(\'"+"' + preloadRelation.href + '".toString(\'url\')+"\') format(\'' + formatMap[preloadRelation.to.extension] + '\')';
+                                var props = Object.keys(initialFontPropertyValues).reduce(function (result, prop) {
+                                    if (fontUsage.props[prop] !== initialFontPropertyValues[prop]) {
+                                        result[prop] = fontUsage.props[prop];
+                                    }
+
+                                    return result;
+                                }, {});
+
+                                return 'new FontFace("' + name + '", "' + url + '", ' + JSON.stringify(props) + ');';
+                            });
+
+                            var originalFontJsPreloadAsset = new AssetGraph.JavaScript(assetGraph.resolveAssetConfig({
+                                text: 'try{' + preloadData.join('') + '}catch(e){}'
+                            }));
+                            assetGraph.addAsset(originalFontJsPreloadAsset);
+
+                            originalFontJsPreloadAsset.outgoingRelations.forEach(function (rel, idx) {
+                                rel.to = preloadRelations[idx].to;
+                            });
+
+                            new AssetGraph.HtmlScript({ to: originalFontJsPreloadAsset }).attach(htmlAsset, 'before', insertionPoint);
+
+                            originalFontJsPreloadAsset.minify();
+                        }
 
                         if (subsetFontUsages.length < 1) {
                             return;
@@ -575,11 +623,9 @@ module.exports = function (options) {
                         if (!cssAsset) {
                             cssAsset = new AssetGraph.Css(assetGraph.resolveAssetConfig({
                                 type: 'Css',
+                                url: subsetPath + 'subfontTemp.css',
                                 text: subsetCssText
                             }));
-
-                            var cssFileName = 'fonts-' + cssAsset.md5Hex.slice(0, 10) + '.css';
-                            cssAsset.url = subsetPath + cssFileName;
 
                             assetGraph.addAsset(cssAsset);
 
@@ -615,6 +661,9 @@ module.exports = function (options) {
                                     }
                                 });
                             }
+
+                            var cssFileName = 'fonts-' + cssAsset.md5Hex.slice(0, 10) + '.css';
+                            cssAsset.url = subsetPath + cssFileName;
                         }
 
                         if (!inlineSubsets) {
@@ -647,6 +696,18 @@ module.exports = function (options) {
 
                         if (inlineCss) {
                             cssRelation.inline();
+
+                            // Inject JS preloading of font subsets for browsers wihtout <link rel="preload"> support
+                            var jsPreloadInlineAsset = new AssetGraph.JavaScript(assetGraph.resolveAssetConfig({
+                                text: 'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load(); }); } catch (e) {}'
+                            }));
+                            assetGraph.addAsset(jsPreloadInlineAsset);
+
+                            new AssetGraph.HtmlScript({
+                                to: jsPreloadInlineAsset
+                            }).attach(htmlAsset, 'after', cssRelation);
+
+                            jsPreloadInlineAsset.minify();
                         }
 
                         cssAsset.minify();
@@ -671,7 +732,6 @@ module.exports = function (options) {
                             });
                         }
 
-                        // FIXME: This will fail on @import css relations
                         htmlParents.forEach(function (htmlParent) {
                             asyncLoadStyleRelationWithFallback(htmlParent, googleFontStylesheetRelation, htmlParent.outgoingRelations.find(function (relation) {
                                 return relation.type === 'HtmlStyle';

--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -177,6 +177,7 @@ function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation, insertP
     // Clean up
     originalRelation.detach();
 
+    asyncCssLoadingRelation.to.minify();
     htmlAsset.markDirty();
 }
 

--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -767,7 +767,7 @@ module.exports = function (options) {
                             });
 
                             var jsPreloadAsset = new AssetGraph.JavaScript(assetGraph.resolveAssetConfig({
-                                text: 'try {' + fontFaceContructorCalls.join('; ') + '} catch (e) {}'
+                                text: 'try {' + fontFaceContructorCalls.join('') + '} catch (e) {}'
                             }));
                             assetGraph.addAsset(jsPreloadAsset);
 

--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -1,4 +1,5 @@
 var _ = require('lodash');
+var url = require('url');
 var Promise = require('bluebird');
 var memoizeSync = require('memoizesync');
 var urltools = require('urltools');
@@ -133,22 +134,23 @@ function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation, insertP
     var injectionPointRelation = insertPoint || htmlAsset.outgoingRelations[0];
 
     // Resource hint: prefetch google font stylesheet
-    var preconnectRelation = new AssetGraph.HtmlPreconnectLink({
+    var fontDomainPreconnect = new AssetGraph.HtmlPreconnectLink({
         hrefType: 'absolute',
         from: htmlAsset,
         to: { url: 'https://fonts.gstatic.com' }
     });
 
-    preconnectRelation.attach(htmlAsset, 'after', injectionPointRelation);
+    fontDomainPreconnect.attach(htmlAsset, 'after', injectionPointRelation);
 
     // Resource hint: prefetch google font stylesheet
-    var prefetchRelation = new AssetGraph.HtmlPrefetchLink({
+    var parsedOriginalUrl = url.parse(originalRelation.to.url);
+    var cssDomainPreconnect = new AssetGraph.HtmlPreconnectLink({
         hrefType: 'absolute',
         from: htmlAsset,
-        to: { url: originalRelation.to.url }
+        to: { url: 'https://' + parsedOriginalUrl.host }
     });
 
-    prefetchRelation.attach(htmlAsset, 'before', preconnectRelation);
+    cssDomainPreconnect.attach(htmlAsset, 'before', fontDomainPreconnect);
 
 
     // Async load google font stylesheet

--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -596,7 +596,7 @@ module.exports = function (options) {
                                     return result;
                                 }, {});
 
-                                return 'new FontFace("' + name + '", "' + url + '", ' + JSON.stringify(props) + ');';
+                                return 'new FontFace("' + name + '", "' + url + '", ' + JSON.stringify(props) + ').load();';
                             });
 
                             var originalFontJsPreloadAsset = new AssetGraph.JavaScript(assetGraph.resolveAssetConfig({
@@ -604,11 +604,13 @@ module.exports = function (options) {
                             }));
                             assetGraph.addAsset(originalFontJsPreloadAsset);
 
-                            originalFontJsPreloadAsset.outgoingRelations.forEach(function (rel, idx) {
-                                rel.to = preloadRelations[idx].to;
-                            });
-
                             new AssetGraph.HtmlScript({ to: originalFontJsPreloadAsset }).attach(htmlAsset, 'before', insertionPoint);
+
+                            originalFontJsPreloadAsset.outgoingRelations.forEach(function (rel, idx) {
+                                rel.hrefType = 'rootRelative';
+                                rel.to = preloadRelations[idx].to;
+                                rel.refreshHref();
+                            });
 
                             originalFontJsPreloadAsset.minify();
                         }
@@ -696,8 +698,13 @@ module.exports = function (options) {
 
                         if (inlineCss) {
                             cssRelation.inline();
+                        }
 
-                            // Inject JS preloading of font subsets for browsers wihtout <link rel="preload"> support
+                        cssAsset.minify();
+
+                        // JS-based font preloading for browsers without <link rel="preload"> support
+                        if (inlineCss) {
+                            // If the CSS is inlined we can use the font declarations directly to load the fonts
                             var jsPreloadInlineAsset = new AssetGraph.JavaScript(assetGraph.resolveAssetConfig({
                                 text: 'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load(); }); } catch (e) {}'
                             }));
@@ -708,9 +715,71 @@ module.exports = function (options) {
                             }).attach(htmlAsset, 'after', cssRelation);
 
                             jsPreloadInlineAsset.minify();
-                        }
+                        } else {
+                            // The CSS is external, can't use the font face declarations without waiting for a blocking load.
+                            // Go for direct FontFace construction instead
+                            var fontFaceContructorCalls = [];
 
-                        cssAsset.minify();
+                            cssAsset.parseTree.walkAtRules('font-face', function (rule) {
+                                var name;
+                                var url;
+                                var props = {};
+
+                                rule.walkDecls(function (declaration) {
+                                    var prop = declaration.prop;
+                                    var value = declaration.value;
+
+                                    if (prop === 'font-weight') {
+                                        value = Number(value) || value;
+                                    }
+
+                                    if (prop in initialFontPropertyValues) {
+                                        if (value !== initialFontPropertyValues[prop]) {
+                                            props[prop] = value;
+                                        }
+                                    }
+
+                                    if (prop === 'font-family') {
+                                        name = value;
+                                    }
+
+                                    if (prop === 'src') {
+                                        var fontRelations = cssAsset.outgoingRelations.filter(function (rel) { return rel.node === rule; });
+                                        var urlStrings = value
+                                            .split(', ')
+                                            .filter(function (entry) {
+                                                return entry.indexOf('url(') === 0;
+                                            });
+
+                                        var urlValues = urlStrings.map(function (urlString, idx) {
+                                            return urlString.replace(fontRelations[idx].href, '\'" + "/__subfont__".toString("url") + "\'');
+                                        });
+
+                                        url = '"' + urlValues.join(', ') + '"';
+                                    }
+
+                                });
+
+                                fontFaceContructorCalls.push('new FontFace(' + name + ', ' + url + ', ' + JSON.stringify(props) + ').load();');
+                            });
+
+                            var jsPreloadAsset = new AssetGraph.JavaScript(assetGraph.resolveAssetConfig({
+                                text: 'try {' + fontFaceContructorCalls.join('; ') + '} catch (e) {}'
+                            }));
+                            assetGraph.addAsset(jsPreloadAsset);
+
+                            new AssetGraph.HtmlScript({
+                                to: jsPreloadAsset
+                            }).attach(htmlAsset, 'before', cssRelation);
+
+                            jsPreloadAsset.outgoingRelations.forEach(function (rel, idx) {
+                                rel.to = cssAsset.outgoingRelations[idx].to;
+                                rel.hrefType = 'rootRelative';
+                                rel.refreshHref();
+                            });
+
+                            jsPreloadAsset.minify();
+                        }
                     });
             })
             .queue(function asyncLoadGoogleFontCss(assetGraph) {

--- a/test/transforms/subsetFonts.js
+++ b/test/transforms/subsetFonts.js
@@ -173,6 +173,21 @@ describe('transforms/subsetFonts', function () {
                             contentType: 'font/ttf'
                         },
                         {
+                            type: 'HtmlScript',
+                            to: {
+                                isInline: true,
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        href: '/OpenSans.ttf',
+                                        to: {
+                                            isLoaded: true
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
                             type: 'HtmlStyle',
                             to: {
                                 isLoaded: true,
@@ -359,6 +374,14 @@ describe('transforms/subsetFonts', function () {
                                 type: 'HtmlPreconnectLink',
                                 hrefType: 'absolute',
                                 href: 'https://fonts.gstatic.com'
+                            },
+                            {
+                                type: 'HtmlScript',
+                                to: {
+                                    type: 'JavaScript',
+                                    isInline: true,
+                                    text: expect.it('to contain', 'document.fonts.forEach').and('to contain', '__subset')
+                                }
                             },
                             {
                                 type: 'HtmlStyle',
@@ -1928,6 +1951,22 @@ describe('transforms/subsetFonts', function () {
                             },
                             as: 'font',
                             contentType: 'text/plain' // Caused by fake test data
+                        },
+                        {
+                            type: 'HtmlScript',
+                            to: {
+                                type: 'JavaScript',
+                                isInline: true,
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        href: '/OpenSans.ttf',
+                                        to: {
+                                            isLoaded: true
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         {
                             type: 'HtmlStyle',

--- a/test/transforms/subsetFonts.js
+++ b/test/transforms/subsetFonts.js
@@ -295,9 +295,9 @@ describe('transforms/subsetFonts', function () {
                             }
                         },
                         {
-                            type: 'HtmlPrefetchLink',
+                            type: 'HtmlPreconnectLink',
                             hrefType: 'absolute',
-                            href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                            href: 'https://fonts.googleapis.com'
                         },
                         {
                             type: 'HtmlPreconnectLink',
@@ -393,9 +393,9 @@ describe('transforms/subsetFonts', function () {
                                 }
                             },
                             {
-                                type: 'HtmlPrefetchLink',
+                                type: 'HtmlPreconnectLink',
                                 hrefType: 'absolute',
-                                href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                                href: 'https://fonts.googleapis.com'
                             },
                             {
                                 type: 'HtmlPreconnectLink',
@@ -528,9 +528,9 @@ describe('transforms/subsetFonts', function () {
                             }
                         },
                         {
-                            type: 'HtmlPrefetchLink',
+                            type: 'HtmlPreconnectLink',
                             hrefType: 'absolute',
-                            href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                            href: 'https://fonts.googleapis.com'
                         },
                         {
                             type: 'HtmlPreconnectLink',
@@ -937,9 +937,9 @@ describe('transforms/subsetFonts', function () {
                             }
                         },
                         {
-                            type: 'HtmlPrefetchLink',
+                            type: 'HtmlPreconnectLink',
                             hrefType: 'absolute',
-                            href: 'https://fonts.googleapis.com/css?family=Jim+Nightshade|Montserrat|Space+Mono'
+                            href: 'https://fonts.googleapis.com'
                         },
                         {
                             type: 'HtmlPreconnectLink',
@@ -1359,9 +1359,9 @@ describe('transforms/subsetFonts', function () {
                             }
                         },
                         {
-                            type: 'HtmlPrefetchLink',
+                            type: 'HtmlPreconnectLink',
                             hrefType: 'absolute',
-                            href: 'https://fonts.googleapis.com/css?family=Roboto:300i,400,500'
+                            href: 'https://fonts.googleapis.com'
                         },
                         {
                             type: 'HtmlPreconnectLink',
@@ -1654,9 +1654,9 @@ describe('transforms/subsetFonts', function () {
                                 }
                             },
                             {
-                                type: 'HtmlPrefetchLink',
+                                type: 'HtmlPreconnectLink',
                                 hrefType: 'absolute',
-                                href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                                href: 'https://fonts.googleapis.com'
                             },
                             {
                                 type: 'HtmlPreconnectLink',
@@ -1741,9 +1741,9 @@ describe('transforms/subsetFonts', function () {
                                 to: expect.it('not to be', indexFontStyle)
                             },
                             {
-                                type: 'HtmlPrefetchLink',
+                                type: 'HtmlPreconnectLink',
                                 hrefType: 'absolute',
-                                href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                                href: 'https://fonts.googleapis.com'
                             },
                             {
                                 type: 'HtmlPreconnectLink',
@@ -1924,9 +1924,9 @@ describe('transforms/subsetFonts', function () {
                                 }
                             },
                             {
-                                type: 'HtmlPrefetchLink',
+                                type: 'HtmlPreconnectLink',
                                 hrefType: 'absolute',
-                                href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                                href: 'https://fonts.googleapis.com'
                             },
                             {
                                 type: 'HtmlPreconnectLink',
@@ -2008,9 +2008,9 @@ describe('transforms/subsetFonts', function () {
                                 to: sharedFontStyles
                             },
                             {
-                                type: 'HtmlPrefetchLink',
+                                type: 'HtmlPreconnectLink',
                                 hrefType: 'absolute',
-                                href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                                href: 'https://fonts.googleapis.com'
                             },
                             {
                                 type: 'HtmlPreconnectLink',
@@ -2516,9 +2516,9 @@ describe('transforms/subsetFonts', function () {
                             }
                         },
                         {
-                            type: 'HtmlPrefetchLink',
+                            type: 'HtmlPreconnectLink',
                             hrefType: 'absolute',
-                            href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                            href: 'https://fonts.googleapis.com'
                         },
                         {
                             type: 'HtmlPreconnectLink',
@@ -2713,9 +2713,9 @@ describe('transforms/subsetFonts', function () {
                             }
                         },
                         {
-                            type: 'HtmlPrefetchLink',
+                            type: 'HtmlPreconnectLink',
                             hrefType: 'absolute',
-                            href: 'https://fonts.googleapis.com/css?family=Open+Sans'
+                            href: 'https://fonts.googleapis.com'
                         },
                         {
                             type: 'HtmlPreconnectLink',

--- a/test/transforms/subsetFonts.js
+++ b/test/transforms/subsetFonts.js
@@ -239,6 +239,33 @@ describe('transforms/subsetFonts', function () {
                             as: 'font'
                         },
                         {
+                            type: 'HtmlScript',
+                            to: {
+                                isInline: true,
+                                isMinified: true,
+                                text: expect.it('to contain', 'Open Sans__subset'),
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
                             type: 'HtmlStyle',
                             hrefType: 'rootRelative',
                             href: expect.it('to begin with', '/subfont/fonts-')
@@ -443,6 +470,34 @@ describe('transforms/subsetFonts', function () {
                                 isLoaded: true
                             },
                             as: 'font'
+                        },
+                        {
+                            type: 'HtmlScript',
+                            to: {
+                                isInline: true,
+                                isMinified: true,
+                                text: expect.it('to contain', 'Open Sans__subset'),
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: '/subfont/Open_Sans-400-7e4f7435c9.woff2',
+                                        to: {
+                                            isLoaded: true
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         {
                             type: 'HtmlStyle',
@@ -744,6 +799,80 @@ describe('transforms/subsetFonts', function () {
                                 isLoaded: true
                             },
                             as: 'font'
+                        },
+                        {
+                            type: 'HtmlScript',
+                            to: {
+                                isInline: true,
+                                isMinified: true,
+                                text: expect.it('to contain', 'Jim Nightshade__subset')
+                                    .and('to contain', 'Montserrat__subset')
+                                    .and('to contain', 'Space Mono__subset'),
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: '/subfont/Jim_Nightshade-400-ad9702f89a.woff2',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: '/subfont/Montserrat-400-6606281bf9.woff2',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: '/subfont/Space_Mono-400-69f5758c65.woff2',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         {
                             type: 'HtmlStyle',
@@ -1096,6 +1225,80 @@ describe('transforms/subsetFonts', function () {
                             as: 'font'
                         },
                         {
+                            type: 'HtmlScript',
+                            to: {
+                                isMinified: true,
+                                isInline: true,
+                                text: expect.it('to contain', 'Roboto__subset')
+                                    .and('to contain', "'font-weight':500")
+                                    .and('to contain', "'font-style':'italic','font-weight':300"),
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: '/subfont/Roboto-500-3d0cd01e1e.woff2',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: '/subfont/Roboto-400-7a7a41bc79.woff2',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: '/subfont/Roboto-300i-5bba471dfa.woff2',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
                             type: 'HtmlStyle',
                             href: expect.it('to begin with', '/subfont/fonts-')
                                 .and('to end with', '.css')
@@ -1412,6 +1615,36 @@ describe('transforms/subsetFonts', function () {
                                 as: 'font'
                             },
                             {
+                                type: 'HtmlScript',
+                                to: {
+                                    isMinified: true,
+                                    isInline: true,
+                                    text: expect.it('to contain', 'Open Sans__subset'),
+                                    outgoingRelations: [
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            href: '/subfont/Open_Sans-400-0585f4b130.woff2',
+                                            to: {
+                                                isLoaded: true,
+                                                contentType: 'font/woff2',
+                                                extension: '.woff2'
+                                            }
+                                        },
+
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            to: {
+                                                isLoaded: true,
+                                                contentType: 'font/woff',
+                                                extension: '.woff'
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
                                 type: 'HtmlStyle',
                                 href: expect.it('to begin with', '/subfont/fonts-')
                                     .and('to end with', '.css')
@@ -1469,6 +1702,36 @@ describe('transforms/subsetFonts', function () {
                                 href: '/subfont/Open_Sans-400-a92122b2f9.woff2',
                                 to: expect.it('not to be', indexFont),
                                 as: 'font'
+                            },
+                            {
+                                type: 'HtmlScript',
+                                to: {
+                                    isMinified: true,
+                                    isInline: true,
+                                    text: expect.it('to contain', 'Open Sans__subset'),
+                                    outgoingRelations: [
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            href: '/subfont/Open_Sans-400-a92122b2f9.woff2',
+                                            to: {
+                                                isLoaded: true,
+                                                contentType: 'font/woff2',
+                                                extension: '.woff2'
+                                            }
+                                        },
+
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            to: {
+                                                isLoaded: true,
+                                                contentType: 'font/woff',
+                                                extension: '.woff'
+                                            }
+                                        }
+                                    ]
+                                }
                             },
                             {
                                 type: 'HtmlStyle',
@@ -1621,6 +1884,36 @@ describe('transforms/subsetFonts', function () {
                                 as: 'font'
                             },
                             {
+                                type: 'HtmlScript',
+                                to: {
+                                    isMinified: true,
+                                    isInline: true,
+                                    text: expect.it('to contain', 'Open Sans__subset'),
+                                    outgoingRelations: [
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            href: '/subfont/Open_Sans-400-5c45d9271a.woff2',
+                                            to: {
+                                                isLoaded: true,
+                                                contentType: 'font/woff2',
+                                                extension: '.woff2'
+                                            }
+                                        },
+
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            to: {
+                                                isLoaded: true,
+                                                contentType: 'font/woff',
+                                                extension: '.woff'
+                                            }
+                                        }
+                                    ]
+                                }
+                            },
+                            {
                                 type: 'HtmlStyle',
                                 href: expect.it('to begin with', '/subfont/fonts-')
                                     .and('to end with', '.css')
@@ -1669,7 +1962,7 @@ describe('transforms/subsetFonts', function () {
                             }
                         ]);
 
-                        var sharedFontStyles = index.outgoingRelations[1].to;
+                        var sharedFontStyles = index.outgoingRelations[2].to;
                         var sharedFont = index.outgoingRelations[0].to;
 
                         expect(about.outgoingRelations, 'to satisfy', [
@@ -1679,6 +1972,33 @@ describe('transforms/subsetFonts', function () {
                                 href: '/subfont/Open_Sans-400-5c45d9271a.woff2',
                                 to: sharedFont,
                                 as: 'font'
+                            },
+                            {
+                                type: 'HtmlScript',
+                                to: {
+                                    type: 'JavaScript',
+                                    isMinified: true,
+                                    isInline: true,
+                                    text: expect.it('to contain', 'Open Sans__subset'),
+                                    outgoingRelations: [
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            href: '/subfont/Open_Sans-400-5c45d9271a.woff2',
+                                            to: sharedFont
+                                        },
+
+                                        {
+                                            type: 'JavaScriptStaticUrl',
+                                            hrefType: 'rootRelative',
+                                            to: {
+                                                isLoaded: true,
+                                                contentType: 'font/woff',
+                                                extension: '.woff'
+                                            }
+                                        }
+                                    ]
+                                }
                             },
                             {
                                 type: 'HtmlStyle',
@@ -2017,6 +2337,40 @@ describe('transforms/subsetFonts', function () {
                             contentType: 'font/woff2'
                         },
                         {
+                            type: 'HtmlScript',
+                            to: {
+                                type: 'JavaScript',
+                                isMinified: true,
+                                isInline: true,
+                                text: expect.it('to contain', 'Open Sans__subset'),
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: expect.it('to begin with', '/subfont/Open_Sans-400-')
+                                            .and('to match', /-[0-9a-f]{10}\./)
+                                            .and('to end with', '.woff2'),
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+
+                        {
                             type: 'HtmlStyle',
                             hrefType: 'rootRelative',
                             href: expect.it('to begin with', '/subfont/fonts-')
@@ -2098,6 +2452,39 @@ describe('transforms/subsetFonts', function () {
                                 isLoaded: true
                             },
                             as: 'font'
+                        },
+                        {
+                            type: 'HtmlScript',
+                            to: {
+                                type: 'JavaScript',
+                                isMinified: true,
+                                isInline: true,
+                                text: expect.it('to contain', 'Open Sans__subset'),
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: expect.it('to begin with', '/subfont/Open_Sans-400-')
+                                            .and('to match', /-[0-9a-f]{10}\./)
+                                            .and('to end with', '.woff2'),
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         {
                             type: 'HtmlStyle',
@@ -2208,6 +2595,68 @@ describe('transforms/subsetFonts', function () {
                                 isLoaded: true
                             },
                             as: 'font'
+                        },
+                        {
+                            type: 'HtmlScript',
+                            to: {
+                                type: 'JavaScript',
+                                isMinified: true,
+                                isInline: true,
+                                text: expect.it('to contain', 'Open Sans__subset'),
+                                outgoingRelations: [
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: expect.it('to begin with', '/subfont/Local_Sans-400-')
+                                            .and('to match', /-[0-9a-f]{10}\./)
+                                            .and('to end with', '.woff2'),
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: expect.it('to begin with', '/subfont/Local_Sans-400-')
+                                            .and('to match', /-[0-9a-f]{10}\./)
+                                            .and('to end with', '.woff'),
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: expect.it('to begin with', '/subfont/Open_Sans-400-')
+                                            .and('to match', /-[0-9a-f]{10}\./)
+                                            .and('to end with', '.woff2'),
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff2',
+                                            extension: '.woff2'
+                                        }
+                                    },
+
+                                    {
+                                        type: 'JavaScriptStaticUrl',
+                                        hrefType: 'rootRelative',
+                                        href: expect.it('to begin with', '/subfont/Open_Sans-400-')
+                                            .and('to match', /-[0-9a-f]{10}\./)
+                                            .and('to end with', '.woff'),
+                                        to: {
+                                            isLoaded: true,
+                                            contentType: 'font/woff',
+                                            extension: '.woff'
+                                        }
+                                    }
+                                ]
+                            }
                         },
                         {
                             type: 'HtmlStyle',


### PR DESCRIPTION
Modern browsers that don't yet support `<link rel="preload">` generally have support for triggering font downloads using the font face javascript API. Lets add that to widen preloading support