### PR TITLE
ag4ify/es6ify the subsetFonts transform

### DIFF
--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -1,22 +1,22 @@
-var _ = require('lodash');
-var url = require('url');
-var Promise = require('bluebird');
-var memoizeSync = require('memoizesync');
-var urltools = require('urltools');
+const _ = require('lodash');
+const url = require('url');
+const Promise = require('bluebird');
+const memoizeSync = require('memoizesync');
+const urltools = require('urltools');
 
-var AssetGraph = require('../../');
+const AssetGraph = require('../../');
 
-var getTextByFontProperties = require('../util/fonts/getTextByFontProperties');
-var getGoogleIdForFontProps = require('../util/fonts/getGoogleIdForFontProps');
-var snapToAvailableFontProperties = require('../util/fonts/snapToAvailableFontProperties');
-var cssListHelpers = require('css-list-helpers');
-var cssFontWeightNames = require('css-font-weight-names');
-var unquote = require('../util/fonts/unquote');
-var getCssRulesByProperty = require('../util/fonts/getCssRulesByProperty');
+const getTextByFontProperties = require('../util/fonts/getTextByFontProperties');
+const getGoogleIdForFontProps = require('../util/fonts/getGoogleIdForFontProps');
+const snapToAvailableFontProperties = require('../util/fonts/snapToAvailableFontProperties');
+const cssListHelpers = require('css-list-helpers');
+const cssFontWeightNames = require('css-font-weight-names');
+const unquote = require('../util/fonts/unquote');
+const getCssRulesByProperty = require('../util/fonts/getCssRulesByProperty');
 
-var googleFontsCssUrlRegex = /^(?:https?:)?\/\/fonts\.googleapis\.com\/css/;
+const googleFontsCssUrlRegex = /^(?:https?:)?\/\/fonts\.googleapis\.com\/css/;
 
