### PR TITLE
Added format-property on Css declaration of CssFontFaceSrc asset config

### DIFF
--- a/lib/assets/Css.js
+++ b/lib/assets/Css.js
@@ -209,13 +209,17 @@ class Css extends Text {
                 for (const childNode of node.nodes) {
                     if (childNode.type === 'decl' && childNode.prop === 'src') {
                         for (const [tokenNumber, href] of AssetGraph.CssFontFaceSrc.prototype.findUrlsInPropertyValue(childNode.value).entries()) {
+                            const match = childNode.value.split(',')[tokenNumber].match(/format\(['"]?([^\)'"]+)['"]?\)/);
+                            const format = match && match[1];
+
                             outgoingRelations.push({
                                 type: 'CssFontFaceSrc',
                                 href,
                                 tokenNumber,
                                 parentNode: parentRuleOrStylesheet,
                                 node,
-                                propertyNode: childNode
+                                propertyNode: childNode,
+                                format // This should probably be chaned to a getter/setter on CssFontFaceSrc in the future
                             });
                         }
                     }

--- a/test/assets/Css.js
+++ b/test/assets/Css.js
@@ -162,4 +162,27 @@ describe('assets/Css', function () {
     it('should not break when attempting to retrieve the text content of an unloaded Css asset', function () {
         expect(new AssetGraph.Css({}).text, 'to be undefined');
     });
+
+    it('should set the format of CssFontFaceSrc if available', () => {
+        const css = new AssetGraph.Css({
+            text: `
+                @font-face {
+                    font-family: 'icomoon';
+                    src: url('icomoon.eot');
+                    src: url('icomoon.eot?#iefix') format('embedded-opentype'),
+                         url('icomoon.woff') format('woff'),
+                         url('icomoon.ttf') format('truetype'),
+                         url('icomoon.svg#icomoon') format('svg');
+                }
+            `
+        });
+
+        expect(css.findOutgoingRelationsInParseTree(), 'to satisfy', [
+            { format: null },
+            { format: 'embedded-opentype' },
+            { format: 'woff' },
+            { format: 'truetype' },
+            { format: 'svg' }
+        ]);
+    });
 });


### PR DESCRIPTION
This is needed for easier access to the author declared format of a font face src file