### PR TITLE
Trace ::first-letter and ::first-line when subsetting fonts

### DIFF
--- a/lib/util/arePredicatesExhaustive.js
+++ b/lib/util/arePredicatesExhaustive.js
@@ -1,0 +1,21 @@
+var expandPermutations = require('./expandPermutations');
+
+function arePredicatesExhaustive(predicatesArray) {
+    var seenPredicateNames = {};
+    predicatesArray.forEach(function (predicates) {
+        Object.keys(predicates).forEach(function (predicateName) {
+            seenPredicateNames[predicateName] = true;
+        });
+    });
+    return expandPermutations(
+        Object.keys(seenPredicateNames).reduce((acc, predicateName) => (acc[predicateName] = [true, false], acc), {})
+    ).every(
+        permutation => predicatesArray.some(
+            predicates => Object.keys(seenPredicateNames).every(
+                predicateName => predicates[predicateName] === undefined || predicates[predicateName] === permutation[predicateName]
+            )
+        )
+    );
+};
+
+module.exports = arePredicatesExhaustive;

--- a/lib/util/cssPseudoElementRegExp.js
+++ b/lib/util/cssPseudoElementRegExp.js
@@ -27,6 +27,8 @@ var pseudoElements = [
     '-webkit-calendar-picker-indicator',
     '-webkit-inner-spin-button',
     '-webkit-clear-button',
+    '-webkit-file-upload-button',
+    '-webkit-input-placeholder',
 
     // These occur in the Firefox default stylesheet we're using:
     '-moz-native-anonymous',

--- a/lib/util/expandPermutations.js
+++ b/lib/util/expandPermutations.js
@@ -11,6 +11,9 @@
 function expandPermutations(obj, propertyNames) {
     propertyNames = propertyNames || Object.keys(obj);
     var permutations = [];
+    if (propertyNames.length === 0) {
+        return [];
+    }
     var firstPropertyName = propertyNames[0];
     var firstPropertyValues = obj[propertyNames[0]];
 

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -204,11 +204,11 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                 var hasPseudoElement = false;
 
                 if (!isStyleAttribute) {
-                    var matchPseudoElement = strippedSelector.match(/^(.*?)::?(before|after|first-letter|first-line|placeholder)$/);
+                    var matchPseudoElement = strippedSelector.match(/^(.*?)::?(before|after|first-letter|first-line|placeholder)$/i);
                     if (matchPseudoElement) {
                         hasPseudoElement = true;
                         // The selector ends with :before, :after, :first-letter, or :first-line
-                        if (pseudoElementName === matchPseudoElement[2]) {
+                        if (pseudoElementName === matchPseudoElement[2].toLowerCase()) {
                             strippedSelector = matchPseudoElement[1];
                         } else {
                             // We're not currently tracing this pseudo element, skip this rule

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -15,6 +15,7 @@ var unescapeCssString = require('./unescapeCssString');
 var getCounterCharacters = require('./getCounterCharacters');
 var expandPermutations = require('../expandPermutations');
 var combinePredicates = require('./combinePredicates');
+var arePredicatesExhaustive = require('../arePredicatesExhaustive');
 
 var FONT_PROPS = [
     'font-family',
@@ -33,7 +34,8 @@ var ALL_PROPS_TO_TRACE = FONT_PROPS.concat([
     'transition-duration',
     'counter-increment',
     'counter-reset',
-    'counter-set'
+    'counter-set',
+    'white-space'
 ]);
 
 var ALL_PROPS_TO_TRACE_AND_TEXT = ['text'].concat(ALL_PROPS_TO_TRACE);
@@ -52,7 +54,8 @@ var INITIAL_VALUES = {
     'transition-duration': '0s',
     'counter-increment': 'none',
     'counter-reset': 'none',
-    'counter-set': 'none'
+    'counter-set': 'none',
+    'white-space': 'normal'
 };
 
 var INHERITED = {
@@ -68,7 +71,8 @@ var INHERITED = {
     'transition-property': false,
     'transition-duration': false,
     'counter-increment': false,
-    'counter-reset': false
+    'counter-reset': false,
+    'white-space': true
 };
 
 var NAME_CONVERSIONS = {
@@ -154,7 +158,7 @@ function getFontRulesWithDefaultStylesheetApplied(htmlAsset, memoizedGetCssRules
 function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByProperty) {
     var nonInheritingTags = ['BUTTON', 'INPUT', 'OPTION', 'TEXTAREA'];
 
-    var getComputedStyle = memoizeSync(function (node, idArray, predicates) {
+    var getComputedStyle = memoizeSync(function (node, idArray, predicates, parentTrace, pseudoElementName) {
         predicates = predicates || {};
         var localFontPropRules = Object.assign({}, fontPropRules);
         var result = {};
@@ -178,6 +182,8 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
             });
         }
 
+        var foundPseudoElement = false;
+
         function traceProp(prop, startIndex, predicates) {
             startIndex = startIndex || 0;
 
@@ -198,11 +204,11 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                 var hasPseudoElement = false;
 
                 if (!isStyleAttribute) {
-                    var matchPseudoElement = strippedSelector.match(/^(.*?)::?(before|after)$/);
+                    var matchPseudoElement = strippedSelector.match(/^(.*?)::?(before|after|first-letter|first-line)$/);
                     if (matchPseudoElement) {
                         hasPseudoElement = true;
-                        // The selector ends with :before or :after
-                        if (predicates['pseudoElement:' + matchPseudoElement[2]]) {
+                        // The selector ends with :before, :after, :first-letter, or :first-line
+                        if (pseudoElementName === matchPseudoElement[2]) {
                             strippedSelector = matchPseudoElement[1];
                         } else {
                             // We're not currently tracing this pseudo element, skip this rule
@@ -216,16 +222,19 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                     continue;
                 }
 
-                if (!INHERITED[prop] && !hasPseudoElement && Object.keys(predicates).some(function (predicate) { return predicates[predicate] && /^pseudoElement:/.test(predicate); })) {
+                if (!INHERITED[prop] && !hasPseudoElement && pseudoElementName) {
                     continue;
                 }
 
                 if (isStyleAttribute || node.matches(strippedSelector.replace(/ i\]/, ']'))) { // nwmatcher doesn't support the i flag in attribute selectors
+                    if (hasPseudoElement) {
+                        foundPseudoElement = true;
+                    }
                     var hypotheticalValues;
                     if (declaration.value === 'inherit' || declaration.value === 'unset') {
-                        hypotheticalValues = getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates)[prop];
+                        hypotheticalValues = (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates))[prop];
                     } else if (prop === 'font-weight' && (declaration.value === 'lighter' || declaration.value === 'bolder')) {
-                        hypotheticalValues = getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates)[prop].map(
+                        hypotheticalValues = (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates))[prop].map(
                             inheritedHypotheticalValue => ({
                                 value: inheritedHypotheticalValue.value + '+' + declaration.value,
                                 predicates: inheritedHypotheticalValue
@@ -282,15 +291,14 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                                 );
                             }
                         });
-                        return multipliedHypotheticalValues;
-                    } else {
-                        return hypotheticalValues;
+                        hypotheticalValues = multipliedHypotheticalValues;
                     }
+                    return hypotheticalValues;
                 }
             }
 
             if (nonInheritingTags.indexOf(node.tagName) === -1) {
-                return getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates)[prop];
+                return (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates))[prop];
             } else {
                 return [ { value: INITIAL_VALUES[prop], predicates: predicates }];
             }
@@ -299,14 +307,24 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
         ALL_PROPS_TO_TRACE.forEach(function (prop) {
             result[prop] = traceProp(prop, 0, predicates);
         });
+        if (pseudoElementName && !foundPseudoElement) {
+            // We're tracing a pseudo element, but didn't match any rules
+            return;
+        }
         return result;
     }, {
         argumentsStringifier: function (args) {
+            if (args[3]) {
+                // Bypass memoization if parentTrace is given
+                return false;
+            }
+            // node, idArray, predicates, parentTrace, pseudoElementName
             return (
                 args[1].join(',') + '\x1e' +
                 (args[2] ? Object.keys(args[2]).map(function (key) {
                     return key + '\x1d' + args[2][key];
-                }).join('\x1d') : '')
+                }).join('\x1d') : '') +
+                (args[4] || '')
             );
         }
     });
@@ -482,6 +500,16 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
     return _.omit(computedStyle, '');
 }
 
+// null represents <br>
+function normalizeTextNodeValues(textNodeValues, computedStyle) {
+    var allWhiteSpacePre = computedStyle['white-space'].every(
+        hypotheticalWhiteSpaceValue => /^pre/i.test(hypotheticalWhiteSpaceValue.value)
+    );
+    return textNodeValues.map(
+        textNodeValue => textNodeValue === null ? '\n' : (allWhiteSpacePre ? textNodeValue : textNodeValue.replace(/\n/g, ' '))
+    ).join('');
+}
+
 // memoizedGetCssRulesByProperty is optional
 function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     if (!htmlAsset || htmlAsset.type !== 'Html' || !htmlAsset.assetGraph) {
@@ -518,8 +546,6 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         'url',
         'week'
     ];
-
-    var styledTexts = [];
 
     var possibleNextListItemNumberStack = [[1]];
     var possibleCounterValuesByName = {};
@@ -629,19 +655,99 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         );
     }
 
