### PR TITLE
Remove local font references in generated subset font declaration

### DIFF
--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -227,7 +227,6 @@ function getSubsetPromiseId(fontUsage, format) {
   return [fontUsage.text, fontUsage.fontUrl, format].join('\x1d');
 }
 
-const localRegex = /(?:local\(')(.+)(?:'\))/;
 async function getSubsetsForFontUsage(
   assetGraph,
   htmlAssetTextsWithProps,
@@ -255,21 +254,6 @@ async function getSubsetsForFontUsage(
 
       if (allFonts.indexOf(fontUsage.fontUrl) === -1) {
         allFonts.push(fontUsage.fontUrl);
-      }
-
-      const fontRelation = assetGraph.findRelations({
-        type: 'CssFontFaceSrc',
-        to: { url: fontUsage.fontUrl }
-      })[0];
-
-      if (fontRelation) {
-        fontUsage.localFamilyNames = fontRelation.propertyNode.value
-          .split(',')
-          .map(str => {
-            const match = str.match(localRegex);
-            return match && match[1];
-          })
-          .filter(str => str);
       }
     }
   }
@@ -432,13 +416,8 @@ const getFontFaceForFontUsage = memoizeSync(
           }
 
           if (prop === 'src') {
-            value = (fontUsage.localFamilyNames || [])
-              .map(name => "local('" + name + "')")
-              .concat(
-                subsets.map(
-                  subset => `url(${subset.url}) format('${subset.format}')`
-                )
-              )
+            value = subsets
+              .map(subset => `url(${subset.url}) format('${subset.format}')`)
               .join(', ');
           }
 
@@ -1096,9 +1075,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
     return {
       fontInfo: htmlAssetTextsWithProps.map(({ fontUsages, htmlAsset }) => ({
         htmlAsset: htmlAsset.urlOrDescription,
-        fontUsages: fontUsages.map(fontUsage =>
-          _.omit(fontUsage, 'subsets', 'localFamilyNames')
-        )
+        fontUsages: fontUsages.map(fontUsage => _.omit(fontUsage, 'subsets'))
       }))
     };
   };


### PR DESCRIPTION
I don't really trust locally installed fonts to be the exact same as the webfont a page uses. Bram doesn't either: https://www.bramstein.com/writing/web-font-anti-patterns-local-fonts.html

Since subfont already speeds things up so much I'd rather go for the guarantee of gettign the right font than going for speed and uncertainty