### PR TITLE
Switch data-url resolving to use data-urls package

### DIFF
--- a/lib/util/resolveDataUrl.js
+++ b/lib/util/resolveDataUrl.js
@@ -1,37 +1,17 @@
+const parseDataUrl = require('data-urls');
+
 module.exports = function resolveDataUrl(dataUrl) {
-  const matchDataUrl = dataUrl.match(
-    /^data:([\w\-+.]+\/[\w\-+.]+)?(?:;charset=([\w/-]+))?(;base64)?,([\u0000-\u007f]*)$/
-  );
-  if (matchDataUrl) {
-    const assetConfig = {};
-    const contentType = matchDataUrl[1] || 'text/plain';
-    const body = matchDataUrl[4];
-    if (matchDataUrl[2]) {
-      assetConfig.encoding = matchDataUrl[2];
-    } else {
-      assetConfig.encoding = 'us-ascii';
-    }
-    if (matchDataUrl[3]) {
-      assetConfig.rawSrc = new Buffer(body, 'base64');
-    } else {
-      const octets = [];
-      for (let i = 0; i < body.length; i += 1) {
-        if (
-          body[i] === '%' &&
-          /^[a-f0-9]$/i.test(body[i + 1]) &&
-          /^[a-f0-9]$/i.test(body[i + 2])
-        ) {
-          octets.push(parseInt(body.substr(i + 1, 2), 16));
-          i += 2;
-        } else {
-          octets.push(body.charCodeAt(i));
-        }
-      }
-      assetConfig.rawSrc = new Buffer(octets);
-    }
-    assetConfig.contentType = assetConfig.contentType || contentType;
+  try {
+    const result = parseDataUrl(dataUrl);
+
+    const assetConfig = {
+      contentType: result.mimeType.essence,
+      encoding: result.mimeType.parameters.get('charset') || 'utf-8',
+      rawSrc: result.body
+    };
+
     return assetConfig;
-  } else {
+  } catch (err) {
     return null;
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "css-font-weight-names": "0.2.1",
     "css-list-helpers": "1.0.1",
     "cssnano": "^4.0.0-rc.2",
+    "data-urls": "^1.0.0",
     "esanimate": "^1.1.0",
     "escodegen": "^1.9.1",
     "esprima": "^4.0.0",

--- a/test/resolvers/data.js
+++ b/test/resolvers/data.js
@@ -42,7 +42,11 @@ describe('resolvers/data', function() {
     );
     expect(assetGraph.findAssets({ type: 'Text' })[3].text, 'to equal', 'ΩδΦ');
 
-    expect(assetGraph.findAssets({ type: 'Svg' })[0].text, 'to equal', '<svg width="10" height="10" viewBox="0 0 20 38" xmlns="http://www.w3.org/2000/svg"><path d="M1.49 4.31l14 16.126.002-2.624-14 16.074-1.314 1.51 3.017 2.626 1.313-1.508 14-16.075 1.142-1.313-1.14-1.313-14-16.125L3.2.18.18 2.8l1.31 1.51z" /><text>🐭</text></svg>');
+    expect(
+      assetGraph.findAssets({ type: 'Svg' })[0].text,
+      'to equal',
+      '<svg width="10" height="10" viewBox="0 0 20 38" xmlns="http://www.w3.org/2000/svg"><path d="M1.49 4.31l14 16.126.002-2.624-14 16.074-1.314 1.51 3.017 2.626 1.313-1.508 14-16.075 1.142-1.313-1.14-1.313-14-16.125L3.2.18.18 2.8l1.31 1.51z" /><text>🐭</text></svg>'
+    );
   });
 
   it('should handle a test case with an unparsable data: url', async function() {

--- a/test/resolvers/data.js
+++ b/test/resolvers/data.js
@@ -11,7 +11,7 @@ describe('resolvers/data', function() {
     });
     await assetGraph.loadAssets('dataUrl.html').populate();
 
-    expect(assetGraph, 'to contain assets', 8);
+    expect(assetGraph, 'to contain assets', 9);
     expect(
       assetGraph.findAssets({ type: 'Html' })[1].parseTree.body.firstChild
         .nodeValue,
@@ -41,6 +41,8 @@ describe('resolvers/data', function() {
       'A brief note'
     );
     expect(assetGraph.findAssets({ type: 'Text' })[3].text, 'to equal', 'ΩδΦ');
+
+    expect(assetGraph.findAssets({ type: 'Svg' })[0].text, 'to equal', '<svg width="10" height="10" viewBox="0 0 20 38" xmlns="http://www.w3.org/2000/svg"><path d="M1.49 4.31l14 16.126.002-2.624-14 16.074-1.314 1.51 3.017 2.626 1.313-1.508 14-16.075 1.142-1.313-1.14-1.313-14-16.125L3.2.18.18 2.8l1.31 1.51z" /><text>🐭</text></svg>');
   });
 
   it('should handle a test case with an unparsable data: url', async function() {

--- a/testdata/resolvers/data/dataUrl.html
+++ b/testdata/resolvers/data/dataUrl.html
@@ -8,5 +8,7 @@
     <a href='data:text/plain;charset=utf-8;base64,SGVsbMO2'>"Hellö", from a Chromium bug report</a>
     <a href='data:,A%20brief%20note'>From rfc 2398 (should fall back to text/plain when the Content-Type is omitted)</a>
     <a href='data:;charset=iso-8859-7,%d9%e4%d6'>Default Content-Type, but charset specified</a>
+
+    <a href='data:image/svg+xml;utf8,<svg width="10" height="10" viewBox="0 0 20 38" xmlns="http://www.w3.org/2000/svg"><path d="M1.49 4.31l14 16.126.002-2.624-14 16.074-1.314 1.51 3.017 2.626 1.313-1.508 14-16.075 1.142-1.313-1.14-1.313-14-16.125L3.2.18.18 2.8l1.31 1.51z" /><text>🐭</text></svg>'>SVG with no 'charset=' to define encoding</a>
 </body>
 </html>


### PR DESCRIPTION
Example of this svg data-url inlining has been found on https://css-tricks.com/probably-dont-base64-svg/ and in the wild on https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css

The url `data:image/svg+xml;utf8,<svg width="10" height="10" viewBox="0 0 20 38" xmlns="http://www.w3.org/2000/svg"><path d="M1.49 4.31l14 16.126.002-2.624-14 16.074-1.314 1.51 3.017 2.626 1.313-1.508 14-16.075 1.142-1.313-1.14-1.313-14-16.125L3.2.18.18 2.8l1.31 1.51z" fill-rule="evenodd" fill="%231D3657" /></svg>` caused assetgraph to emit a warning: `Cannot read property 'url' of undefined`

The update makes Assetgraph more resilient and parses that url, without any defined encoding, but the updated default encoding in this PR makes the example work. Utf-8 seems to be a sane choice for a default fallback, so hopefully this will improve the behavior

Closes #765 