+    function traceBeforeOrAfterPseudoElement(pseudoElementName, node, idArray) {
+        var styledTexts = [];
+        var computedStyle = getComputedStyle(node, idArray, {}, undefined, pseudoElementName);
+        if (computedStyle) {
+            computedStyle = expandComputedStyle(Object.assign({}, computedStyle));
+            var expandedContents = [];
+            // Multiply the hypothetical content values with the hypothetical quotes values:
+            computedStyle.content.forEach(function (hypotheticalContent) {
+                var hypotheticalValues = extractTextFromContentPropertyValue(hypotheticalContent.value, node, computedStyle.quotes, hypotheticalCounterStylesByName, possibleCounterValuesByName);
+                hypotheticalValues.forEach(function (hypotheticalValue) {
+                    hypotheticalValue.predicates = combinePredicates([hypotheticalValue.predicates, hypotheticalContent.predicates]);
+                    if (hypotheticalValue.predicates) {
+                        expandedContents.push(hypotheticalValue);
+                    }
+                });
+            });
+            computedStyle.text = expandedContents;
+            var styledText = adjustPossibleCountersAndListItemNumbers(computedStyle, conditionalCommentStack.length > 0 || noscriptStack.length > 0);
+            styledText.text = styledText.text.filter(function (hypotheticalText) {
+                return hypotheticalText.value.length > 0;
+            });
+            if (styledText.text.length > 0) {
+                styledTexts.push(styledText);
+            }
+            return styledTexts;
+        }
+    }
+
+    function expandFirstLineAndFirstLetter(groupedStyledTexts, node, idArray) {
+        ['first-line', 'first-letter'].forEach(function (pseudoElementName) {
+            var additionalStyledTexts = [];
+            // Whether there's a perfect overlap between the predicates of the existing styled texts we've "taken bites" of:
+            var aligned = true;
+            groupedStyledTexts.some(function (styledTextsInSection) {
+                var allExhaustive = false;
+                // Keep track of whether we have consumed all the required characters:
+                var done = true;
+                for (var i = 0 ; i < styledTextsInSection.length ; i += 1) {
+                    var styledTextInSection = styledTextsInSection[i];
+                    var thisExhaustive = Object.keys(styledTextInSection).every(
+                        prop => arePredicatesExhaustive(styledTextInSection[prop].map(hypotheticalValue => hypotheticalValue.predicates)
+                    ));
+                    allExhaustive = allExhaustive || thisExhaustive;
+
+                    var pseudoElementStyle = getComputedStyle(node, idArray.slice(0, -1), {}, styledTextInSection, pseudoElementName);
+                    if (pseudoElementStyle) {
+                        styledTextInSection.text.forEach(function (hypotheticalValue) {
+                            var matchContent;
+                            if (pseudoElementName === 'first-letter') {
+                                matchContent = hypotheticalValue.value.match(/^(\s*"?\s*\w|\s*"\s*\w?)/);
+                            } else {
+                                // pseudoElementName === 'first-line'
+                                matchContent = hypotheticalValue.value.match(/^([^\n]+)/);
+                                done = false;
+                            }
+                            if (matchContent) {
+                                var content = matchContent[1];
+                                additionalStyledTexts.push(Object.assign({
+                                    text: [ { value: content, predicates: hypotheticalValue.predicates } ]
+                                }, pseudoElementStyle));
+                                if (aligned) {
+                                    if (pseudoElementName === 'first-letter') {
+                                        hypotheticalValue.value = hypotheticalValue.value.substr(content.length);
+                                    } else if (pseudoElementName === 'first-line') {
+                                        done = hypotheticalValue.value.indexOf('\n') !== -1;
+                                    }
+                                }
+                            } else {
+                                done = false;
+                            }
+                        });
+                    }
+                }
+                if (allExhaustive && done) {
+                    // Short circuit -- no need to proceed to the next section
+                    return true;
+                } else if (!done) {
+                    aligned = false;
+                }
+            });
+            Array.prototype.unshift.apply(groupedStyledTexts[0], additionalStyledTexts);
+        });
+    }
+
+    var styledTexts = [];
+
     (function traversePreOrder(node, idArray) {
+        var textNodeValues = [];
         if (node.nodeType === node.TEXT_NODE) {
             // Include an actual hyphen when there's a soft hyphen:
             var textContent = node.nodeValue.trim().replace(/\xad/g, '-');
             if (textContent) {
-                styledTexts.push(
-                    expandComputedStyle(
-                        Object.assign(
-                            { text: [ { value: textContent, predicates: {} } ] },
-                            getComputedStyle(node.parentNode, idArray.slice(0, -1))
-                        )
-                    )
-                );
+                textNodeValues.push(textContent);
             }
         } else if (node.nodeType === node.COMMENT_NODE) {
             if (/^\s*\[if\s+!IE\s*\]\s*>\s*$/i.test(node.nodeValue)) {
@@ -677,7 +783,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                                 configurable: true,
                                 get() { return node.parentNode; }
                             });
-                            traversePreOrder(childNode, idArray.concat(i));
+                            Array.prototype.push.apply(textNodeValues, traversePreOrder(childNode, idArray.concat(i)));
                             delete childNode.parentNode;
                         }
                         conditionalCommentStack.pop();
@@ -686,10 +792,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     }
                 });
             }