-var initialFontPropertyValues = {
+const initialFontPropertyValues = {
     'font-style': 'normal',
     'font-weight': 400,
     'font-stretch': 'normal'
@@ -31,82 +31,59 @@ function cssQuoteIfNecessary(value) {
 }
 
 function getGoogleFontSubsetCssUrl(fontProps, text) {
-    var googleFontId = getGoogleIdForFontProps(fontProps);
+    const googleFontId = getGoogleIdForFontProps(fontProps);
 
     return 'https://fonts.googleapis.com/css?family=' + googleFontId + '&text=' + encodeURIComponent(text);
 }
 
 // Takes the output of util/fonts/getTextByFontProperties
 function groupTextsByFontFamilyProps(textByPropsArray, availableFontFaceDeclarations) {
-    var snappedTexts = textByPropsArray
-        .map(function (textAndProps) {
-            return {
-                text: textAndProps.text,
-                props: snapToAvailableFontProperties(availableFontFaceDeclarations, textAndProps.props)
-            };
-        })
-        .filter(function (textByProps) {
-            return textByProps.props;
-        });
+    const snappedTexts = textByPropsArray
+        .map(textAndProps => ({
+            text: textAndProps.text,
+            props: snapToAvailableFontProperties(availableFontFaceDeclarations, textAndProps.props)
+        }))
+        .filter(textByProps => textByProps.props);
 
-    var textsByFontUrl = _.groupBy(snappedTexts, function (obj) { return obj.props.src; });
+    const textsByFontUrl = _.groupBy(snappedTexts, obj => obj.props.src);
 
     return _.map(textsByFontUrl, function (textsPropsArray) {
-        var texts = textsPropsArray.map(function (obj) {
-            return obj.text;
-        });
+        const texts = textsPropsArray.map(obj => obj.text);
         return {
-            texts: texts,
+            texts,
             text: _.uniq(texts.join(''))
                 .sort()
                 .join(''),
-            props: Object.assign({}, textsPropsArray[0].props)
+            props: {...textsPropsArray[0].props}
         };
     });
 }
 
-// function getParents(assetGraph, asset, relationQuery) {
-//   const seenAssets = new Set();
-//   const parents = new Set();
-//   (function visit(asset) {
-//     if (seenAssets.has(asset)) {
-//       return;
-//     }
-//     seenAssets.add(asset);
-//     for (const matchingIncomingRelation of assetGraph.findRelations({to: asset, ...relationQuery})) {
-//       parents.add(matchingIncomingRelation.from);
-//       visit(matchingIncomingRelation.from);
-//     }
-//   }(asset));
-//   return Array.from(parents);
-// }
-
 function getParents(assetGraph, asset, assetQuery) {
-    var assetMatcher = assetGraph.query.createValueMatcher(assetQuery);
-    var seenAssets = {};
-    var parents = [];
+    const assetMatcher = assetGraph.query.createValueMatcher(assetQuery);
+    const seenAssets = new Set();
+    const parents = [];
     (function visit(asset) {
-        if (asset.id in seenAssets) {
+        if (seenAssets.has(asset)) {
             return;
         }
-        seenAssets[asset.id] = asset;
+        seenAssets.add(asset);
 
-        asset.incomingRelations.forEach(function (incomingRelation) {
+        for (const incomingRelation of asset.incomingRelations) {
             if (assetMatcher(incomingRelation.from)) {
                 parents.push(incomingRelation.from);
             } else {
                 visit(incomingRelation.from);
             }
-        });
+        }
     }(asset));
 
     return parents;
 }
 
 function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation, insertPoint) {
-    var document = htmlAsset.parseTree;
-    var injectionPointRelation = insertPoint || htmlAsset.outgoingRelations[0];
-
+    const document = htmlAsset.parseTree;
+    const injectionPointRelation = insertPoint || htmlAsset.outgoingRelations[0];
     // Resource hint: prefetch google font stylesheet
     const fontDomainPreconnect = htmlAsset.addRelation({
         type: 'HtmlPreconnectLink',
@@ -115,7 +92,7 @@ function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation, insertP
     }, 'after', injectionPointRelation);
 
     // Resource hint: prefetch google font stylesheet
-    var parsedOriginalUrl = url.parse(originalRelation.to.url);
+    const parsedOriginalUrl = url.parse(originalRelation.to.url);
     htmlAsset.addRelation({
         type: 'HtmlPreconnectLink',
         hrefType: 'absolute',
@@ -130,7 +107,7 @@ function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation, insertP
     }, 'last');
 
     // Insert async CSS loading <script> before <noscript>
-    var scriptText = [
+    const scriptText = [
         '(function () {',
         '  var el = document.createElement(\'link\');',
         '  el.href = \'' + fallbackRelation.to.url + '\'.toString(\'url\');',
@@ -150,7 +127,7 @@ function asyncLoadStyleRelationWithFallback(htmlAsset, originalRelation, insertP
     }, 'before', fallbackRelation);
 
     // Attach <noscript /> at bottom of <body> and put the <link> in it
-    var noScriptNode = document.createElement('noscript');
+    const noScriptNode = document.createElement('noscript');
     document.body.appendChild(noScriptNode);
     noScriptNode.appendChild(fallbackRelation.node);
 
@@ -169,197 +146,185 @@ function getSubsetPromiseId(fontUsage, format) {
     ].join('\x1d');
 }
 
-function getSubsetsForFontUsage(assetGraph, htmlAssetTextsWithProps, formats) {
-    var subsetLocalFont;
+const localRegex = /(?:local\(')(.+)(?:'\))/;
+async function getSubsetsForFontUsage(assetGraph, htmlAssetTextsWithProps, formats) {
+    let subsetLocalFont;
 
     try {
         subsetLocalFont = require('../util/fonts/subsetLocalFont');
     } catch (err) {
-        assetGraph.emit('warn', err);
+        assetGraph.warn(err);
     }
 
-    var allFonts = [];
+    const allFonts = [];
 
-    htmlAssetTextsWithProps.forEach(function (item) {
-        item.fontUsages.forEach(function (fontUsage) {
+    for (const item of htmlAssetTextsWithProps) {
+        for (const fontUsage of item.fontUsages) {
             if (allFonts.indexOf(fontUsage.props.src) === -1) {
                 allFonts.push(fontUsage.props.src);
             }
 
-            var fontRelation = assetGraph.findRelations({ type: 'CssFontFaceSrc', to: { url: fontUsage.props.src }}, true)[0];
+            const fontRelation = assetGraph.findRelations({ type: 'CssFontFaceSrc', to: { url: fontUsage.props.src }})[0];
 
             if (fontRelation) {
-                var localRegex = /(?:local\(')(.+)(?:'\))/;
                 fontUsage.localFamilyNames = fontRelation.propertyNode.value.split(',')
-                    .map(function (str) {
-                        var match = str.match(localRegex);
+                    .map(str => {
+                        const match = str.match(localRegex);
                         return match && match[1];
                     })
-                    .filter(function (str) { return str; });
+                    .filter(str => str);
             }
-
-        });
-    });
+        }
+    }
 
     if (subsetLocalFont) {
-        return assetGraph
-            .populate({
-                followRelations: {
-                    to: {
-                        url: allFonts
-                    }
+        await assetGraph.populate({
+            followRelations: {
+                to: {
+                    url: allFonts
                 }
-            })
-            .then(function () {
-                var originalFontBuffers = allFonts.reduce(function (result, fontUrl) {
-                    var fontAsset = assetGraph.findAssets({ url: fontUrl })[0];
+            }
+        });
 
-                    if (fontAsset) {
-                        result[fontUrl] = fontAsset.rawSrc;
+        const originalFontBuffers = allFonts.reduce((result, fontUrl) => {
+            const fontAsset = assetGraph.findAssets({ url: fontUrl })[0];
+
+            if (fontAsset) {
+                result[fontUrl] = fontAsset.rawSrc;
+            }
+
+            return result;
+        }, {});
+
+        const subsetPromiseMap = {};
+
+        const missingCharsByFontSrc = {};
+        for (const item of htmlAssetTextsWithProps) {
+            for (const fontUsage of item.fontUsages) {
+                const fontBuffer = originalFontBuffers[fontUsage.props.src];
+                const text = fontUsage.text;
+                for (const format of formats) {
+                    const promiseId = getSubsetPromiseId(fontUsage, format);
+
+                    if (!subsetPromiseMap[promiseId]) {
+                        subsetPromiseMap[promiseId] = subsetLocalFont(fontBuffer, format, text)
+                            .catch(err => {
+                                const error = new Error(err.message);
+                                error.asset = assetGraph.findAssets({ url: fontUsage.props.src })[0];
+
+                                assetGraph.warn(error);
+                            });
                     }
 
-                    return result;
-                }, {});
-
-                var subsetPromiseMap = {};
-
-                var missingCharsByFontSrc = {};
-                htmlAssetTextsWithProps.forEach(function (item) {
-                    item.fontUsages.forEach(function (fontUsage) {
-                        var fontBuffer = originalFontBuffers[fontUsage.props.src];
-                        var text = fontUsage.text;
-                        formats.forEach(function (format) {
-                            var promiseId = getSubsetPromiseId(fontUsage, format);
-
-                            if (!subsetPromiseMap[promiseId]) {
-                                subsetPromiseMap[promiseId] = subsetLocalFont(fontBuffer, format, text)
-                                    .catch(function (err) {
-                                        var error = new Error(err.message);
-                                        error.asset = assetGraph.findAssets({ url: fontUsage.props.src })[0];
-
-                                        assetGraph.emit('warn', error);
-                                    });
+                    subsetPromiseMap[promiseId].then(result => {
+                        if (result) {
+                            if (result.missingChars.length > 0) {
+                                missingCharsByFontSrc[fontUsage.props.src] =
+                                    result.missingChars.concat(missingCharsByFontSrc[fontUsage.props.src] || []);
                             }
 
-                            subsetPromiseMap[promiseId].then(function (result) {
-                                if (result) {
-                                    if (result.missingChars.length > 0) {
-                                        missingCharsByFontSrc[fontUsage.props.src] =
-                                            result.missingChars.concat(missingCharsByFontSrc[fontUsage.props.src] || []);
-                                    }
-
-                                    if (!fontUsage.subsets) {
-                                        fontUsage.subsets = {};
-                                    }
-                                    fontUsage.subsets[format] = result.buffer;
-                                }
-                            });
-                        });
+                            if (!fontUsage.subsets) {
+                                fontUsage.subsets = {};
+                            }
+                            fontUsage.subsets[format] = result.buffer;
+                        }
                     });
-                });
+                }
+            }
+        }
 
-                return Promise.all(_.values(subsetPromiseMap))
-                    .tap(function () {
-                        Object.keys(missingCharsByFontSrc).forEach(function (fontSrc) {
-                            assetGraph.emit('warn', new Error(
-                                'The font ' + fontSrc + ' is missing these characters: ' +
-                                _.uniq(missingCharsByFontSrc[fontSrc]).join('') + '\n' +
-                                'Under these circumstances the subsetting strategy will load both the subset, the original font,\n' +
-                                'as well as any additional fallbacks you might have in font-family\n' +
-                                'Please make sure that the highest prioritized font-family that applies to the elements\n' +
-                                'containing those characters does include them.'
-                            ));
-                        });
-                    });
-            });
+        await Promise.all(_.values(subsetPromiseMap));
+
+        for (const fontSrc of Object.keys(missingCharsByFontSrc)) {
+            assetGraph.warn(new Error(
+                'The font ' + fontSrc + ' is missing these characters: ' +
+                _.uniq(missingCharsByFontSrc[fontSrc]).join('') + '\n' +
+                'Under these circumstances the subsetting strategy will load both the subset, the original font,\n' +
+                'as well as any additional fallbacks you might have in font-family\n' +
+                'Please make sure that the highest prioritized font-family that applies to the elements\n' +
+                'containing those characters does include them.'
+            ));
+        }
     } else {
-        var fontCssUrlMap = {};
+        const fontCssUrlMap = {};
 
-        htmlAssetTextsWithProps.forEach(function (item) {
-            item.fontUsages.forEach(function (fontUsage) {
-                if (fontUsage.props.src.indexOf('//fonts.gstatic.com') === -1) {
-                    return;
+        for (const item of htmlAssetTextsWithProps) {
+            for (const fontUsage of item.fontUsages) {
+                if (!fontUsage.props.src.includes('//fonts.gstatic.com')) {
+                    continue;
                 }
 
-                formats.forEach(function (format) {
-                    var mapId = getSubsetPromiseId(fontUsage, format);
+                for (const format of formats) {
+                    const mapId = getSubsetPromiseId(fontUsage, format);
 
                     if (!fontCssUrlMap[mapId]) {
                         fontCssUrlMap[mapId] = getGoogleFontSubsetCssUrl(fontUsage.props, fontUsage.text) + '&format=' + format;
                     }
-                });
-            });
-        });
+                }
+            }
+        }
 
         const assetGraphForLoadingFonts = new AssetGraph();
-        const queue = assetGraphForLoadingFonts
-            .queue();
 
-        formats.forEach(function (format) {
-            var formatUrls = _.uniq(_.values(fontCssUrlMap).filter(function (url) { return url.endsWith('format=' + format); }));
-            queue
-                .queue(function () {
-                    assetGraphForLoadingFonts.teepee.headers['User-Agent'] = fontFormatUA[format];
-                })
-                .loadAssets(_.values(formatUrls));
+        for (const format of formats) {
+            assetGraphForLoadingFonts.teepee.headers['User-Agent'] = fontFormatUA[format];
+            const formatUrls = _.uniq(
+                _.values(fontCssUrlMap)
+                    .filter(url => url.endsWith('format=' + format))
+            );
+            await assetGraphForLoadingFonts.loadAssets(_.values(formatUrls));
+        }
+
+        await assetGraphForLoadingFonts.populate({
+            followRelations: {
+                type: 'CssFontFaceSrc'
+            }
         });
 
-        return queue
-            .populate({
-                followRelations: {
-                    type: 'CssFontFaceSrc'
-                }
-            })
-            .then(function () {
-                htmlAssetTextsWithProps.forEach(function (item) {
-                    item.fontUsages.forEach(function (fontUsage) {
-                        formats.forEach(function (format) {
-                            var cssUrl = fontCssUrlMap[getSubsetPromiseId(fontUsage, format)];
-                            var cssAsset = assetGraphForLoadingFonts.findAssets({ url: cssUrl, isLoaded: true })[0];
-                            if (cssAsset) {
-                                var fontRelation = cssAsset.outgoingRelations[0];
-                                var fontAsset = fontRelation.to;
+        for (const item of htmlAssetTextsWithProps) {
+            for (const fontUsage of item.fontUsages) {
+                for (const format of formats) {
+                    const cssUrl = fontCssUrlMap[getSubsetPromiseId(fontUsage, format)];
+                    const cssAsset = assetGraphForLoadingFonts.findAssets({ url: cssUrl, isLoaded: true })[0];
+                    if (cssAsset) {
+                        const fontRelation = cssAsset.outgoingRelations[0];
+                        const fontAsset = fontRelation.to;
 
-                                if (fontAsset.isLoaded) {
-                                    if (!fontUsage.subsets) {
-                                        fontUsage.subsets = {};
-                                    }
-
-                                    fontUsage.subsets[format] = fontAsset.rawSrc;
-                                }
+                        if (fontAsset.isLoaded) {
+                            if (!fontUsage.subsets) {
+                                fontUsage.subsets = {};
                             }
-                        });
-                    });
-                });
-            });
+
+                            fontUsage.subsets[format] = fontAsset.rawSrc;
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
-var fontContentTypeMap = {
+const fontContentTypeMap = {
     woff: 'font/woff', // https://tools.ietf.org/html/rfc8081#section-4.4.5
     woff2: 'font/woff2'
 };
 
-var fontOrder = ['woff2', 'woff'];
+const fontOrder = ['woff2', 'woff'];
 
-var getFontFaceForFontUsage = memoizeSync(function (fontUsage) {
-    var subsets = fontOrder
-        .filter(function (format) { return fontUsage.subsets[format]; })
-        .map(function (format) {
-            var buffer = fontUsage.subsets[format];
+const getFontFaceForFontUsage = memoizeSync(fontUsage => {
+    const subsets = fontOrder
+        .filter(format => fontUsage.subsets[format])
+        .map(format => ({
+            format,
+            url: 'data:' + fontContentTypeMap[format] + ';base64,' + fontUsage.subsets[format].toString('base64')
+        }));
 
-            return {
-                format: format,
-                url: 'data:' + fontContentTypeMap[format] + ';base64,' + buffer.toString('base64')
-            };
-        });
+    const resultString = ['@font-face {'];
 
-    var resultString = ['@font-face {'];
-
-    resultString.push.apply(resultString, Object.keys(fontUsage.props)
+    resultString.push(...Object.keys(fontUsage.props)
         .sort()
-        .map(function (prop) {
-            var value = fontUsage.props[prop];
+        .map(prop => {
+            let value = fontUsage.props[prop];
 
             if (prop === 'font-family') {
                 value = cssQuoteIfNecessary(value + '__subset');
@@ -367,46 +332,40 @@ var getFontFaceForFontUsage = memoizeSync(function (fontUsage) {
 
             if (prop === 'src') {
                 value = (fontUsage.localFamilyNames || [])
-                    .map(function (name) { return 'local(\'' + name + '\')'; })
-                    .concat(subsets.map(function (subset) { return 'url(' + subset.url + ') format(\'' + subset.format + '\')'; }))
+                    .map(name => 'local(\'' + name + '\')')
+                    .concat(subsets.map(subset => `url(${subset.url}) format('${subset.format}')`))
                     .join(', ');
             }
 
             return prop + ': ' + value + ';';
         })
-        .map(function (str) { return '  ' + str; })
+        .map(str => '  ' + str)
     );
 
     resultString.push('}');
 
     return resultString.join('\n');
 }, {
-    argumentsStringifier: function (args) {
+    argumentsStringifier: args => {
         return [args[0].text, args[0].props, args[1]]
-            .map(function (arg) {
-                return JSON.stringify(arg);
-            })
+            .map(arg => JSON.stringify(arg))
             .join('\x1d');
     }
 });
 
 function getFontUsageStylesheet(fontUsages) {
-    var stylesheet = fontUsages
-        .filter(function (fontUsage) { return fontUsage.subsets; })
-        .map(function (fontUsage) {
-            return getFontFaceForFontUsage(fontUsage);
-        })
+    return fontUsages
+        .filter(fontUsage => fontUsage.subsets)
+        .map(fontUsage => getFontFaceForFontUsage(fontUsage))
         .join('\n\n');
-
-    return stylesheet;
 }
 
-var fontFormatUA = {
+const fontFormatUA = {
     woff: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0',
     woff2: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.96 Safari/537.36'
 };
 
-var validFontDisplayValues = [
+const validFontDisplayValues = [
     'auto',
     'block',
     'swap',
@@ -414,452 +373,448 @@ var validFontDisplayValues = [
     'optional'
 ];
 
-module.exports = function (options) {
-    options = options || {};
-    var formats = options.formats || ['woff2', 'woff'];
-    var subsetPerPage = !!options.subsetPerPage;
-    var inlineSubsets = !!options.inlineSubsets;
-    var inlineCss = !!options.inlineCss;
-    var fontDisplay = validFontDisplayValues.indexOf(options.fontDisplay) !== -1 && options.fontDisplay;
+module.exports = ({
+    formats = ['woff2', 'woff'],
+    subsetPath = 'subfont/',
+    subsetPerPage,
+    inlineSubsets,
+    inlineCss,
+    fontDisplay,
+    debug
+} = {}) => {
+    if (!validFontDisplayValues.includes(fontDisplay)) {
+        fontDisplay = undefined;
+    }
 
-    return function subsetFonts(assetGraph, cb) {
-        var htmlAssetTextsWithProps = [];
-        var subsetPath = urltools.ensureTrailingSlash(assetGraph.root + (options.subsetPath || 'subfont/'));
+    return async function subsetFonts(assetGraph) {
+        const htmlAssetTextsWithProps = [];
+        const subsetUrl = urltools.ensureTrailingSlash(assetGraph.root + subsetPath);
 
-        assetGraph
-            .populate({
-                followRelations: {
-                    to: {
-                        url: googleFontsCssUrlRegex
-                    }
-                }
-            })
-            .queue(function collectTextsByPage() {
-                var memoizedGetCssRulesByProperty = memoizeSync(getCssRulesByProperty);
-                var htmlAssets = assetGraph.findAssets({ type: 'Html', isInline: false });
-                var traversalRelationQuery = assetGraph.query.or(
-                    {
-                        type: ['HtmlStyle', 'CssImport']
-                    },
-                    {
-                        to: {
-                            type: 'Html',
-                            isInline: true
-                        }
-                    }
-                );
-
-                htmlAssets.forEach(function (htmlAsset) {
-                    var accumulatedFontFaceDeclarations = [];
-
-                    assetGraph.eachAssetPreOrder(htmlAsset, traversalRelationQuery, function (asset) {
-                        if (asset.type === 'Css' && asset.isLoaded) {
-                            var fontRelations = asset.outgoingRelations.filter(function (relation) { return relation.type === 'CssFontFaceSrc'; });
-
-                            fontRelations.forEach(function (fontRelation) {
-                                var fontFaceDeclaration = {
-                                    src: fontRelation.to.url
-                                };
-
-                                fontRelation.node.walkDecls(function (declaration) {
-                                    if (declaration.prop !== 'src') {
-                                        if (declaration.prop === 'font-weight') {
-                                            fontFaceDeclaration[declaration.prop] = cssFontWeightNames[declaration.value] || parseInt(declaration.value, 10);
-                                        } else {
-                                            fontFaceDeclaration[declaration.prop] = unquote(declaration.value);
-                                        }
-                                    }
-                                });
-
-                                accumulatedFontFaceDeclarations.push(fontFaceDeclaration);
-                            });
-                        }
-                    });
-
-                    if (accumulatedFontFaceDeclarations.length) {
-                        var textByProps = getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty);
-
-                        htmlAssetTextsWithProps.push({
-                            htmlAsset: htmlAsset,
-                            fontUsages: groupTextsByFontFamilyProps(textByProps, accumulatedFontFaceDeclarations)
-                        });
-                    }
-                });
-
-                if (htmlAssetTextsWithProps.length <= 1) {
-                    subsetPerPage = false;
-                }
-
-                if (!subsetPerPage) {
-                    var globalFontUsage = {};
-
-                    // Gather all subsets
-                    htmlAssetTextsWithProps.forEach(function (htmlAssetTextWithProps) {
-                        htmlAssetTextWithProps.fontUsages.forEach(function (fontUsage) {
-                            if (!globalFontUsage[fontUsage.props.src]) {
-                                globalFontUsage[fontUsage.props.src] = [];
-                            }
-
-                            globalFontUsage[fontUsage.props.src].push(fontUsage);
-                        });
-                    });
-
-                    // Merge subset values, unique glyphs, sort
-                    Object.keys(globalFontUsage).forEach(function (src) {
-                        var fontUsages = globalFontUsage[src];
-                        var texts = _.map(fontUsages, 'text');
-
-                        globalFontUsage[src] = {
-                            props: fontUsages[0].props,
-                            text: _.uniq(texts.join(''))
-                                .sort()
-                                .join('')
-                        };
-                    });
-
-                    // Assign the single global subset to all pages
-                    htmlAssetTextsWithProps.forEach(function (htmlAssetTextWithProps) {
-                        htmlAssetTextWithProps.fontUsages = _.toArray(globalFontUsage);
-                    });
-                }
-
-                if (options.debug) {
-                    console.error(JSON.stringify(htmlAssetTextsWithProps, function (key, value) {
-                        if (value.isAsset === true) {
-                            return value.url;
-                        }
-
-                        return value;
-                    }, 2));
-
-                    process.exit();
-                }
-
-                if (fontDisplay) {
-                    htmlAssetTextsWithProps.forEach(function (htmlAssetTextWithProps) {
-                        htmlAssetTextWithProps.fontUsages.forEach(function (fontUsage) {
-                            fontUsage.props['font-display'] = fontDisplay;
-                        });
-                    });
-                }
-            })
-            .queue(function generateSubsets() {
-                return getSubsetsForFontUsage(assetGraph, htmlAssetTextsWithProps, formats);
-            })
-            .queue(function insertSubsets() {
-                var cssAssetMap = {};
-
-                htmlAssetTextsWithProps
-                    .forEach(function (htmlAssetTextWithProps) {
-                        var htmlAsset = htmlAssetTextWithProps.htmlAsset;
-                        var insertionPoint = assetGraph.findRelations({ type: 'HtmlStyle', from: htmlAsset })[0];
-                        var fontUsages = htmlAssetTextWithProps.fontUsages;
-                        var subsetFontUsages = fontUsages.filter(function (fontUsage) { return fontUsage.subsets; });
-                        var unsubsettedFontUsages = fontUsages.filter(function (fontUsage) { return subsetFontUsages.indexOf(fontUsage) === -1; });
-
-                        // Remove all existing preload hints to fonts that might have new subsets
-                        fontUsages.forEach(function (fontUsage) {
-                            assetGraph.findRelations({
-                                type: ['HtmlPrefetchLink', 'HtmlPreloadLink'],
-                                from: htmlAsset,
-                                to: {
-                                    url: fontUsage.props.src
-                                }
-                            })
-                                .forEach(function (relation) {
-                                    if (relation.type === 'HtmlPrefetchLink') {
-                                        var err = new Error('Detached ' + relation.node.outerHTML + '. Will be replaced with preload with JS fallback.\nIf you feel this is wrong, open an issue at https://github.com/assetgraph/assetgraph/issues');
-                                        err.asset = relation.from;
-                                        err.relation = relation;
-
-                                        assetGraph.emit('info', err);
-                                    }
-
-                                    relation.detach();
-                                });
-                        });
-
-                        if (unsubsettedFontUsages.length > 0) {
-                            // Insert <link rel="preload">
-                            var preloadRelations = unsubsettedFontUsages.map(function (fontUsage) {
-                                // Always preload unsubsetted font files, they might be any format, so can't be clever here
-                                return htmlAsset.addRelation({
-                                    type: 'HtmlPreloadLink',
-                                    hrefType: 'rootRelative',
-                                    to: assetGraph.findAssets({ url: fontUsage.props.src })[0],
-                                    as: 'font'
-                                }, 'before', insertionPoint);
-                            });
-
-                            // Generate JS fallback for browser that don't support <link rel="preload">
-                            var preloadData = unsubsettedFontUsages.map(function (fontUsage, idx) {
-                                var preloadRelation = preloadRelations[idx];
-
-                                var formatMap = {
-                                    '.woff': 'woff',
-                                    '.woff2': 'woff2',
-                                    '.ttf': 'truetype',
-                                    '.svg': 'svg',
-                                    '.eot': 'embedded-opentype'
-                                };
-                                var name = fontUsage.props['font-family'];
-                                var url = 'url(\'"+"' + preloadRelation.href + '".toString(\'url\')+"\') format(\'' + formatMap[preloadRelation.to.extension] + '\')';
-                                var props = Object.keys(initialFontPropertyValues).reduce(function (result, prop) {
-                                    if (fontUsage.props[prop] !== initialFontPropertyValues[prop]) {
-                                        result[prop] = fontUsage.props[prop];
-                                    }
-
-                                    return result;
-                                }, {});
-
-                                return 'new FontFace("' + name + '", "' + url + '", ' + JSON.stringify(props) + ').load();';
-                            });
-
-                            const originalFontJsPreloadAsset = htmlAsset.addRelation({
-                                type: 'HtmlScript',
-                                hrefType: 'inline',
-                                to: {
-                                    type: 'JavaScript',
-                                    text: 'try{' + preloadData.join('') + '}catch(e){}'
-                                }
-                            }, 'before', insertionPoint).to;
-
-                            originalFontJsPreloadAsset.outgoingRelations.forEach(function (rel, idx) {
-                                rel.hrefType = 'rootRelative';
-                                rel.to = preloadRelations[idx].to;
-                                rel.refreshHref();
-                            });
-
-                            originalFontJsPreloadAsset.minify();
-                        }
-                        if (subsetFontUsages.length < 1) {
-                            return;
-                        }
-
-                        var subsetCssText = getFontUsageStylesheet(subsetFontUsages);
-                        var cssAsset = cssAssetMap[subsetCssText];
-                        if (!cssAsset) {
-                            cssAsset = assetGraph.addAsset({
-                                type: 'Css',
-                                url: subsetPath + 'subfontTemp.css',
-                                text: subsetCssText,
-                                _minifyMe: true
-                            });
-
-                            cssAssetMap[subsetCssText] = cssAsset;
-
-                            if (!inlineSubsets) {
-                                cssAsset.outgoingRelations.forEach(function (fontRelation) {
-                                    var fontAsset = fontRelation.to;
-                                    var extension = fontAsset.contentType.split('/').pop();
-
-                                    var nameProps = ['font-family', 'font-weight', 'font-style']
-                                        .map(function (prop) {
-                                            return fontRelation.node.nodes.find(function (decl) {
-                                                return decl.prop === prop;
-                                            });
-                                        })
-                                        .map(function (decl) { return decl.value; });
-
-                                    var fileNamePreFix = [
-                                        unquote(nameProps[0]).replace(/__subset$/, '').replace(/ /g, '_') + '-',
-                                        nameProps[1],
-                                        nameProps[2] === 'italic' ? 'i' : ''
-                                    ].join('');
-
-                                    var fontFileName = fileNamePreFix + '-' + fontAsset.md5Hex.slice(0, 10) + '.' + extension;
-
-                                    fontAsset.url = subsetPath + fontFileName;
-
-                                    if (inlineCss) {
-                                        fontRelation.hrefType = 'rootRelative';
-                                    } else {
-                                        fontRelation.hrefType = 'relative';
-                                    }
-                                });
-                            }
-
-                            var cssFileName = 'fonts-' + cssAsset.md5Hex.slice(0, 10) + '.css';
-                            cssAsset.url = subsetPath + cssFileName;
-                        }
-
-                        if (!inlineSubsets) {
-                            cssAsset.outgoingRelations.forEach(function (fontRelation) {
-                                var fontAsset = fontRelation.to;
-
-                                if (fontAsset.contentType === 'font/woff2') {
-                                    // Only <link rel="preload"> for woff2 files
-                                    // Preload support is a subset of woff2 support:
-                                    // - https://caniuse.com/#search=woff2
-                                    // - https://caniuse.com/#search=preload
-
-                                    htmlAsset.addRelation({
-                                        type: 'HtmlPreloadLink',
-                                        hrefType: 'rootRelative',
-                                        to: fontAsset,
-                                        as: 'font'
-                                    }, 'before', insertionPoint);
-                                }
-                            });
-                        }
-                        var cssRelation = htmlAsset.addRelation({
-                            type: 'HtmlStyle',
-                            hrefType: 'rootRelative',
-                            to: cssAsset
-                        }, 'before', insertionPoint);
-
-                        if (inlineCss) {
-                            cssRelation.inline();
-                        }
-
-                        // cssAsset.minify();
-
-                        // JS-based font preloading for browsers without <link rel="preload"> support
-                        if (inlineCss) {
-                            // If the CSS is inlined we can use the font declarations directly to load the fonts
-                            const jsPreloadInlineAsset = htmlAsset.addRelation({
-                                type: 'HtmlScript',
-                                hrefType: 'inline',
-                                to: {
-                                    type: 'JavaScript',
-                                    text: 'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load(); }); } catch (e) {}'
-                                }
-                            }, 'after', cssRelation).to;
-
-                            jsPreloadInlineAsset.minify();
-                        } else {
-                            // The CSS is external, can't use the font face declarations without waiting for a blocking load.
-                            // Go for direct FontFace construction instead
-                            var fontFaceContructorCalls = [];
-
-                            cssAsset.parseTree.walkAtRules('font-face', function (rule) {
-                                var name;
-                                var url;
-                                var props = {};
-
-                                rule.walkDecls(function (declaration) {
-                                    var prop = declaration.prop;
-                                    var value = declaration.value;
-
-                                    if (prop === 'font-weight') {
-                                        value = Number(value) || value;
-                                    }
-
-                                    if (prop in initialFontPropertyValues) {
-                                        if (value !== initialFontPropertyValues[prop]) {
-                                            props[prop] = value;
-                                        }
-                                    }
-
-                                    if (prop === 'font-family') {
-                                        name = value;
-                                    }
-
-                                    if (prop === 'src') {
-                                        var fontRelations = cssAsset.outgoingRelations.filter(function (rel) { return rel.node === rule; });
-                                        var urlStrings = value
-                                            .split(', ')
-                                            .filter(function (entry) {
-                                                return entry.indexOf('url(') === 0;
-                                            });
-
-                                        var urlValues = urlStrings.map(function (urlString, idx) {
-                                            return urlString.replace(fontRelations[idx].href, '\'" + "/__subfont__".toString("url") + "\'');
-                                        });
-
-                                        url = '"' + urlValues.join(', ') + '"';
-                                    }
-
-                                });
-
-                                fontFaceContructorCalls.push('new FontFace(' + name + ', ' + url + ', ' + JSON.stringify(props) + ').load();');
-                            });
-
-                            const jsPreloadAsset = htmlAsset.addRelation({
-                                type: 'HtmlScript',
-                                hrefType: 'inline',
-                                to: {
-                                    type: 'JavaScript',
-                                    text: 'try {' + fontFaceContructorCalls.join('') + '} catch (e) {}'
-                                }
-                            }, 'before', cssRelation).to;
-
-                            jsPreloadAsset.outgoingRelations.forEach(function (rel, idx) {
-                                rel.to = cssAsset.outgoingRelations[idx].to;
-                                rel.hrefType = 'rootRelative';
-                                rel.refreshHref();
-                            });
-
-                            jsPreloadAsset.minify();
-                        }
-                    });
-            })
-            .queue(function asyncLoadGoogleFontCss(assetGraph) {
-                var googleFontStylesheets = assetGraph.findAssets({
-                    type: 'Css',
+        await assetGraph.populate({
+            followRelations: {
+                to: {
                     url: googleFontsCssUrlRegex
-                });
-                googleFontStylesheets.forEach(function (googleFontStylesheet) {
-                    googleFontStylesheet.incomingRelations.forEach(function (googleFontStylesheetRelation) {
-                        var htmlParents = [googleFontStylesheetRelation.from];
+                }
+            }
+        });
 
-                        if (googleFontStylesheetRelation.type === 'CssImport') {
-                            // Gather Html parents. Relevant if we are dealing with CSS @import relations
-                            htmlParents = getParents(assetGraph, googleFontStylesheetRelation.to, {
-                                type: 'Html',
-                                isInline: false,
-                                isLoaded: true
-                            });
-                        }
+        // Collect texts by page
 
-                        htmlParents.forEach(function (htmlParent) {
-                            asyncLoadStyleRelationWithFallback(htmlParent, googleFontStylesheetRelation, htmlParent.outgoingRelations.find(function (relation) {
-                                return relation.type === 'HtmlStyle';
-                            }));
-                        });
-                    });
+        const memoizedGetCssRulesByProperty = memoizeSync(getCssRulesByProperty);
+        const htmlAssets = assetGraph.findAssets({ type: 'Html', isInline: false });
+        const traversalRelationQuery = assetGraph.query.or(
+            {
+                type: ['HtmlStyle', 'CssImport']
+            },
+            {
+                to: {
+                    type: 'Html',
+                    isInline: true
+                }
+            }
+        );
 
-                    googleFontStylesheet.unload();
-                });
-            })
-            .queue(function useSubsetsInFontFamily() {
-                var webfontNameMap = htmlAssetTextsWithProps
-                    .map(function (pageObject) {
-                        return pageObject.fontUsages
-                            .filter(function (fontUsage) { return fontUsage.subsets; })
-                            .map(function (fontUsage) {
-                                return fontUsage.props['font-family'];
-                            });
-                    })
-                    .reduce(function (result, current) {
-                        current.forEach(function (familyName) {
-                            result[familyName] = familyName + '__subset';
-                        });
+        for (const htmlAsset of htmlAssets) {
+            const accumulatedFontFaceDeclarations = [];
 
-                        return result;
-                    }, {});
+            assetGraph.eachAssetPreOrder(htmlAsset, traversalRelationQuery, asset => {
+                if (asset.type === 'Css' && asset.isLoaded) {
+                    const fontRelations = asset.outgoingRelations
+                        .filter(relation => relation.type === 'CssFontFaceSrc');
 
-                // Inject subset font name before original webfont
-                assetGraph.findAssets({type: 'Css', isLoaded: true }).forEach(function (cssAsset) {
-                    var changesMade = false;
-                    cssAsset.eachRuleInParseTree(function (cssRule) {
-                        if (cssRule.type === 'decl' && cssRule.prop === 'font-family') {
-                            if (cssRule.parent.type === 'rule') {
-                                var fontFamilies = cssListHelpers.splitByCommas(cssRule.value).map(unquote);
-                                var subsetFontFamily = webfontNameMap[fontFamilies[0]];
-                                if (subsetFontFamily && fontFamilies.indexOf(subsetFontFamily) === -1) {
-                                    cssRule.value = cssQuoteIfNecessary(subsetFontFamily) + ', ' + cssRule.value;
-                                    changesMade = true;
+                    for (const fontRelation of fontRelations) {
+                        const fontFaceDeclaration = {
+                            src: fontRelation.to.url
+                        };
+
+                        fontRelation.node.walkDecls(declaration => {
+                            if (declaration.prop !== 'src') {
+                                if (declaration.prop === 'font-weight') {
+                                    fontFaceDeclaration[declaration.prop] = cssFontWeightNames[declaration.value] || parseInt(declaration.value, 10);
+                                } else {
+                                    fontFaceDeclaration[declaration.prop] = unquote(declaration.value);
                                 }
                             }
-                        }
-                    });
-                    if (changesMade) {
-                        cssAsset.markDirty();
+                        });
+
+                        accumulatedFontFaceDeclarations.push(fontFaceDeclaration);
                     }
+                }
+            });
+
+            if (accumulatedFontFaceDeclarations.length > 0) {
+                const textByProps = getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty);
+
+                htmlAssetTextsWithProps.push({
+                    htmlAsset,
+                    fontUsages: groupTextsByFontFamilyProps(textByProps, accumulatedFontFaceDeclarations)
                 });
-            })
-            .minifyCss({_minifyMe: true})
-            .run(cb);
+            }
+        }
+
+        if (htmlAssetTextsWithProps.length <= 1) {
+            subsetPerPage = false;
+        }
+
+        if (!subsetPerPage) {
+            const globalFontUsage = {};
+
+            // Gather all subsets
+            for (const htmlAssetTextWithProps of htmlAssetTextsWithProps) {
+                for (const fontUsage of htmlAssetTextWithProps.fontUsages) {
+                    if (!globalFontUsage[fontUsage.props.src]) {
+                        globalFontUsage[fontUsage.props.src] = [];
+                    }
+
+                    globalFontUsage[fontUsage.props.src].push(fontUsage);
+                }
+            }
+
+            // Merge subset values, unique glyphs, sort
+            for (const src of Object.keys(globalFontUsage)) {
+                const fontUsages = globalFontUsage[src];
+
+                globalFontUsage[src] = {
+                    props: fontUsages[0].props,
+                    text: _.uniq(fontUsages.map(fontUsage => fontUsage.text).join(''))
+                        .sort()
+                        .join('')
+                };
+            }
+
+            // Assign the single global subset to all pages
+            for (const htmlAssetTextWithProps of htmlAssetTextsWithProps) {
+                htmlAssetTextWithProps.fontUsages = _.toArray(globalFontUsage);
+            }
+        }
+
+        if (debug) {
+            console.error(JSON.stringify(htmlAssetTextsWithProps, (key, value) => {
+                if (value.isAsset === true) {
+                    return value.url;
+                }
+
+                return value;
+            }, 2));
+
+            process.exit();
+        }
+
+        if (fontDisplay) {
+            for (const htmlAssetTextWithProps of htmlAssetTextsWithProps) {
+                for (const fontUsage of htmlAssetTextWithProps.fontUsages) {
+                    fontUsage.props['font-display'] = fontDisplay;
+                }
+            }
+        }
+
+        // Generate subsets:
+
+        await getSubsetsForFontUsage(assetGraph, htmlAssetTextsWithProps, formats);
+
+        // Insert subsets:
+
+        const cssAssetMap = {};
+
+        for (const { htmlAsset, fontUsages } of htmlAssetTextsWithProps) {
+            const insertionPoint = assetGraph.findRelations({ type: 'HtmlStyle', from: htmlAsset })[0];
+            const subsetFontUsages = fontUsages
+                .filter(fontUsage => fontUsage.subsets);
+            const unsubsettedFontUsages = fontUsages
+                .filter(fontUsage => !subsetFontUsages.includes(fontUsage));
+
+            // Remove all existing preload hints to fonts that might have new subsets
+            for (const fontUsage of fontUsages) {
+                for (const relation of assetGraph.findRelations({
+                    type: ['HtmlPrefetchLink', 'HtmlPreloadLink'],
+                    from: htmlAsset,
+                    to: {
+                        url: fontUsage.props.src
+                    }
+                })) {
+                    if (relation.type === 'HtmlPrefetchLink') {
+                        const err = new Error(`Detached ${relation.node.outerHTML}. Will be replaced with preload with JS fallback.\nIf you feel this is wrong, open an issue at https://github.com/assetgraph/assetgraph/issues`);
+                        err.asset = relation.from;
+                        err.relation = relation;
+
+                        assetGraph.info(err);
+                    }
+
+                    relation.detach();
+                }
+            }
+
+            if (unsubsettedFontUsages.length > 0) {
+                // Insert <link rel="preload">
+                const preloadRelations = unsubsettedFontUsages.map(fontUsage => {
+                    // Always preload unsubsetted font files, they might be any format, so can't be clever here
+                    return htmlAsset.addRelation({
+                        type: 'HtmlPreloadLink',
+                        hrefType: 'rootRelative',
+                        to: assetGraph.findAssets({ url: fontUsage.props.src })[0],
+                        as: 'font'
+                    }, 'before', insertionPoint);
+                });
+
+                // Generate JS fallback for browser that don't support <link rel="preload">
+                const preloadData = unsubsettedFontUsages.map((fontUsage, idx) => {
+                    const preloadRelation = preloadRelations[idx];
+
+                    const formatMap = {
+                        '.woff': 'woff',
+                        '.woff2': 'woff2',
+                        '.ttf': 'truetype',
+                        '.svg': 'svg',
+                        '.eot': 'embedded-opentype'
+                    };
+                    const name = fontUsage.props['font-family'];
+                    const props = Object.keys(initialFontPropertyValues).reduce(
+                        (result, prop) => {
+                            if (fontUsage.props[prop] !== initialFontPropertyValues[prop]) {
+                                result[prop] = fontUsage.props[prop];
+                            }
+                            return result;
+                        },
+                        {}
+                    );
+
+                    return `new FontFace(
+                        "${name}",
+                        "url('" + "${preloadRelation.href}".toString('url') + "') format('${formatMap[preloadRelation.to.extension]}')",
+                        ${JSON.stringify(props)}
+                    ).load();`;
+                });
+
+                const originalFontJsPreloadAsset = htmlAsset.addRelation({
+                    type: 'HtmlScript',
+                    hrefType: 'inline',
+                    to: {
+                        type: 'JavaScript',
+                        text: 'try{' + preloadData.join('') + '}catch(e){}'
+                    }
+                }, 'before', insertionPoint).to;
+
+                for (const [idx, relation] of originalFontJsPreloadAsset.outgoingRelations.entries()) {
+                    relation.hrefType = 'rootRelative';
+                    relation.to = preloadRelations[idx].to;
+                    relation.refreshHref();
+                }
+
+                originalFontJsPreloadAsset.minify();
+            }
+            if (subsetFontUsages.length < 1) {
+                return;
+            }
+
+            const subsetCssText = getFontUsageStylesheet(subsetFontUsages);
+            let cssAsset = cssAssetMap[subsetCssText];
+            if (!cssAsset) {
+                cssAsset = assetGraph.addAsset({
+                    type: 'Css',
+                    url: subsetUrl + 'subfontTemp.css',
+                    text: subsetCssText,
+                    _subsetFontsToBeMinified: true
+                });
+
+                cssAssetMap[subsetCssText] = cssAsset;
+
+                if (!inlineSubsets) {
+                    for (const fontRelation of cssAsset.outgoingRelations) {
+                        const fontAsset = fontRelation.to;
+                        const extension = fontAsset.contentType.split('/').pop();
+
+                        const nameProps = ['font-family', 'font-weight', 'font-style']
+                            .map(
+                                prop => fontRelation.node.nodes.find(
+                                    decl => decl.prop === prop
+                                )
+                            )
+                            .map(decl => decl.value);
+
+                        const fileNamePreFix = [
+                            unquote(nameProps[0]).replace(/__subset$/, '').replace(/ /g, '_') + '-',
+                            nameProps[1],
+                            nameProps[2] === 'italic' ? 'i' : ''
+                        ].join('');
+
+                        const fontFileName = fileNamePreFix + '-' + fontAsset.md5Hex.slice(0, 10) + '.' + extension;
+
+                        fontAsset.url = subsetUrl + fontFileName;
+
+                        if (inlineCss) {
+                            fontRelation.hrefType = 'rootRelative';
+                        } else {
+                            fontRelation.hrefType = 'relative';
+                        }
+                    }
+                }
+
+                const cssFileName = `fonts-${cssAsset.md5Hex.slice(0, 10)}.css`;
+                cssAsset.url = subsetUrl + cssFileName;
+            }
+
+            if (!inlineSubsets) {
+                for (const fontRelation of cssAsset.outgoingRelations) {
+                    const fontAsset = fontRelation.to;
+
+                    if (fontAsset.contentType === 'font/woff2') {
+                        // Only <link rel="preload"> for woff2 files
+                        // Preload support is a subset of woff2 support:
+                        // - https://caniuse.com/#search=woff2
+                        // - https://caniuse.com/#search=preload
+
+                        htmlAsset.addRelation({
+                            type: 'HtmlPreloadLink',
+                            hrefType: 'rootRelative',
+                            to: fontAsset,
+                            as: 'font'
+                        }, 'before', insertionPoint);
+                    }
+                }
+            }
+            const cssRelation = htmlAsset.addRelation({
+                type: 'HtmlStyle',
+                hrefType: inlineCss ? 'inline' : 'rootRelative',
+                to: cssAsset
+            }, 'before', insertionPoint);
+
+            // JS-based font preloading for browsers without <link rel="preload"> support
+            if (inlineCss) {
+                // If the CSS is inlined we can use the font declarations directly to load the fonts
+                htmlAsset.addRelation({
+                    type: 'HtmlScript',
+                    hrefType: 'inline',
+                    to: {
+                        type: 'JavaScript',
+                        text: 'try { document.fonts.forEach(function (f) { f.family.indexOf("__subset") !== -1 && f.load(); }); } catch (e) {}'
+                    }
+                }, 'after', cssRelation).to.minify();
+            } else {
+                // The CSS is external, can't use the font face declarations without waiting for a blocking load.
+                // Go for direct FontFace construction instead
+                const fontFaceContructorCalls = [];
+
+                cssAsset.parseTree.walkAtRules('font-face', rule => {
+                    let name;
+                    let url;
+                    const props = {};
+
+                    rule.walkDecls(({prop, value}) => {
+                        if (prop === 'font-weight') {
+                            value = Number(value) || value;
+                        }
+
+                        if (prop in initialFontPropertyValues) {
+                            if (value !== initialFontPropertyValues[prop]) {
+                                props[prop] = value;
+                            }
+                        }
+
+                        if (prop === 'font-family') {
+                            name = value;
+                        } else if (prop === 'src') {
+                            const fontRelations = cssAsset.outgoingRelations
+                                .filter(relation => relation.node === rule);
+                            const urlStrings = value
+                                .split(/,\s*/)
+                                .filter(entry => entry.startsWith('url('));
+                            const urlValues = urlStrings.map(
+                                (urlString, idx) => urlString.replace(fontRelations[idx].href, '\'" + "/__subfont__".toString("url") + "\'')
+                            );
+                            url = '"' + urlValues.join(', ') + '"';
+                        }
+
+                    });
+
+                    fontFaceContructorCalls.push(
+                        `new FontFace("${name}", ${url}, ${JSON.stringify(props)}).load();`
+                    );
+                });
+
+                const jsPreloadAsset = htmlAsset.addRelation({
+                    type: 'HtmlScript',
+                    hrefType: 'inline',
+                    to: {
+                        type: 'JavaScript',
+                        text: 'try {' + fontFaceContructorCalls.join('') + '} catch (e) {}'
+                    }
+                }, 'before', cssRelation).to.minify();
+
+                for (const [idx, relation] of jsPreloadAsset.outgoingRelations.entries()) {
+                    relation.to = cssAsset.outgoingRelations[idx].to;
+                    relation.hrefType = 'rootRelative';
+                    relation.refreshHref();
+                }
+            }
+        }
+
+        // Async load Google Web Fonts CSS
+
+        const googleFontStylesheets = assetGraph.findAssets({
+            type: 'Css',
+            url: googleFontsCssUrlRegex
+        });
+        for (const googleFontStylesheet of googleFontStylesheets) {
+            for (const googleFontStylesheetRelation of googleFontStylesheet.incomingRelations) {
+                let htmlParents = [googleFontStylesheetRelation.from];
+
+                if (googleFontStylesheetRelation.type === 'CssImport') {
+                    // Gather Html parents. Relevant if we are dealing with CSS @import relations
+                    htmlParents = getParents(assetGraph, googleFontStylesheetRelation.to, {
+                        type: 'Html',
+                        isInline: false,
+                        isLoaded: true
+                    });
+                }
+
+                for (const htmlParent of htmlParents) {
+                    asyncLoadStyleRelationWithFallback(htmlParent, googleFontStylesheetRelation, htmlParent.outgoingRelations.find(
+                        relation => relation.type === 'HtmlStyle'
+                    ));
+                }
+            }
+            googleFontStylesheet.unload();
+        }
+
+
+        // Use subsets in font-family:
+
+        const webfontNameMap = htmlAssetTextsWithProps
+            .map(pageObject => pageObject.fontUsages
+                .filter(fontUsage => fontUsage.subsets)
+                .map(fontUsage => fontUsage.props['font-family'])
+            )
+            .reduce((result, current) => {
+                for (const familyName of current) {
+                    result[familyName] = familyName + '__subset';
+                }
+                return result;
+            }, {});
+
+        // Inject subset font name before original webfont
+        for (const cssAsset of assetGraph.findAssets({type: 'Css', isLoaded: true })) {
+            let changesMade = false;
+            cssAsset.eachRuleInParseTree(cssRule => {
+                if (cssRule.type === 'decl' && cssRule.prop === 'font-family') {
+                    if (cssRule.parent.type === 'rule') {
+                        const fontFamilies = cssListHelpers.splitByCommas(cssRule.value).map(unquote);
+                        const subsetFontFamily = webfontNameMap[fontFamilies[0]];
+                        if (subsetFontFamily && !fontFamilies.includes(subsetFontFamily)) {
+                            cssRule.value = cssQuoteIfNecessary(subsetFontFamily) + ', ' + cssRule.value;
+                            changesMade = true;
+                        }
+                    }
+                }
+            });
+            if (changesMade) {
+                cssAsset.markDirty();
+            }
+        }
+
+        // This is a bit awkward now, but if it's done sooner, it breaks the CSS source regexping:
+        for (const cssAsset of assetGraph.findAssets({ _subsetFontsToBeMinified: true })) {
+            await assetGraph.minifyCss(cssAsset);
+            delete cssAsset._subsetFontsToBeMinified;
+        }
     };
 };

--- a/test/transforms/subsetFonts.js
+++ b/test/transforms/subsetFonts.js
@@ -154,7 +154,7 @@ describe('transforms/subsetFonts', function () {
             httpception();
 
             const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/existing-preload/'});
-
+            assetGraph.on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/));
             await assetGraph.loadAssets('index.html');
             await assetGraph.populate({
                 followRelations: {
@@ -172,6 +172,7 @@ describe('transforms/subsetFonts', function () {
             var infos = [];
 
             const assetGraph = new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/existing-prefetch/'});
+            assetGraph.on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/));
             assetGraph.on('info', function (info) {
                 infos.push(info);
             });
@@ -201,6 +202,7 @@ describe('transforms/subsetFonts', function () {
 
         it('should preload local fonts that it could not subset', function () {
             return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/local-single/'})
+                .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                 .loadAssets('index.html')
                 .populate()
                 .subsetFonts({
@@ -262,6 +264,7 @@ describe('transforms/subsetFonts', function () {
             httpception(defaultGoogleFontSubsetMock);
 
             return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/html-link/'})
+                .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                 .loadAssets('index.html')
                 .populate({
                     followRelations: {
@@ -388,6 +391,7 @@ describe('transforms/subsetFonts', function () {
                 httpception(defaultGoogleFontSubsetMock);
 
                 return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/html-link/'})
+                    .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                     .loadAssets('index.html')
                     .populate({
                         followRelations: {
@@ -492,6 +496,7 @@ describe('transforms/subsetFonts', function () {
             httpception(defaultGoogleFontSubsetMock);
 
             return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/css-import/'})
+                .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                 .loadAssets('index.html')
                 .populate({
                     followRelations: {
@@ -797,6 +802,7 @@ describe('transforms/subsetFonts', function () {
             ]);
 
             return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/multi-family/'})
+                .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                 .loadAssets('index.html')
                 .populate({
                     followRelations: {
@@ -1218,6 +1224,7 @@ describe('transforms/subsetFonts', function () {
             ]);
 
             return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/multi-weight/'})
+                .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                 .loadAssets('index.html')
                 .populate({
                     followRelations: {
@@ -1562,6 +1569,7 @@ describe('transforms/subsetFonts', function () {
                 ]);
 
                 return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/multi-page/'})
+                    .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                     .loadAssets('index.html')
                     .populate({
                         followRelations: {
@@ -1893,6 +1901,7 @@ describe('transforms/subsetFonts', function () {
                 ]);
 
                 return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/multi-page/'})
+                    .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                     .loadAssets('index.html')
                     .populate({
                         followRelations: {
@@ -2088,6 +2097,7 @@ describe('transforms/subsetFonts', function () {
                 httpception(defaultGoogleFontSubsetMock);
 
                 return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/html-link/'})
+                    .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                     .loadAssets('index.html')
                     .populate({
                         followRelations: {
@@ -2108,6 +2118,7 @@ describe('transforms/subsetFonts', function () {
                 httpception(defaultGoogleFontSubsetMock);
 
                 return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/html-link/'})
+                    .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                     .loadAssets('index.html')
                     .populate({
                         followRelations: {
@@ -2129,6 +2140,7 @@ describe('transforms/subsetFonts', function () {
                 httpception(defaultGoogleFontSubsetMock);
 
                 return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/html-link/'})
+                    .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                     .loadAssets('index.html')
                     .populate({
                         followRelations: {
@@ -2222,6 +2234,7 @@ describe('transforms/subsetFonts', function () {
                 ]);
 
                 return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/html-link/'})
+                    .on('warn', warn => expect(warn, 'to satisfy', /Cannot find module/))
                     .loadAssets('index.html')
                     .populate({
                         followRelations: {
@@ -2481,6 +2494,8 @@ describe('transforms/subsetFonts', function () {
             httpception(defaultLocalSubsetMock);
 
             return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/html-link/'})
+                // FIXME: Maybe use a font that's not missing any chars?
+                .on('warn', warn => expect(warn, 'to satisfy', /is missing these characters/))
                 .loadAssets('index.html')
                 .populate({
                     followRelations: {
@@ -2611,6 +2626,8 @@ describe('transforms/subsetFonts', function () {
             httpception(defaultLocalSubsetMock);
 
             return new AssetGraph({root: __dirname + '/../../testdata/transforms/subsetFonts/local-mixed/'})
+                // FIXME: Maybe use a font that's not missing any chars?
+                .on('warn', warn => expect(warn, 'to satisfy', /is missing these characters/))
                 .loadAssets('index.html')
                 .populate({
                     followRelations: {


### PR DESCRIPTION
Some tests broke because there were unhandled `warn` events, which was bypassed because the transform emitted 'warn' directly instead of using `assetGraph.warn`. I've fixed that by expecting the `warn` events in all the tests, but there is a couple that should probably be revisited.