### PR TITLE
Do not upgrade the type of an asset loaded via http unless the Content-Type matches

### DIFF
--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -79,6 +79,9 @@ class Asset extends EventEmitter {
     if (typeof config.lastKnownByteLength === 'number') {
       this._lastKnownByteLength = config.lastKnownByteLength;
     }
+    if (config.type) {
+      this._type = config.type;
+    }
     if (config.rawSrc) {
       this._updateRawSrcAndLastKnownByteLength(config.rawSrc);
     }
@@ -263,6 +266,14 @@ class Asset extends EventEmitter {
 
   _tryUpgrade(type, incomingRelation) {
     type = type || this._inferType(incomingRelation);
+    if (
+      !this.isLoaded ||
+      (/^https?:/.test(this.protocol) &&
+        !this.hasOwnProperty('contentType') &&
+        !this._type)
+    ) {
+      return;
+    }
     const Class = AssetGraph[type];
     if (Class) {
       // Allow upgrading from Image to Svg, or from Font to Svg:
@@ -281,8 +292,22 @@ class Asset extends EventEmitter {
           }
           superclass = Object.getPrototypeOf(superclass);
         }
-        if (this.location === undefined && !this._isCompatibleWith(type)) {
-          this._warnIncompatibleTypes([this.type, type]);
+        if (this.location === undefined) {
+          if (!this._isCompatibleWith(type)) {
+            this._warnIncompatibleTypes([this.type, type]);
+          } else {
+            const incompatibleIncomingTargetTypes = this.incomingRelations.filter(
+              incomingRelation =>
+                incomingRelation.targetType &&
+                !this._isCompatibleWith(incomingRelation.targetType)
+            );
+            if (incompatibleIncomingTargetTypes.length) {
+              this._warnIncompatibleTypes([
+                this.type,
+                ...incompatibleIncomingTargetTypes.map(i => i.targetType)
+              ]);
+            }
+          }
         }
       }
     }

--- a/lib/relations/HtmlPreloadLink.js
+++ b/lib/relations/HtmlPreloadLink.js
@@ -6,16 +6,6 @@ const HtmlResourceHint = require('./HtmlResourceHint');
  * Implementation of http://w3c.github.io/preload/#dfn-preload
  */
 class HtmlPreloadLink extends HtmlResourceHint {
-  get contentType() {
-    if (typeof this._contentType === 'undefined') {
-      const contentType = this.to.contentType;
-      if (contentType && contentType !== 'application/octet-stream') {
-        this._contentType = contentType;
-      }
-    }
-    return this._contentType;
-  }
-
   attach(position, adjacentRelation) {
     this.node = this.from.parseTree.createElement('link');
     this.node.setAttribute('rel', 'preload');

--- a/lib/relations/HtmlResourceHint.js
+++ b/lib/relations/HtmlResourceHint.js
@@ -28,11 +28,14 @@ class HtmlResourceHint extends HtmlRelation {
     if ('_contentType' in this) {
       return this._contentType;
     } else {
-      if (this.to.contentType) {
+      if (
+        this.to.contentType &&
+        this.to.contentType !== 'application/octet-stream'
+      ) {
         this._contentType = this.to.contentType;
       }
 
-      // Let's see if we can do slihtly better by extension
+      // Let's see if we can do slightly better by extension
       if (
         !this._contentType ||
         this._contentType === 'application/octet-stream'
@@ -41,9 +44,10 @@ class HtmlResourceHint extends HtmlRelation {
         const extensionToTypeMap = {
           woff: 'font/woff',
           woff2: 'font/woff2',
-          ttf: 'application/x-font-ttf',
+          ttf: 'font/ttf',
           eot: 'application/vnd.ms-fontobject',
-          otf: 'font/otf'
+          otf: 'font/otf',
+          js: 'application/javascript'
         };
 
         const betterContentType = extensionToTypeMap[getExtension(this.to.url)];

--- a/test/resolvers/http.js
+++ b/test/resolvers/http.js
@@ -106,7 +106,10 @@ describe('resolvers/http', function() {
     await assetGraph.loadAssets('/foo.html');
     await assetGraph.populate();
 
-    expect(assetGraph, 'to contain asset', { type: 'Html', text: html });
+    expect(assetGraph, 'to contain asset', {
+      type: 'Html',
+      url: 'http://example.com/foo.html'
+    });
     expect(warnSpy, 'to have calls satisfying', () => {
       warnSpy('Invalid Content-Type response header received: &');
     });

--- a/test/transforms/minifySvgAssetsWithSvgo.js
+++ b/test/transforms/minifySvgAssetsWithSvgo.js
@@ -51,6 +51,7 @@ describe('transforms/minifySvgAssetsWithSvgo', function() {
   it('should not throw away too much precision', async function() {
     const assetGraph = new AssetGraph();
     await assetGraph.loadAssets({
+      type: 'Svg',
       url: 'http://example.com/dot.svg',
       text:
         '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">\n' +


### PR DESCRIPTION
Previously we would also upgrade based on the file extension or incoming relations, causing contradictions down the line.

Addresses Munter/hyperlink#145