-        } else if (node.nodeType === node.ELEMENT_NODE) {
-            if (excludedNodes.indexOf(node.tagName) !== -1) {
-                return;
-            }
+        } else if (node.nodeType === node.ELEMENT_NODE && excludedNodes.indexOf(node.tagName) === -1) {
             if (!idArray) {
                 idArray = [0];
             }
@@ -707,7 +810,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                                 configurable: true,
                                 get() { return node; }
                             });
-                            traversePreOrder(childNode, idArray.concat(i));
+                            Array.prototype.push.apply(textNodeValues, traversePreOrder(childNode, idArray.concat(i)));
                             delete childNode.parentNode;
                         }
                         noscriptStack.pop();
@@ -742,48 +845,49 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     );
                 }
             } else if (node.nodeType === node.ELEMENT_NODE) {
-                styledTexts.push(
-                    adjustPossibleCountersAndListItemNumbers(expandComputedStyle(
-                        Object.assign(
-                            { text: [ { value: '', predicates: {} } ] },
-                            getComputedStyle(node, idArray)
-                        )
-                    ), conditionalCommentStack.length > 0 || noscriptStack.length > 0)
-                );
+                if (node.constructor.name === 'HTMLBRElement') {
+                    textNodeValues.push(null);
+                } else {
+                    const computedStyle = getComputedStyle(node, idArray);
+                    styledTexts.push(
+                        adjustPossibleCountersAndListItemNumbers(expandComputedStyle(
+                            Object.assign(
+                                { text: [ { value: '', predicates: {} } ] },
+                                computedStyle
+                            )
+                        ), conditionalCommentStack.length > 0 || noscriptStack.length > 0)
+                    );
+                    possibleNextListItemNumberStack.push([1]);
 
-                possibleNextListItemNumberStack.push([1]);
+                    var beforeStyledTexts = traceBeforeOrAfterPseudoElement('before', node, idArray);
+                    var afterStyledTexts = traceBeforeOrAfterPseudoElement('after', node, idArray);
 
-                ['before', 'after'].forEach(function (pseudoElementName) {
-                    var predicates = {};
-                    predicates['pseudoElement:' + pseudoElementName] = true;
-                    var computedStyle = expandComputedStyle(Object.assign({}, getComputedStyle(node, idArray, predicates)));
-                    var expandedContents = [];
-                    // Multiply the hypothetical content values with the hypothetical quotes values:
-                    computedStyle.content.forEach(function (hypotheticalContent) {
-                        var hypotheticalValues = extractTextFromContentPropertyValue(hypotheticalContent.value, node, computedStyle.quotes, hypotheticalCounterStylesByName, possibleCounterValuesByName);
-                        hypotheticalValues.forEach(function (hypotheticalValue) {
-                            hypotheticalValue.predicates = combinePredicates([hypotheticalValue.predicates, hypotheticalContent.predicates]);
-                            if (hypotheticalValue.predicates) {
-                                expandedContents.push(hypotheticalValue);
-                            }
-                        });
-                    });
-                    computedStyle.text = expandedContents;
-                    var styledText = adjustPossibleCountersAndListItemNumbers(computedStyle, conditionalCommentStack.length > 0 || noscriptStack.length > 0);
-                    styledText.text = styledText.text.filter(function (hypotheticalText) {
-                        return hypotheticalText.value.length > 0;
-                    });
-                    if (styledText.text.length > 0) {
-                        styledTexts.push(styledText);
+                    var text = normalizeTextNodeValues(_.flatten([].slice.call(node.childNodes).map(
+                        (childNode, i) => traversePreOrder(childNode, idArray.concat(i))
+                    )), computedStyle);
+                    var tracedTextNodes = [];
+                    if (text) {
+                        tracedTextNodes.push(
+                            expandComputedStyle(
+                                Object.assign(
+                                    { text: [ { value: text, predicates: {} } ] },
+                                    computedStyle
+                                )
+                            )
+                        );
                     }
-                });
-
-                for (var i = 0 ; i < node.childNodes.length ; i += 1) {
-                    traversePreOrder(node.childNodes[i], idArray.concat(i));
+                    var groupedStyledTexts = _.compact([
+                        beforeStyledTexts,
+                        tracedTextNodes,
+                        afterStyledTexts
+                    ]);
+                    expandFirstLineAndFirstLetter(groupedStyledTexts, node, idArray);
+                    Array.prototype.push.apply(styledTexts, _.flattenDeep(groupedStyledTexts));
+                    possibleNextListItemNumberStack.pop();
                 }
-                possibleNextListItemNumberStack.pop();
             }
         }
+        return textNodeValues;
     }(document.body.parentNode));
 
     // propsByText Before:

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -837,12 +837,13 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 }
 
                 if (inputPlaceholder) {
-                    var computedStyle = getComputedStyle(node, idArray);
+                    // Stupidly named var to avoid clash, fix after merging to master where const and let can be used
+                    var elementComputedStyle = getComputedStyle(node, idArray);
                     styledTexts.push(
                         expandComputedStyle(
                             Object.assign(
                                 { text: [ { value: inputPlaceholder, predicates: {} } ] },
-                                getComputedStyle(node, idArray, 'placeholder', computedStyle) || computedStyle
+                                getComputedStyle(node, idArray, 'placeholder', elementComputedStyle) || elementComputedStyle
                             )
                         )
                     );

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -204,7 +204,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                 var hasPseudoElement = false;
 
                 if (!isStyleAttribute) {
-                    var matchPseudoElement = strippedSelector.match(/^(.*?)::?(before|after|first-letter|first-line)$/);
+                    var matchPseudoElement = strippedSelector.match(/^(.*?)::?(before|after|first-letter|first-line|placeholder)$/);
                     if (matchPseudoElement) {
                         hasPseudoElement = true;
                         // The selector ends with :before, :after, :first-letter, or :first-line
@@ -837,11 +837,12 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                 }
 
                 if (inputPlaceholder) {
+                    var computedStyle = getComputedStyle(node, idArray);
                     styledTexts.push(
                         expandComputedStyle(
                             Object.assign(
                                 { text: [ { value: inputPlaceholder, predicates: {} } ] },
-                                getComputedStyle(node, idArray)
+                                getComputedStyle(node, idArray, undefined, computedStyle, 'placeholder') || computedStyle
                             )
                         )
                     );

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -158,7 +158,7 @@ function getFontRulesWithDefaultStylesheetApplied(htmlAsset, memoizedGetCssRules
 function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByProperty) {
     var nonInheritingTags = ['BUTTON', 'INPUT', 'OPTION', 'TEXTAREA'];
 
-    var getComputedStyle = memoizeSync(function (node, idArray, predicates, parentTrace, pseudoElementName) {
+    var getComputedStyle = memoizeSync(function (node, idArray, pseudoElementName, parentTrace, predicates) {
         predicates = predicates || {};
         var localFontPropRules = Object.assign({}, fontPropRules);
         var result = {};
@@ -232,9 +232,9 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
                     }
                     var hypotheticalValues;
                     if (declaration.value === 'inherit' || declaration.value === 'unset') {
-                        hypotheticalValues = (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates))[prop];
+                        hypotheticalValues = (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), undefined, undefined, predicates))[prop];
                     } else if (prop === 'font-weight' && (declaration.value === 'lighter' || declaration.value === 'bolder')) {
-                        hypotheticalValues = (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates))[prop].map(
+                        hypotheticalValues = (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), undefined, undefined, predicates))[prop].map(
                             inheritedHypotheticalValue => ({
                                 value: inheritedHypotheticalValue.value + '+' + declaration.value,
                                 predicates: inheritedHypotheticalValue
@@ -298,7 +298,7 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
             }
 
             if (nonInheritingTags.indexOf(node.tagName) === -1) {
-                return (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), predicates))[prop];
+                return (parentTrace || getComputedStyle(node.parentNode, idArray.slice(0, -1), undefined, undefined, predicates))[prop];
             } else {
                 return [ { value: INITIAL_VALUES[prop], predicates: predicates }];
             }
@@ -314,17 +314,17 @@ function getMemoizedElementStyleResolver(fontPropRules, memoizedGetCssRulesByPro
         return result;
     }, {
         argumentsStringifier: function (args) {
+            // node, idArray, pseudoElementName, parentTrace, predicates
             if (args[3]) {
                 // Bypass memoization if parentTrace is given
                 return false;
             }
-            // node, idArray, predicates, parentTrace, pseudoElementName
             return (
                 args[1].join(',') + '\x1e' +
-                (args[2] ? Object.keys(args[2]).map(function (key) {
-                    return key + '\x1d' + args[2][key];
+                (args[4] ? Object.keys(args[4]).map(function (key) {
+                    return key + '\x1d' + args[4][key];
                 }).join('\x1d') : '') +
-                (args[4] || '')
+                (args[2] || '')
             );
         }
     });
@@ -659,7 +659,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
 
     function traceBeforeOrAfterPseudoElement(pseudoElementName, node, idArray) {
         var styledTexts = [];
-        var computedStyle = getComputedStyle(node, idArray, {}, undefined, pseudoElementName);
+        var computedStyle = getComputedStyle(node, idArray, pseudoElementName);
         if (computedStyle) {
             computedStyle = expandComputedStyle(Object.assign({}, computedStyle));
             var expandedContents = [];
@@ -701,7 +701,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     ));
                     allExhaustive = allExhaustive || thisExhaustive;
 
-                    var pseudoElementStyle = getComputedStyle(node, idArray.slice(0, -1), {}, styledTextInSection, pseudoElementName);
+                    var pseudoElementStyle = getComputedStyle(node, idArray.slice(0, -1), pseudoElementName, styledTextInSection);
                     if (pseudoElementStyle) {
                         styledTextInSection.text.forEach(function (hypotheticalValue) {
                             var matchContent;
@@ -842,7 +842,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                         expandComputedStyle(
                             Object.assign(
                                 { text: [ { value: inputPlaceholder, predicates: {} } ] },
-                                getComputedStyle(node, idArray, undefined, computedStyle, 'placeholder') || computedStyle
+                                getComputedStyle(node, idArray, 'placeholder', computedStyle) || computedStyle
                             )
                         )
                     );

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -501,12 +501,14 @@ function expandListIndicators(computedStyle, counterStyles, possibleListItemNumb
 }
 
 // null represents <br>
-function normalizeTextNodeValues(textNodeValues, computedStyle) {
-    var allWhiteSpacePre = computedStyle['white-space'].every(
-        hypotheticalWhiteSpaceValue => /^pre/i.test(hypotheticalWhiteSpaceValue.value)
-    );
+function normalizeTextNodeValues(textNodeValues, whiteSpaceValue) {
     return textNodeValues.map(
-        textNodeValue => textNodeValue === null ? '\n' : (allWhiteSpacePre ? textNodeValue : textNodeValue.replace(/\n/g, ' '))
+        textNodeValue => textNodeValue === null ?
+            '\n' :
+            (/^pre/i.test(whiteSpaceValue) ?
+                textNodeValue :
+                textNodeValue.replace(/\n/g, ' ')
+            )
     ).join('');
 }
 
@@ -862,19 +864,24 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
                     var beforeStyledTexts = traceBeforeOrAfterPseudoElement('before', node, idArray);
                     var afterStyledTexts = traceBeforeOrAfterPseudoElement('after', node, idArray);
 
-                    var text = normalizeTextNodeValues(_.flatten([].slice.call(node.childNodes).map(
+                    var childTextNodeValues = _.flatten([].slice.call(node.childNodes).map(
                         (childNode, i) => traversePreOrder(childNode, idArray.concat(i))
-                    )), computedStyle);
+                    ));
                     var tracedTextNodes = [];
-                    if (text) {
-                        tracedTextNodes.push(
-                            expandComputedStyle(
-                                Object.assign(
-                                    { text: [ { value: text, predicates: {} } ] },
-                                    computedStyle
-                                )
-                            )
-                        );
+                    if (childTextNodeValues.length > 0) {
+                        computedStyle['white-space'].forEach(function (hypotheticalValue) {
+                            var normalizedText = normalizeTextNodeValues(childTextNodeValues, hypotheticalValue.value);
+                            if (normalizedText) {
+                                tracedTextNodes.push(
+                                    expandComputedStyle(
+                                        Object.assign(
+                                            { text: [ { value: normalizedText, predicates: hypotheticalValue.predicates } ] },
+                                            computedStyle
+                                        )
+                                    )
+                                );
+                            }
+                        });
                     }
                     var groupedStyledTexts = _.compact([
                         beforeStyledTexts,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "imageinfo": "1.0.4",
     "jsdom": "9.12.0",
     "lodash": "^4.11.2",
-    "memoizesync": "1.0.0",
+    "memoizesync": "1.1.1",
     "mkdirp": "^0.5.1",
     "normalizeurl": "^1.0.0",
     "perfectionist": "^2.4.0",

--- a/test/util/arePredicatesExhaustive.js
+++ b/test/util/arePredicatesExhaustive.js
@@ -1,0 +1,50 @@
+var arePredicatesExhaustive = require('../../lib/util/arePredicatesExhaustive');
+var expect = require('../unexpected-with-plugins');
+
+describe('arePredicatesExhaustive', function () {
+    it('should return true for a single empty object', function () {
+        expect(arePredicatesExhaustive([{}]), 'to be true');
+    });
+
+    it('should return false for a single object with a false predicate', function () {
+        expect(arePredicatesExhaustive([{foo: false}]), 'to be false');
+    });
+
+    it('should return false for a single object with a true predicate', function () {
+        expect(arePredicatesExhaustive([{foo: true}]), 'to be false');
+    });
+
+    it('should return true for two objects with a predicate in true and false states, respectively', function () {
+        expect(arePredicatesExhaustive([{foo: true}, {foo: false}]), 'to be true');
+    });
+
+    it('should return true for two objects with a predicate in true and false states, respectively, and a 3rd object mentioning a second predicate', function () {
+        expect(arePredicatesExhaustive([{foo: true}, {foo: false}, {bar: true}]), 'to be true');
+    });
+
+    it('should return true for four objects covering all combinations of two predicates', function () {
+        expect(arePredicatesExhaustive([
+            {foo: true, bar: true},
+            {foo: false, bar: false},
+            {foo: true, bar: false},
+            {foo: false, bar: true}
+        ]), 'to be true');
+    });
+
+    it('should return true for four objects covering all but one combination of two predicates and with a duplicate', function () {
+        expect(arePredicatesExhaustive([
+            {foo: true, bar: true},
+            {foo: false, bar: false},
+            {foo: true, bar: true},
+            {foo: false, bar: true}
+        ]), 'to be false');
+    });
+
+    it('should return false for three objects covering all but one combination of two predicates', function () {
+        expect(arePredicatesExhaustive([
+            {foo: true, bar: true},
+            {foo: false, bar: false},
+            {foo: true, bar: false}
+        ]), 'to be false');
+    });
+});

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -1837,6 +1837,21 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 ]);
             });
 
+            it('should exclude content after the first linebreak from the ::first-line part, conditional white-space:pre case', function () {
+                var htmlText = [
+                    '<style>div::first-line { font-weight: 700; }</style>',
+                    '<style>@media 3dglasses { div { white-space: pre; font-style: italic; } }</style>',
+                    '<div>foo bar\nquux</div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo bar', props: { 'font-weight': 700, 'font-style': 'italic' } },
+                    { text: 'foo bar quux', props: { 'font-weight': 700, 'font-style': 'normal' } },
+                    { text: 'foo bar\nquux', props: { 'font-weight': 400, 'font-style': 'italic' } },
+                    { text: 'foo bar quux', props: { 'font-weight': 400, 'font-style': 'normal' } }
+                ]);
+            });
+
             it('should include ::before and ::after', function () {
                 var htmlText = [
                     '<style>p::first-line { font-weight: 700; }</style>',

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -1870,6 +1870,33 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 ]);
             });
         });
+
+        describe('with ::placeholder', function () {
+            it('should apply to the placeholder text of an input', function () {
+                var htmlText = [
+                    '<style>input::placeholder { font-family: foo; }</style>',
+                    '<input placeholder="foobar" value="hey">'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'hey', props: { 'font-family': undefined } },
+                    { text: 'foobar', props: { 'font-family': 'foo' } }
+                ]);
+            });
+
+            it('should compose with conditionals', function () {
+                var htmlText = [
+                    '<style>@media 3dglasses { input::placeholder { font-family: foo; } }</style>',
+                    '<input placeholder="foobar" value="hey">'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'hey', props: { 'font-family': undefined } },
+                    { text: 'foobar', props: { 'font-family': 'foo' } },
+                    { text: 'foobar', props: { 'font-family': undefined } }
+                ]);
+            });
+        });
     });
 
     describe('with display:list-item', function () {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -320,7 +320,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'foo',
+                    text: 'bar',
                     props: {
                         'font-family': 'font1',
                         'font-weight': 700,
@@ -328,7 +328,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     }
                 },
                 {
-                    text: 'bar',
+                    text: 'foo',
                     props: {
                         'font-family': 'font1',
                         'font-weight': 700,
@@ -782,17 +782,17 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
         return expect(htmlText, 'to exhaustively satisfy computed font properties', [
             {
-                text: 'foo',
+                text: 'bar',
                 props: {
-                    'font-family': 'font1',
+                    'font-family': 'font2',
                     'font-weight': 700,
                     'font-style': 'normal'
                 }
             },
             {
-                text: 'bar',
+                text: 'foo',
                 props: {
-                    'font-family': 'font2',
+                    'font-family': 'font1',
                     'font-weight': 700,
                     'font-style': 'normal'
                 }
@@ -809,17 +809,17 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'after',
+                    text: 'h1',
                     props: {
-                        'font-family': 'font1',
+                        'font-family': undefined,
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
                 },
                 {
-                    text: 'h1',
+                    text: 'after',
                     props: {
-                        'font-family': undefined,
+                        'font-family': 'font1',
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
@@ -948,17 +948,17 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'after',
+                    text: 'h1',
                     props: {
-                        'font-family': 'font2',
+                        'font-family': undefined,
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
                 },
                 {
-                    text: 'h1',
+                    text: 'after',
                     props: {
-                        'font-family': undefined,
+                        'font-family': 'font2',
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
@@ -975,17 +975,17 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'after',
+                    text: 'h1',
                     props: {
-                        'font-family': 'font1',
+                        'font-family': undefined,
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
                 },
                 {
-                    text: 'h1',
+                    text: 'after',
                     props: {
-                        'font-family': undefined,
+                        'font-family': 'font1',
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
@@ -1002,17 +1002,17 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'after',
+                    text: 'h1',
                     props: {
-                        'font-family': 'font1',
+                        'font-family': undefined,
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
                 },
                 {
-                    text: 'h1',
+                    text: 'after',
                     props: {
-                        'font-family': undefined,
+                        'font-family': 'font1',
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
@@ -1031,14 +1031,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'after',
-                    props: {
-                        'font-family': 'font1',
-                        'font-weight': 200,
-                        'font-style': 'normal'
-                    }
-                },
-                {
                     text: 'p',
                     props: {
                         'font-family': undefined,
@@ -1050,7 +1042,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     text: 'after',
                     props: {
                         'font-family': 'font1',
-                        'font-weight': 600,
+                        'font-weight': 200,
                         'font-style': 'normal'
                     }
                 },
@@ -1058,6 +1050,14 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     text: 'article',
                     props: {
                         'font-family': undefined,
+                        'font-weight': 600,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'after',
+                    props: {
+                        'font-family': 'font1',
                         'font-weight': 600,
                         'font-style': 'normal'
                     }
@@ -1095,17 +1095,17 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'I',
+                    text: 'foo',
                     props: {
-                        'font-family': 'font1',
+                        'font-family': undefined,
                         'font-weight': 400,
                         'font-style': 'normal'
                     }
                 },
                 {
-                    text: 'foo',
+                    text: 'I',
                     props: {
-                        'font-family': undefined,
+                        'font-family': 'font1',
                         'font-weight': 400,
                         'font-style': 'normal'
                     }
@@ -1514,18 +1514,18 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'foo',
-                    props: {
-                        'font-family': 'myClass',
-                        'font-weight': 900,
-                        'font-style': 'normal'
-                    }
-                },
-                {
                     text: 'text',
                     props: {
                         'font-family': undefined,
                         'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'foo',
+                    props: {
+                        'font-family': 'myClass',
+                        'font-weight': 900,
                         'font-style': 'normal'
                     }
                 },
@@ -1557,6 +1557,14 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
+                    text: 'h1',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 700,
+                        'font-style': 'normal'
+                    }
+                },
+                {
                     text: 'bar',
                     props: {
                         'font-family': 'font1',
@@ -1568,14 +1576,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     text: 'foo',
                     props: {
                         'font-family': 'font1',
-                        'font-weight': 700,
-                        'font-style': 'normal'
-                    }
-                },
-                {
-                    text: 'h1',
-                    props: {
-                        'font-family': undefined,
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
@@ -1600,22 +1600,260 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     }
                 },
                 {
-                    text: 'after',
-                    props: {
-                        'font-family': 'font1',
-                        'font-weight': 700,
-                        'font-style': 'normal'
-                    }
-                },
-                {
                     text: 'h1',
                     props: {
                         'font-family': undefined,
                         'font-weight': 700,
                         'font-style': 'normal'
                     }
+                },
+                {
+                    text: 'after',
+                    props: {
+                        'font-family': 'font1',
+                        'font-weight': 700,
+                        'font-style': 'normal'
+                    }
                 }
             ]);
+        });
+
+        describe('with ::first-letter', function () {
+            it('should do a separate trace and derive the right styling for the first letter', function () {
+                var htmlText = [
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'f', props: { 'font-weight': 700 } },
+                    { text: 'oo', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should ignore leading whitespace when identifying the first letter', function () {
+                var htmlText = [
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>  \n \t foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'f', props: { 'font-weight': 700 } },
+                    { text: 'oo', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should not dive into child elements', function () {
+                var htmlText = [
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p><div>foo</div></p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should not extract text after a child element', function () {
+                var htmlText = [
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p><div>foo</div>bar</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo', props: { 'font-weight': 400 } },
+                    { text: 'bar', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should include a leading quote marker in the first letter trace', function () {
+                var htmlText = [
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>"foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: '"f', props: { 'font-weight': 700 } },
+                    { text: 'oo', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should include a leading quote marker from ::before', function () {
+                var htmlText = [
+                    '<style>p::before { content: \'"a\'; }</style>',
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: '"a', props: { 'font-weight': 700 } },
+                    { text: 'foo', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should retain the unrelated styling from ::before when combining with ::first-letter', function () {
+                var htmlText = [
+                    '<style>p::before { content: \'a\'; font-style: italic; }</style>',
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'a', props: { 'font-weight': 700, 'font-style': 'italic' } },
+                    { text: 'foo', props: { 'font-weight': 400, 'font-style': 'normal' } }
+                ]);
+            });
+
+            it('should include a leading quote marker from ::after', function () {
+                var htmlText = [
+                    '<style>p::after { content: \'"a\'; }</style>',
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p></p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: '"a', props: { 'font-weight': 700 } }
+                ]);
+            });
+
+            // This is counter-intuitive, but has been observed in both Chrome and Firefox
+            it('should not combine a leading quote marker from ::before with a letter from the element', function () {
+                var htmlText = [
+                    '<style>p::before { content: \'"\'; }</style>',
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: '"', props: { 'font-weight': 700 } },
+                    { text: 'foo', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should get the first letter from the ::before pseudo element', function () {
+                var htmlText = [
+                    '<style>p::before { content: \'bar\'; font-weight: 200; }</style>',
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'b', props: { 'font-weight': 700 } },
+                    { text: 'ar', props: { 'font-weight': 200 } },
+                    { text: 'foo', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should get the first letter from the ::after pseudo element if it is the only content', function () {
+                var htmlText = [
+                    '<style>p::after { content: \'foo\'; font-weight: 200; }</style>',
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p></p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'f', props: { 'font-weight': 700 } },
+                    { text: 'oo', props: { 'font-weight': 200 } }
+                ]);
+            });
+
+            it('should compose with other conditionals', function () {
+                var htmlText = [
+                    '<style>@media 3dglasses { p::before { content: \'abc\' } }</style>',
+                    '<style>p::first-letter { font-weight: 700; }</style>',
+                    '<p>foo</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'a', props: { 'font-weight': 700 } },
+                    { text: 'f', props: { 'font-weight': 700 } },
+                    { text: 'bc', props: { 'font-weight': 400 } },
+                    { text: 'oo', props: { 'font-weight': 400 } }
+                ]);
+            });
+        });
+
+        describe('with ::first-line', function () {
+            it('should pessimistically assume that all of the content is rendered in both the the base and the ::first-line style', function () {
+                var htmlText = [
+                    '<style>p::first-line { font-weight: 700; }</style>',
+                    '<p>foo bar quux</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo bar quux', props: { 'font-weight': 700 } },
+                    { text: 'foo bar quux', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should have a lower precedence than ::first-letter, even when it occurs later in the cascade', function () {
+                var htmlText = [
+                    '<style>div::first-letter { font-weight: 700; }</style>',
+                    '<style>div::first-line { font-weight: 200; font-style: italic; }</style>',
+                    '<div>foo</div>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'f', props: { 'font-weight': 700, 'font-style': 'italic' } },
+                    { text: 'f', props: { 'font-weight': 700, 'font-style': 'normal' } },
+                    { text: 'oo', props: { 'font-weight': 200, 'font-style': 'italic' } },
+                    { text: 'oo', props: { 'font-weight': 400, 'font-style': 'normal' } }
+                ]);
+            });
+
+            it('should exclude content after the first linebreak from the ::first-line part, <br> case', function () {
+                var htmlText = [
+                    '<style>p::first-line { font-weight: 700; }</style>',
+                    '<p>foo bar<br>quux</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo bar', props: { 'font-weight': 700 } },
+                    { text: 'foo bar\nquux', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should not let a regular linebreak interfere with the ::first-line tracing', function () {
+                var htmlText = [
+                    '<style>p::first-line { font-weight: 700; }</style>',
+                    '<p>foo\nbar<br>quux</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo bar', props: { 'font-weight': 700 } },
+                    { text: 'foo bar\nquux', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should exclude content after the first linebreak from the ::first-line part, white-space:pre case', function () {
+                var htmlText = [
+                    '<style>pre::first-line { font-weight: 700; }</style>',
+                    '<pre>foo bar\nquux</pre>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo bar', props: { 'font-weight': 700 } },
+                    { text: 'foo bar\nquux', props: { 'font-weight': 400 } }
+                ]);
+            });
+
+            it('should include ::before and ::after', function () {
+                var htmlText = [
+                    '<style>p::first-line { font-weight: 700; }</style>',
+                    '<style>p::before { content: \'foo\'; }</style>',
+                    '<style>p::after { content: \'quux\'; }</style>',
+                    '<p>bar</p>'
+                ].join('\n');
+
+                return expect(htmlText, 'to satisfy computed font properties', [
+                    { text: 'foo', props: { 'font-weight': 700 } },
+                    { text: 'bar', props: { 'font-weight': 700 } },
+                    { text: 'quux', props: { 'font-weight': 700 } },
+                    { text: 'foo', props: { 'font-weight': 400 } },
+                    { text: 'bar', props: { 'font-weight': 400 } },
+                    { text: 'quux', props: { 'font-weight': 400 } }
+                ]);
+            });
         });
     });
 
@@ -1855,14 +2093,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'foo',
-                    props: {
-                        'font-family': undefined,
-                        'font-weight': 400,
-                        'font-style': 'normal'
-                    }
-                },
-                {
                     text: 'bar',
                     props: {
                         'font-family': 'font1',
@@ -1872,6 +2102,14 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 },
                 {
                     text: 'bar',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 400,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'foo',
                     props: {
                         'font-family': undefined,
                         'font-weight': 400,
@@ -1941,7 +2179,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'foo',
+                    text: 'bar',
                     props: {
                         'font-family': 'font1',
                         'font-weight': 400,
@@ -1949,7 +2187,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     }
                 },
                 {
-                    text: 'foo',
+                    text: 'bar',
                     props: {
                         'font-family': undefined,
                         'font-weight': 400,
@@ -1957,7 +2195,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     }
                 },
                 {
-                    text: 'bar',
+                    text: 'foo',
                     props: {
                         'font-family': 'font1',
                         'font-weight': 400,
@@ -1965,7 +2203,7 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                     }
                 },
                 {
-                    text: 'bar',
+                    text: 'foo',
                     props: {
                         'font-family': undefined,
                         'font-weight': 400,
@@ -3066,14 +3304,6 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
 
             return expect(htmlText, 'to exhaustively satisfy computed font properties', [
                 {
-                    text: 'foo',
-                    props: {
-                        'font-family': undefined,
-                        'font-weight': 700,
-                        'font-style': 'normal'
-                    }
-                },
-                {
                     text: 'bar',
                     props: {
                         'font-family': undefined,
@@ -3083,6 +3313,14 @@ describe('lib/util/fonts/getTextByFontProperties', function () {
                 },
                 {
                     text: 'bar',
+                    props: {
+                        'font-family': undefined,
+                        'font-weight': 700,
+                        'font-style': 'normal'
+                    }
+                },
+                {
+                    text: 'foo',
                     props: {
                         'font-family': undefined,
                         'font-weight': 700,


### PR DESCRIPTION
This is a bit of a mess, I know. Tracing those required a restructuring of how text and pseudo elements are traced.

Bonus feature: `::placeholder`