### PR TITLE
Implement lightweight Asset#load({metadataOnly: true})

### DIFF
--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -388,34 +388,34 @@ class Asset extends EventEmitter {
         const protocol = url.substr(0, url.indexOf(':')).toLowerCase();
         if (protocol === 'file') {
           const pathname = urlTools.fileUrlToFsPath(url);
-          try {
-            if (metadataOnly) {
-              const stats = await fs.statAsync(pathname);
-              if (stats.isDirectory()) {
-                this.fileRedirectTargetUrl = urlTools.fsFilePathToFileUrl(
-                  pathname.replace(/(\/)?$/, '/index.html')
-                );
-                // Make believe it's loaded:
-                this._rawSrc = new Buffer([]);
-              }
-            } else {
-              this._rawSrc = await fs.readFileAsync(pathname);
-              this._updateRawSrcAndLastKnownByteLength(this._rawSrc);
-            }
-          } catch (err) {
-            if (
-              err.code === 'EISDIR' ||
-              err.errno === constants.EISDIR ||
-              err.code === 'EINVAL' ||
-              err.errno === constants.EINVAL
-            ) {
+          if (metadataOnly) {
+            const stats = await fs.statAsync(pathname);
+            if (stats.isDirectory()) {
               this.fileRedirectTargetUrl = urlTools.fsFilePathToFileUrl(
                 pathname.replace(/(\/)?$/, '/index.html')
               );
               // Make believe it's loaded:
               this._rawSrc = new Buffer([]);
-            } else {
-              throw err;
+            }
+          } else {
+            try {
+              this._rawSrc = await fs.readFileAsync(pathname);
+              this._updateRawSrcAndLastKnownByteLength(this._rawSrc);
+            } catch (err) {
+              if (
+                err.code === 'EISDIR' ||
+                err.errno === constants.EISDIR ||
+                err.code === 'EINVAL' ||
+                err.errno === constants.EINVAL
+              ) {
+                this.fileRedirectTargetUrl = urlTools.fsFilePathToFileUrl(
+                  pathname.replace(/(\/)?$/, '/index.html')
+                );
+                // Make believe it's loaded:
+                this._rawSrc = new Buffer([]);
+              } else {
+                throw err;
+              }
             }
           }
         } else if (protocol === 'http' || protocol === 'https') {

--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -377,7 +377,7 @@ class Asset extends EventEmitter {
    * @async
    * @return {Promise<Asset>} The loaded Asset
    */
-  async load() {
+  async load({ metadataOnly = false } = {}) {
     try {
       if (!this.isLoaded) {
         if (!this.url) {
@@ -389,8 +389,19 @@ class Asset extends EventEmitter {
         if (protocol === 'file') {
           const pathname = urlTools.fileUrlToFsPath(url);
           try {
-            this._rawSrc = await fs.readFileAsync(pathname);
-            this._updateRawSrcAndLastKnownByteLength(this._rawSrc);
+            if (metadataOnly) {
+              const stats = await fs.statAsync(pathname);
+              if (stats.isDirectory()) {
+                this.fileRedirectTargetUrl = urlTools.fsFilePathToFileUrl(
+                  pathname.replace(/(\/)?$/, '/index.html')
+                );
+                // Make believe it's loaded:
+                this._rawSrc = new Buffer([]);
+              }
+            } else {
+              this._rawSrc = await fs.readFileAsync(pathname);
+              this._updateRawSrcAndLastKnownByteLength(this._rawSrc);
+            }
           } catch (err) {
             if (
               err.code === 'EISDIR' ||
@@ -408,12 +419,17 @@ class Asset extends EventEmitter {
             }
           }
         } else if (protocol === 'http' || protocol === 'https') {
-          const response = await this.assetGraph.teepee.request(
-            _.defaults({ url, json: false }, this.assetGraph.requestOptions)
-          );
+          const response = await this.assetGraph.teepee.request({
+            ...this.assetGraph.requestOptions,
+            method: metadataOnly ? 'HEAD' : 'GET',
+            url,
+            json: false
+          });
           this.statusCode = response.statusCode;
-          this._rawSrc = response.body;
-          this._updateRawSrcAndLastKnownByteLength(this._rawSrc);
+          if (!metadataOnly) {
+            this._rawSrc = response.body;
+            this._updateRawSrcAndLastKnownByteLength(this._rawSrc);
+          }
           if (response.headers.location) {
             this.location = response.headers.location;
           }

--- a/test/assets/Asset.js
+++ b/test/assets/Asset.js
@@ -322,6 +322,125 @@ describe('assets/Asset', function() {
       });
       await assetGraph.populate();
     });
+
+    describe('with metadataOnly:true', function() {
+      describe('with a file: asset', function() {
+        it('should succeed if the file does exist, but not populate asset.text or asset.rawSrc', async function() {
+          const assetGraph = new AssetGraph({
+            root: pathModule.resolve(
+              __dirname,
+              '../../testdata/assets/Asset/metadataOnly/'
+            )
+          });
+          const asset = assetGraph.addAsset({
+            url: 'index.html'
+          });
+          await asset.load({ metadataOnly: true });
+          expect(asset.isLoaded, 'to be false');
+          expect(asset._text, 'to be undefined');
+          expect(asset._rawSrc, 'to be undefined');
+        });
+
+        it('should return a rejected promise if the file does not exist', async function() {
+          const assetGraph = new AssetGraph({
+            root: pathModule.resolve(
+              __dirname,
+              '../../testdata/assets/Asset/metadataOnly/'
+            )
+          });
+          const asset = assetGraph.addAsset({
+            url: 'foo.html'
+          });
+          await expect(
+            asset.load({ metadataOnly: true }),
+            'to be rejected with',
+            /ENOENT/
+          );
+        });
+
+        it('should materialize a FileRedirect relation and make believe the asset is loaded', async function() {
+          const assetGraph = new AssetGraph({
+            root: pathModule.resolve(
+              __dirname,
+              '../../testdata/assets/Asset/metadataOnly/'
+            )
+          });
+          const warnSpy = sinon.spy().named('warn');
+          assetGraph.on('warn', warnSpy);
+
+          const asset = assetGraph.addAsset({
+            url: 'subdir'
+          });
+          await asset.load({ metadataOnly: true });
+          expect(asset.outgoingRelations, 'to satisfy', [
+            {
+              type: 'FileRedirect',
+              to: {
+                url: `${assetGraph.root}subdir/index.html`
+              }
+            }
+          ]);
+          expect(asset.rawSrc, 'to equal', new Buffer([]));
+        });
+      });
+
+      describe('with an http(s): asset', function() {
+        it('should issue a HEAD request', async function() {
+          const asset = new AssetGraph().addAsset({
+            url: 'https://www.example.com/'
+          });
+
+          expect(asset.type, 'to be undefined');
+
+          httpception({
+            request: 'HEAD https://www.example.com/',
+            response: {
+              headers: {
+                'Content-Type': 'text/html; charset=iso-8859-1'
+              }
+            }
+          });
+
+          await asset.load({ metadataOnly: true });
+
+          expect(asset.type, 'to equal', 'Html');
+          expect(asset.contentType, 'to equal', 'text/html');
+          expect(asset.isLoaded, 'to be false');
+          expect(asset._encoding, 'to equal', 'iso-8859-1');
+          expect(asset._text, 'to be undefined');
+          expect(asset._rawSrc, 'to be undefined');
+        });
+
+        it('should materialize a HttpRedirect relation', async function() {
+          const asset = new AssetGraph().addAsset({
+            url: 'https://www.example.com/'
+          });
+
+          expect(asset.type, 'to be undefined');
+
+          httpception({
+            request: 'HEAD https://www.example.com/',
+            response: {
+              statusCode: 302,
+              headers: {
+                Location: 'https://somewhereelse.com/'
+              }
+            }
+          });
+
+          await asset.load({ metadataOnly: true });
+
+          expect(asset.outgoingRelations, 'to satisfy', [
+            {
+              type: 'HttpRedirect',
+              to: {
+                url: 'https://somewhereelse.com/'
+              }
+            }
+          ]);
+        });
+      });
+    });
   });
 
   describe('#addRelation()', function() {

--- a/testdata/assets/Asset/metadataOnly/index.html
+++ b/testdata/assets/Asset/metadataOnly/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body></body>
+</html>

--- a/testdata/assets/Asset/metadataOnly/subdir/index.html
+++ b/testdata/assets/Asset/metadataOnly/subdir/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body></body>
+</html>


### PR DESCRIPTION
Runs `fs.stat` or issues a `HEAD` request instead of loading and parsing the actual body.

`FileRedirect` and `HttpRedirect` relations will also be populated, and for http `Content-Type` warnings will be emitted.

This could be useful in hyperlink for avoiding a second pass with hand-rolled `HEAD` requests.