### PR TITLE
Trace custom CSS properties

### DIFF
--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -10,6 +10,10 @@ const AssetGraph = require('../../');
 const getTextByFontProperties = require('../util/fonts/getTextByFontProperties');
 const getGoogleIdForFontProps = require('../util/fonts/getGoogleIdForFontProps');
 const snapToAvailableFontProperties = require('../util/fonts/snapToAvailableFontProperties');
+const findCustomPropertyDefinitions = require('../util/fonts/findCustomPropertyDefinitions');
+const extractReferencedCustomPropertyNames = require('../util/fonts/extractReferencedCustomPropertyNames');
+const injectSubsetDefinitions = require('../util/fonts/injectSubsetDefinitions');
+const cssFontParser = require('css-font-parser');
 const cssListHelpers = require('css-list-helpers');
 const LinesAndColumns = require('lines-and-columns').default;
 const fontkit = require('fontkit');
@@ -1016,15 +1020,44 @@ These glyphs are used on your site, but they don't exist in the font you applied
         return result;
       }, {});
 
+    let customPropertyDefinitions; // Avoid computing this unless necessary
     // Inject subset font name before original webfont
-    for (const cssAsset of assetGraph.findAssets({
+    const cssAssets = assetGraph.findAssets({
       type: 'Css',
       isLoaded: true
-    })) {
+    });
+    let changesMadeToCustomPropertyDefinitions = false;
+    for (const cssAsset of cssAssets) {
       let changesMade = false;
       cssAsset.eachRuleInParseTree(cssRule => {
         if (cssRule.parent.type === 'rule' && cssRule.type === 'decl') {
-          if (cssRule.prop === 'font-family') {
+          if (
+            (cssRule.prop === 'font' || cssRule.prop === 'font-family') &&
+            cssRule.value.includes('var(')
+          ) {
+            if (!customPropertyDefinitions) {
+              customPropertyDefinitions = findCustomPropertyDefinitions(
+                cssAssets
+              );
+            }
+            for (const customPropertyName of extractReferencedCustomPropertyNames(
+              cssRule.value
+            )) {
+              for (const relatedCssRule of [
+                cssRule,
+                ...(customPropertyDefinitions[customPropertyName] || [])
+              ]) {
+                const modifiedValue = injectSubsetDefinitions(
+                  relatedCssRule.value,
+                  webfontNameMap
+                );
+                if (modifiedValue !== relatedCssRule.value) {
+                  relatedCssRule.value = modifiedValue;
+                  changesMadeToCustomPropertyDefinitions = true;
+                }
+              }
+            }
+          } else if (cssRule.prop === 'font-family') {
             const fontFamilies = cssListHelpers
               .splitByCommas(cssRule.value)
               .map(unquote);
@@ -1035,7 +1068,6 @@ These glyphs are used on your site, but they don't exist in the font you applied
               changesMade = true;
             }
           } else if (cssRule.prop === 'font') {
-            const cssFontParser = require('css-font-parser');
             const fontProperties = cssFontParser(cssRule.value);
             const fontFamilies =
               fontProperties && fontProperties['font-family'].map(unquote);
@@ -1061,6 +1093,13 @@ These glyphs are used on your site, but they don't exist in the font you applied
         }
       });
       if (changesMade) {
+        cssAsset.markDirty();
+      }
+    }
+
+    // This is a bit crude, could be more efficient if we tracked the containing asset in findCustomPropertyDefinitions
+    if (changesMadeToCustomPropertyDefinitions) {
+      for (const cssAsset of cssAssets) {
         cssAsset.markDirty();
       }
     }

--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -11,7 +11,6 @@ const getTextByFontProperties = require('../util/fonts/getTextByFontProperties')
 const getGoogleIdForFontProps = require('../util/fonts/getGoogleIdForFontProps');
 const snapToAvailableFontProperties = require('../util/fonts/snapToAvailableFontProperties');
 const cssListHelpers = require('css-list-helpers');
-const cssFontWeightNames = require('css-font-weight-names');
 const LinesAndColumns = require('lines-and-columns').default;
 const fontkit = require('fontkit');
 

--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -16,6 +16,7 @@ const LinesAndColumns = require('lines-and-columns').default;
 const fontkit = require('fontkit');
 
 const unquote = require('../util/fonts/unquote');
+const normalizeFontWeight = require('../util/fonts/normalizeFontWeight');
 const getCssRulesByProperty = require('../util/fonts/getCssRulesByProperty');
 
 const googleFontsCssUrlRegex = /^(?:https?:)?\/\/fonts\.googleapis\.com\/css/;
@@ -532,9 +533,9 @@ module.exports = ({
 
               node.walkDecls(declaration => {
                 if (declaration.prop === 'font-weight') {
-                  fontFaceDeclaration[declaration.prop] =
-                    cssFontWeightNames[declaration.value] ||
-                    parseInt(declaration.value, 10);
+                  fontFaceDeclaration[declaration.prop] = normalizeFontWeight(
+                    declaration.value
+                  );
                 } else {
                   fontFaceDeclaration[declaration.prop] = unquote(
                     declaration.value
@@ -809,7 +810,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
               unquote(nameProps[0])
                 .replace(/__subset$/, '')
                 .replace(/ /g, '_') + '-',
-              nameProps[1],
+              normalizeFontWeight(nameProps[1]),
               nameProps[2] === 'italic' ? 'i' : ''
             ].join('');
 
@@ -897,7 +898,7 @@ These glyphs are used on your site, but they don't exist in the font you applied
 
           rule.walkDecls(({ prop, value }) => {
             if (prop === 'font-weight') {
-              value = Number(value) || value;
+              value = normalizeFontWeight(value);
             }
 
             if (prop in initialFontPropertyValues) {

--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -20,11 +20,11 @@ const getCssRulesByProperty = require('../util/fonts/getCssRulesByProperty');
 
 const googleFontsCssUrlRegex = /^(?:https?:)?\/\/fonts\.googleapis\.com\/css/;
 
-const initialFontPropertyValues = {
-  'font-style': 'normal',
-  'font-weight': 400,
-  'font-stretch': 'normal'
-};
+const initialValueByProp = _.pick(require('../util/fonts/initialValueByProp'), [
+  'font-style',
+  'font-weight',
+  'font-stretch'
+]);
 
 function cssQuoteIfNecessary(value) {
   if (/^\w+$/.test(value)) {
@@ -733,9 +733,9 @@ These glyphs are used on your site, but they don't exist in the font you applied
             '.eot': 'embedded-opentype'
           };
           const name = fontUsage.props['font-family'];
-          const props = Object.keys(initialFontPropertyValues).reduce(
+          const props = Object.keys(initialValueByProp).reduce(
             (result, prop) => {
-              if (fontUsage.props[prop] !== initialFontPropertyValues[prop]) {
+              if (fontUsage.props[prop] !== initialValueByProp[prop]) {
                 result[prop] = fontUsage.props[prop];
               }
               return result;
@@ -900,8 +900,8 @@ These glyphs are used on your site, but they don't exist in the font you applied
               value = normalizeFontWeight(value);
             }
 
-            if (prop in initialFontPropertyValues) {
-              if (value !== initialFontPropertyValues[prop]) {
+            if (prop in initialValueByProp) {
+              if (value !== initialValueByProp[prop]) {
                 props[prop] = value;
               }
             }

--- a/lib/util/cssPseudoClassRegExp.js
+++ b/lib/util/cssPseudoClassRegExp.js
@@ -35,7 +35,7 @@ const pseudoClasses = [
   'read-write',
   // 'required',
   // 'right',
-  'root',
+  // 'root', // It's not practical to treat :root as a pseudo class as it always matches the root element
   'scope',
   'target',
   'valid',

--- a/lib/util/fonts/chromium-default-stylesheet.css
+++ b/lib/util/fonts/chromium-default-stylesheet.css
@@ -328,7 +328,7 @@ input, textarea, keygen, select, button, meter, progress {
 }
 input, textarea, keygen, select, button {
     margin: 0__qem;
-    font: -webkit-small-control;
+    /* font: -webkit-small-control; */
     text-rendering: auto; /* FIXME: Remove when tabs work with optimizeLegibility. */
     color: initial;
     letter-spacing: normal;

--- a/lib/util/fonts/expandCustomProperties.js
+++ b/lib/util/fonts/expandCustomProperties.js
@@ -28,6 +28,7 @@ function expandCustomProperties(computedStyle) {
             ] = hypotheticalValuesByCustomProp[customPropertyName] ||
               computedStyle[customPropertyName] || [
                 {
+                  prop: hypotheticalValue.prop,
                   value: undefined,
                   predicates: hypotheticalValue.predicates
                 }

--- a/lib/util/fonts/expandCustomProperties.js
+++ b/lib/util/fonts/expandCustomProperties.js
@@ -3,97 +3,105 @@ const expandPermutations = require('../expandPermutations');
 const combinePredicates = require('./combinePredicates');
 const initialValueByProp = require('./initialValueByProp');
 
-function expandCustomProperties(hypotheticalValues, prop, traceProp) {
-  let hasCopied = false;
-  const hypotheticalValuesByCustomProp = {};
-  for (let i = 0; i < hypotheticalValues.length; i += 1) {
-    const hypotheticalValue = hypotheticalValues[i];
-    // Quick test for whether the value contains custom properties:
-    if (/var\(--[^)]+\)/.test(hypotheticalValue.value)) {
-      const tokens = postCssValuesParser(hypotheticalValue.value).tokens;
-      const seenCustomProperties = new Set();
-      for (let j = 0; j < tokens.length - 3; j += 1) {
-        if (
-          tokens[j][1] === 'var' &&
-          tokens[j + 1][0] === '(' &&
-          tokens[j + 2][1] === '--' &&
-          tokens[j + 3][0] === 'word'
-        ) {
-          const customPropertyName = '--' + tokens[j + 3][1];
-          hypotheticalValuesByCustomProp[
-            customPropertyName
-          ] = hypotheticalValuesByCustomProp[customPropertyName] ||
-            traceProp(customPropertyName, 0, hypotheticalValue.predicates) || [
-              {
-                value: undefined,
-                predicates: hypotheticalValue.predicates
-              }
-            ];
-          seenCustomProperties.add(customPropertyName);
-        }
-      }
-      if (seenCustomProperties.size === 0) {
-        // The quick regexp test was a false positive
-        continue;
-      }
-      const replacementHypotheticalValues = [];
-      for (const permutation of expandPermutations(
-        hypotheticalValuesByCustomProp
-      )) {
-        const predicates = combinePredicates([
-          hypotheticalValue.predicates,
-          ...Object.values(permutation).map(v => v.predicates)
-        ]);
-        let value = '';
-        for (let j = 0; j < tokens.length; j += 1) {
+function expandCustomProperties(computedStyle) {
+  let hasCopiedOuter = false;
+  for (const prop of Object.keys(computedStyle)) {
+    let hasCopiedInner = false;
+    let hypotheticalValues = computedStyle[prop];
+    const hypotheticalValuesByCustomProp = {};
+    for (let i = 0; i < hypotheticalValues.length; i += 1) {
+      const hypotheticalValue = hypotheticalValues[i];
+      // Quick test for whether the value contains custom properties:
+      if (/var\(--[^)]+\)/.test(hypotheticalValue.value)) {
+        const tokens = postCssValuesParser(hypotheticalValue.value).tokens;
+        const seenCustomProperties = new Set();
+        for (let j = 0; j < tokens.length - 3; j += 1) {
           if (
             tokens[j][1] === 'var' &&
             tokens[j + 1][0] === '(' &&
             tokens[j + 2][1] === '--' &&
             tokens[j + 3][0] === 'word'
           ) {
-            const customPropertyName = `--${tokens[j + 3][1]}`;
-            if (
-              permutation[customPropertyName] &&
-              permutation[customPropertyName].value
-            ) {
-              value += permutation[customPropertyName].value;
-              while (j < tokens.length && tokens[j][0] !== ')') {
-                j += 1;
-              }
-            } else if (j < tokens.length && tokens[j + 4][0] === 'comma') {
-              // Undefined property, but there is a default value
-              j += 5;
-              while (j < tokens.length && tokens[j][0] === 'space') {
-                j += 1;
-              }
-              while (j < tokens.length && tokens[j][0] !== ')') {
-                value += tokens[j][1];
-                j += 1;
-              }
-            } else {
-              // Reference to an undefined custom property and no default value
-              value = initialValueByProp[prop];
-              break;
-            }
-          } else {
-            value += tokens[j][1];
+            const customPropertyName = '--' + tokens[j + 3][1];
+            hypotheticalValuesByCustomProp[
+              customPropertyName
+            ] = hypotheticalValuesByCustomProp[customPropertyName] ||
+              computedStyle[customPropertyName] || [
+                {
+                  value: undefined,
+                  predicates: hypotheticalValue.predicates
+                }
+              ];
+            seenCustomProperties.add(customPropertyName);
           }
         }
-        replacementHypotheticalValues.push({
-          predicates,
-          value
-        });
+        if (seenCustomProperties.size === 0) {
+          // The quick regexp test was a false positive
+          continue;
+        }
+        const replacementHypotheticalValues = [];
+        for (const permutation of expandPermutations(
+          hypotheticalValuesByCustomProp
+        )) {
+          const predicates = combinePredicates([
+            hypotheticalValue.predicates,
+            ...Object.values(permutation).map(v => v.predicates)
+          ]);
+          let value = '';
+          for (let j = 0; j < tokens.length; j += 1) {
+            if (
+              tokens[j][1] === 'var' &&
+              tokens[j + 1][0] === '(' &&
+              tokens[j + 2][1] === '--' &&
+              tokens[j + 3][0] === 'word'
+            ) {
+              const customPropertyName = `--${tokens[j + 3][1]}`;
+              if (
+                permutation[customPropertyName] &&
+                permutation[customPropertyName].value
+              ) {
+                value += permutation[customPropertyName].value;
+                while (j < tokens.length && tokens[j][0] !== ')') {
+                  j += 1;
+                }
+              } else if (j < tokens.length && tokens[j + 4][0] === 'comma') {
+                // Undefined property, but there is a default value
+                j += 5;
+                while (j < tokens.length && tokens[j][0] === 'space') {
+                  j += 1;
+                }
+                while (j < tokens.length && tokens[j][0] !== ')') {
+                  value += tokens[j][1];
+                  j += 1;
+                }
+              } else {
+                // Reference to an undefined custom property and no default value
+                value = initialValueByProp[prop];
+                break;
+              }
+            } else {
+              value += tokens[j][1];
+            }
+          }
+          replacementHypotheticalValues.push({
+            predicates,
+            value
+          });
+        }
+        if (!hasCopiedOuter) {
+          computedStyle = { ...computedStyle };
+          hasCopiedOuter = true;
+        }
+        if (!hasCopiedInner) {
+          hypotheticalValues = computedStyle[prop] = [...hypotheticalValues];
+          hasCopiedInner = true;
+        }
+        hypotheticalValues.splice(i, 1, ...replacementHypotheticalValues);
+        i -= 1;
       }
-      if (!hasCopied) {
-        hypotheticalValues = [...hypotheticalValues];
-        hasCopied = true;
-      }
-      hypotheticalValues.splice(i, 1, ...replacementHypotheticalValues);
-      i -= 1;
     }
   }
-  return hypotheticalValues;
+  return computedStyle;
 }
 
 module.exports = expandCustomProperties;

--- a/lib/util/fonts/expandCustomProperties.js
+++ b/lib/util/fonts/expandCustomProperties.js
@@ -48,6 +48,10 @@ function expandCustomProperties(computedStyle) {
             hypotheticalValue.predicates,
             ...Object.values(permutation).map(v => v.predicates)
           ]);
+          if (!predicates) {
+            // Skip value because of an impossible combination of predicates
+            continue;
+          }
           let value = '';
           for (let j = 0; j < tokens.length; j += 1) {
             if (

--- a/lib/util/fonts/expandCustomProperties.js
+++ b/lib/util/fonts/expandCustomProperties.js
@@ -1,0 +1,99 @@
+const postCssValuesParser = require('postcss-values-parser');
+const expandPermutations = require('../expandPermutations');
+const combinePredicates = require('./combinePredicates');
+const initialValueByProp = require('./initialValueByProp');
+
+function expandCustomProperties(hypotheticalValues, prop, traceProp) {
+  let hasCopied = false;
+  const hypotheticalValuesByCustomProp = {};
+  for (let i = 0; i < hypotheticalValues.length; i += 1) {
+    const hypotheticalValue = hypotheticalValues[i];
+    // Quick test for whether the value contains custom properties:
+    if (/var\(--[^)]+\)/.test(hypotheticalValue.value)) {
+      const tokens = postCssValuesParser(hypotheticalValue.value).tokens;
+      const seenCustomProperties = new Set();
+      for (let j = 0; j < tokens.length - 3; j += 1) {
+        if (
+          tokens[j][1] === 'var' &&
+          tokens[j + 1][0] === '(' &&
+          tokens[j + 2][1] === '--' &&
+          tokens[j + 3][0] === 'word'
+        ) {
+          const customPropertyName = '--' + tokens[j + 3][1];
+          hypotheticalValuesByCustomProp[
+            customPropertyName
+          ] = hypotheticalValuesByCustomProp[customPropertyName] ||
+            traceProp(customPropertyName, 0, hypotheticalValue.predicates) || [
+              {
+                value: undefined,
+                predicates: hypotheticalValue.predicates
+              }
+            ];
+          seenCustomProperties.add(customPropertyName);
+        }
+      }
+      if (seenCustomProperties.size === 0) {
+        // The quick regexp test was a false positive
+        continue;
+      }
+      const replacementHypotheticalValues = [];
+      for (const permutation of expandPermutations(
+        hypotheticalValuesByCustomProp
+      )) {
+        const predicates = combinePredicates([
+          hypotheticalValue.predicates,
+          ...Object.values(permutation).map(v => v.predicates)
+        ]);
+        let value = '';
+        for (let j = 0; j < tokens.length; j += 1) {
+          if (
+            tokens[j][1] === 'var' &&
+            tokens[j + 1][0] === '(' &&
+            tokens[j + 2][1] === '--' &&
+            tokens[j + 3][0] === 'word'
+          ) {
+            const customPropertyName = `--${tokens[j + 3][1]}`;
+            if (
+              permutation[customPropertyName] &&
+              permutation[customPropertyName].value
+            ) {
+              value += permutation[customPropertyName].value;
+              while (j < tokens.length && tokens[j][0] !== ')') {
+                j += 1;
+              }
+            } else if (j < tokens.length && tokens[j + 4][0] === 'comma') {
+              // Undefined property, but there is a default value
+              j += 5;
+              while (j < tokens.length && tokens[j][0] === 'space') {
+                j += 1;
+              }
+              while (j < tokens.length && tokens[j][0] !== ')') {
+                value += tokens[j][1];
+                j += 1;
+              }
+            } else {
+              // Reference to an undefined custom property and no default value
+              value = initialValueByProp[prop];
+              break;
+            }
+          } else {
+            value += tokens[j][1];
+          }
+        }
+        replacementHypotheticalValues.push({
+          predicates,
+          value
+        });
+      }
+      if (!hasCopied) {
+        hypotheticalValues = [...hypotheticalValues];
+        hasCopied = true;
+      }
+      hypotheticalValues.splice(i, 1, ...replacementHypotheticalValues);
+      i -= 1;
+    }
+  }
+  return hypotheticalValues;
+}
+
+module.exports = expandCustomProperties;

--- a/lib/util/fonts/expandCustomProperties.js
+++ b/lib/util/fonts/expandCustomProperties.js
@@ -58,7 +58,11 @@ function expandCustomProperties(computedStyle) {
               const customPropertyName = `--${tokens[j + 3][1]}`;
               if (
                 permutation[customPropertyName] &&
-                permutation[customPropertyName].value
+                permutation[customPropertyName].value &&
+                (!hypotheticalValue.expandedCustomProperties ||
+                  !hypotheticalValue.expandedCustomProperties.has(
+                    customPropertyName
+                  ))
               ) {
                 value += permutation[customPropertyName].value;
                 while (j < tokens.length && tokens[j][0] !== ')') {
@@ -85,7 +89,11 @@ function expandCustomProperties(computedStyle) {
           }
           replacementHypotheticalValues.push({
             predicates,
-            value
+            value,
+            expandedCustomProperties: new Set([
+              ...(hypotheticalValues.expandedCustomProperties || []),
+              ...seenCustomProperties
+            ])
           });
         }
         if (!hasCopiedOuter) {

--- a/lib/util/fonts/expandCustomProperties.js
+++ b/lib/util/fonts/expandCustomProperties.js
@@ -90,6 +90,7 @@ function expandCustomProperties(computedStyle) {
           replacementHypotheticalValues.push({
             predicates,
             value,
+            prop: hypotheticalValue.prop,
             expandedCustomProperties: new Set([
               ...(hypotheticalValues.expandedCustomProperties || []),
               ...seenCustomProperties

--- a/lib/util/fonts/extractReferencedCustomPropertyNames.js
+++ b/lib/util/fonts/extractReferencedCustomPropertyNames.js
@@ -1,0 +1,19 @@
+const postCssValuesParser = require('postcss-values-parser');
+
+function extractReferencedCustomPropertyNames(cssValue) {
+  const tokens = postCssValuesParser(cssValue).tokens;
+  const customPropertyNames = new Set();
+  for (let i = 0; i < tokens.length - 3; i += 1) {
+    if (
+      tokens[i][1] === 'var' &&
+      tokens[i + 1][0] === '(' &&
+      tokens[i + 2][1] === '--' &&
+      tokens[i + 3][0] === 'word'
+    ) {
+      customPropertyNames.add('--' + tokens[i + 3][1]);
+    }
+  }
+  return customPropertyNames;
+}
+
+module.exports = extractReferencedCustomPropertyNames;

--- a/lib/util/fonts/findCustomPropertyDefinitions.js
+++ b/lib/util/fonts/findCustomPropertyDefinitions.js
@@ -1,0 +1,54 @@
+const extractReferencedCustomPropertyNames = require('./extractReferencedCustomPropertyNames');
+
+// Find all custom property definitions grouped by the custom properties they contribute to
+function findCustomPropertyDefinitions(cssAssets) {
+  const definitionsByProp = {};
+  const incomingReferencesByProp = {};
+  for (const cssAsset of cssAssets) {
+    cssAsset.eachRuleInParseTree(cssRule => {
+      if (
+        cssRule.parent.type === 'rule' &&
+        cssRule.type === 'decl' &&
+        /^--/.test(cssRule.prop)
+      ) {
+        (definitionsByProp[cssRule.prop] =
+          definitionsByProp[cssRule.prop] || new Set()).add(cssRule);
+        for (const customPropertyName of extractReferencedCustomPropertyNames(
+          cssRule.value
+        )) {
+          (incomingReferencesByProp[cssRule.prop] =
+            incomingReferencesByProp[cssRule.prop] || new Set()).add(
+            customPropertyName
+          );
+        }
+      }
+    });
+  }
+  const expandedDefinitionsByProp = {};
+  for (const prop of Object.keys(definitionsByProp)) {
+    expandedDefinitionsByProp[prop] = new Set();
+    const seenProps = new Set();
+    const queue = [prop];
+    while (queue.length > 0) {
+      const referencedProp = queue.shift();
+      if (!seenProps.has(referencedProp)) {
+        seenProps.add(referencedProp);
+        if (definitionsByProp[referencedProp]) {
+          for (const cssRule of definitionsByProp[referencedProp]) {
+            expandedDefinitionsByProp[prop].add(cssRule);
+          }
+        }
+        const incomingReferences = incomingReferencesByProp[referencedProp];
+        if (incomingReferences) {
+          for (const incomingReference of incomingReferences) {
+            queue.push(incomingReference);
+          }
+        }
+      }
+    }
+  }
+
+  return expandedDefinitionsByProp;
+}
+
+module.exports = findCustomPropertyDefinitions;

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -192,11 +192,16 @@ function getCssRulesByProperty(properties, cssSource, existingPredicates) {
           });
       } else if (node.prop === 'font') {
         // Shorthand
-        let fontProperties = cssFontParser(node.value);
+        let fontProperties;
+        if (/^var\(.*\)$/.test(node.value)) {
+          fontProperties = { 'font-family': [node.value] };
+        } else {
+          fontProperties = cssFontParser(node.value);
 
-        // If the shorthand value was invalid we get null in return
-        if (fontProperties === null) {
-          return;
+          // If the shorthand value was invalid we get null in return
+          if (fontProperties === null) {
+            return;
+          }
         }
 
         if (Array.isArray(fontProperties['font-family'])) {

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -1,13 +1,6 @@
 const specificity = require('specificity');
 const postcss = require('postcss');
-const cssFontParser = require('css-font-parser');
 const counterRendererByListStyleType = require('./counterRendererByListStyleType');
-
-const INITIAL_VALUES = {
-  // 'font-family': 'serif',
-  'font-weight': 400,
-  'font-style': 'normal'
-};
 
 function getCssRulesByProperty(properties, cssSource, existingPredicates) {
   if (!Array.isArray(properties)) {
@@ -191,56 +184,34 @@ function getCssRulesByProperty(properties, cssSource, existingPredicates) {
             }
           });
       } else if (node.prop === 'font') {
-        // Shorthand
-        let fontProperties;
-        if (/^var\(.*\)$/.test(node.value)) {
-          fontProperties = { 'font-family': [node.value] };
-        } else {
-          fontProperties = cssFontParser(node.value);
-
-          // If the shorthand value was invalid we get null in return
-          if (fontProperties === null) {
-            return;
-          }
-        }
-
-        if (Array.isArray(fontProperties['font-family'])) {
-          fontProperties['font-family'] = fontProperties['font-family']
-            .map(function quoteIfNeeded(family) {
-              if (!/^".*$|^'.*'$/.test(family) && family.includes(' ')) {
-                return '"' + family + '"';
-              }
-
-              return family;
-            })
-            .join(', ');
-        }
-
-        fontProperties = Object.assign({}, INITIAL_VALUES, fontProperties);
-
         specificity
           .calculate(node.parent.selector)
           .forEach(specificityObject => {
-            Object.keys(fontProperties).forEach(prop => {
-              const value = fontProperties[prop];
-              const isStyleAttribute =
-                specificityObject.selector === 'bogusselector';
+            const isStyleAttribute =
+              specificityObject.selector === 'bogusselector';
+            const value = {
+              predicates: getCurrentPredicates(),
+              selector: isStyleAttribute
+                ? undefined
+                : specificityObject.selector.trim(),
+              specificityArray: isStyleAttribute
+                ? [1, 0, 0, 0]
+                : specificityObject.specificityArray,
+              prop: 'font',
+              value: node.value,
+              important: !!node.important
+            };
 
-              if (Array.isArray(rulesByProperty[prop])) {
-                rulesByProperty[prop].push({
-                  predicates: getCurrentPredicates(),
-                  selector: isStyleAttribute
-                    ? undefined
-                    : specificityObject.selector.trim(),
-                  specificityArray: isStyleAttribute
-                    ? [1, 0, 0, 0]
-                    : specificityObject.specificityArray,
-                  prop,
-                  value,
-                  important: !!node.important
-                });
+            for (const prop of [
+              'font-family',
+              'font-weight',
+              'font-size',
+              'font-style'
+            ]) {
+              if (properties.includes(prop)) {
+                rulesByProperty[prop].push(value);
               }
-            });
+            }
           });
       }
     } else if (node.type === 'atrule' && node.name === 'counter-style') {

--- a/lib/util/fonts/getCssRulesByProperty.js
+++ b/lib/util/fonts/getCssRulesByProperty.js
@@ -45,14 +45,15 @@ function getCssRulesByProperty(properties, cssSource, existingPredicates) {
   (function visit(node) {
     // Check for selector. We might be in an at-rule like @font-face
     if (node.type === 'decl' && node.parent.selector) {
-      if (properties.includes(node.prop)) {
+      if (properties.includes(node.prop) || /^--/.test(node.prop)) {
         // Split up combined selectors as they might have different specificity
         specificity
           .calculate(node.parent.selector)
           .forEach(specificityObject => {
             const isStyleAttribute =
               specificityObject.selector === 'bogusselector';
-            rulesByProperty[node.prop].push({
+            (rulesByProperty[node.prop] =
+              rulesByProperty[node.prop] || []).push({
               predicates: getCurrentPredicates(),
               selector: isStyleAttribute
                 ? undefined

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -509,15 +509,13 @@ function expandTransitions(computedStyle) {
               hypotheticalFontWeightValueInPseudoClassStates => {
                 computedStyle['font-weight'].forEach(
                   hypotheticalFontWeightValue => {
-                    const fontWeight1 = normalizeFontWeight(
-                      hypotheticalFontWeightValue.value
-                    );
-                    const fontWeight2 = normalizeFontWeight(
+                    const fontWeightEndPoints = [
+                      hypotheticalFontWeightValue.value,
                       hypotheticalFontWeightValueInPseudoClassStates.value
-                    );
+                    ].map(normalizeFontWeight);
                     for (
-                      let fontWeight = Math.min(fontWeight1, fontWeight2) + 100;
-                      fontWeight < Math.max(fontWeight1, fontWeight2);
+                      let fontWeight = Math.min(...fontWeightEndPoints) + 100;
+                      fontWeight < Math.max(...fontWeightEndPoints);
                       fontWeight += 100
                     ) {
                       // Explicitly don't include hypotheticalFontWeightValueInPseudoClassStates.predicates

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -18,6 +18,7 @@ const combinePredicates = require('./combinePredicates');
 const arePredicatesExhaustive = require('../arePredicatesExhaustive');
 const initialValueByProp = require('./initialValueByProp');
 const expandCustomProperties = require('./expandCustomProperties');
+const cssFontParser = require('css-font-parser');
 
 const FONT_PROPS = ['font-family', 'font-style', 'font-weight'];
 
@@ -164,7 +165,9 @@ function getMemoizedElementStyleResolver(
       // Stop condition. We moved above <HTML>
       if (!node.tagName) {
         cssPropsAndCustomPropsToTrace.forEach(prop => {
-          result[prop] = [{ value: initialValueByProp[prop], predicates }];
+          result[prop] = [
+            { value: initialValueByProp[prop], predicates, prop }
+          ];
         });
         return result;
       }
@@ -280,6 +283,7 @@ function getMemoizedElementStyleResolver(
                   undefined,
                   predicates
                 ))[prop].map(inheritedHypotheticalValue => ({
+                prop: inheritedHypotheticalValue.prop,
                 value:
                   inheritedHypotheticalValue.value + '+' + declaration.value,
                 predicates: inheritedHypotheticalValue
@@ -298,7 +302,9 @@ function getMemoizedElementStyleResolver(
                 value = declaration.value;
               }
 
-              hypotheticalValues = [{ value, predicates }];
+              hypotheticalValues = [
+                { prop: declaration.prop, value, predicates }
+              ];
             }
 
             const predicatesToVary = Object.keys(declaration.predicates);
@@ -337,6 +343,7 @@ function getMemoizedElementStyleResolver(
                 ) {
                   multipliedHypotheticalValues.push(
                     ...hypotheticalValues.map(hypotheticalValue => ({
+                      prop: hypotheticalValue.prop,
                       value: hypotheticalValue.value,
                       predicates: predicatesForThisPermutation
                     }))
@@ -363,7 +370,7 @@ function getMemoizedElementStyleResolver(
               predicates
             ))[prop];
         } else {
-          return [{ value: initialValueByProp[prop], predicates }];
+          return [{ prop, value: initialValueByProp[prop], predicates }];
         }
       }
 
@@ -468,6 +475,7 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
                   values.forEach(value => {
                     (extraValuesByProp[prop] =
                       extraValuesByProp[prop] || []).push({
+                      prop, // Maybe?
                       value,
                       predicates: permutation['animation-name'].predicates
                     });
@@ -539,6 +547,7 @@ function expandTransitions(computedStyle) {
                       ]);
                       if (combinedPredicates) {
                         extraHypotheticalFontWeightValues.push({
+                          prop: 'font-weight',
                           value: fontWeight,
                           predicates: combinedPredicates
                         });
@@ -1176,15 +1185,47 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
 
   const seenPermutationByKey = {};
   for (const styledText of styledTexts) {
-    for (const fontFamily of styledText['font-family']) {
-      fontFamily.value = unquote(fontFamily.value);
+    for (const [i, fontFamily] of styledText['font-family'].entries()) {
+      let value = fontFamily.value;
+
+      if (value) {
+        if (fontFamily.prop === 'font') {
+          const fontProperties = cssFontParser(value);
+          if (fontProperties) {
+            value = fontProperties['font-family'][0];
+          } else {
+            value = undefined;
+          }
+        }
+        fontFamily._alreadyMutated = true;
+        value = unquote(value);
+        if (value !== fontFamily.value) {
+          styledText['font-family'].splice(i, 1, {
+            predicates: fontFamily.predicates,
+            prop: 'font-family',
+            value
+          });
+        }
+      }
     }
-    for (const fontWeight of styledText['font-weight']) {
-      if (
-        typeof fontWeight.value === 'string' &&
-        /^\d+$/.test(fontWeight.value)
-      ) {
-        fontWeight.value = Number(fontWeight.value);
+    for (const [i, fontWeight] of styledText['font-weight'].entries()) {
+      let value = fontWeight.value;
+      if (fontWeight.prop === 'font') {
+        const fontProperties = cssFontParser(value);
+        value = (fontProperties && fontProperties['font-weight']) || 400;
+      }
+
+      if (typeof value === 'string' && /^\d+$/.test(value)) {
+        value = Number(value);
+      } else {
+        value = cssFontWeightNames[value] || value;
+      }
+      if (value !== fontWeight.value) {
+        styledText['font-weight'].splice(i, 1, {
+          predicates: fontWeight.predicates,
+          prop: 'font-weight',
+          value
+        });
       }
     }
   }

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -1185,47 +1185,32 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
 
   const seenPermutationByKey = {};
   for (const styledText of styledTexts) {
-    for (const [i, fontFamily] of styledText['font-family'].entries()) {
-      let value = fontFamily.value;
+    for (const prop of ['font-family', 'font-weight']) {
+      for (const [i, hypotheticalValue] of styledText[prop].entries()) {
+        let value = hypotheticalValue.value;
 
-      if (value) {
-        if (fontFamily.prop === 'font') {
-          const fontProperties = cssFontParser(value);
-          if (fontProperties) {
-            value = fontProperties['font-family'][0];
+        if (value) {
+          if (hypotheticalValue.prop === 'font') {
+            const fontProperties = cssFontParser(value);
+            value =
+              (fontProperties && fontProperties[prop]) ||
+              initialValueByProp[prop];
+          }
+          if (prop === 'font-family') {
+            value = unquote(Array.isArray(value) ? value[0] : value);
+          } else if (/^\d+$/.test(value)) {
+            value = Number(value);
           } else {
-            value = undefined;
+            value = cssFontWeightNames[value] || value;
+          }
+          if (value !== hypotheticalValue.value) {
+            styledText[prop].splice(i, 1, {
+              predicates: hypotheticalValue.predicates,
+              prop,
+              value
+            });
           }
         }
-        fontFamily._alreadyMutated = true;
-        value = unquote(value);
-        if (value !== fontFamily.value) {
-          styledText['font-family'].splice(i, 1, {
-            predicates: fontFamily.predicates,
-            prop: 'font-family',
-            value
-          });
-        }
-      }
-    }
-    for (const [i, fontWeight] of styledText['font-weight'].entries()) {
-      let value = fontWeight.value;
-      if (fontWeight.prop === 'font') {
-        const fontProperties = cssFontParser(value);
-        value = (fontProperties && fontProperties['font-weight']) || 400;
-      }
-
-      if (typeof value === 'string' && /^\d+$/.test(value)) {
-        value = Number(value);
-      } else {
-        value = cssFontWeightNames[value] || value;
-      }
-      if (value !== fontWeight.value) {
-        styledText['font-weight'].splice(i, 1, {
-          predicates: fontWeight.predicates,
-          prop: 'font-weight',
-          value
-        });
       }
     }
   }

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -1175,8 +1175,8 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
               (fontProperties && fontProperties[prop]) ||
               initialValueByProp[prop];
           }
-          if (prop === 'font-family') {
-            value = unquote(Array.isArray(value) ? value[0] : value);
+          if (prop === 'font-family' && Array.isArray(value)) {
+            value = value.join(', ');
           }
           if (value !== hypotheticalValue.value) {
             styledText[prop].splice(i, 1, {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -3,7 +3,6 @@ const defaultStylesheets = require('./defaultStylesheets');
 const stylePropObjectComparator = require('./stylePropObjectComparator');
 const unquote = require('./unquote');
 const memoizeSync = require('memoizesync');
-const cssFontWeightNames = require('css-font-weight-names');
 const capitalize = require('capitalize');
 const cssPseudoElementRegExp = require('../cssPseudoElementRegExp');
 const stripPseudoClassesFromSelector = require('./stripPseudoClassesFromSelector');
@@ -18,6 +17,7 @@ const combinePredicates = require('./combinePredicates');
 const arePredicatesExhaustive = require('../arePredicatesExhaustive');
 const initialValueByProp = require('./initialValueByProp');
 const expandCustomProperties = require('./expandCustomProperties');
+const normalizeFontWeight = require('./normalizeFontWeight');
 const cssFontParser = require('css-font-parser');
 
 const FONT_PROPS = ['font-family', 'font-style', 'font-weight'];
@@ -448,7 +448,7 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
                   let values = seenValuesByProp[prop];
                   if (prop === 'font-weight') {
                     // https://drafts.csswg.org/css-transitions/#animtype-font-weight
-                    const sortedValues = values.sort();
+                    const sortedValues = values.map(normalizeFontWeight).sort();
                     values = [];
                     for (
                       let fontWeight = sortedValues[0];
@@ -509,17 +509,12 @@ function expandTransitions(computedStyle) {
               hypotheticalFontWeightValueInPseudoClassStates => {
                 computedStyle['font-weight'].forEach(
                   hypotheticalFontWeightValue => {
-                    const fontWeight1 =
-                      cssFontWeightNames[hypotheticalFontWeightValue.value] ||
-                      parseInt(hypotheticalFontWeightValue.value, 10);
-                    const fontWeight2 =
-                      cssFontWeightNames[
-                        hypotheticalFontWeightValueInPseudoClassStates.value
-                      ] ||
-                      parseInt(
-                        hypotheticalFontWeightValueInPseudoClassStates.value,
-                        10
-                      );
+                    const fontWeight1 = normalizeFontWeight(
+                      hypotheticalFontWeightValue.value
+                    );
+                    const fontWeight2 = normalizeFontWeight(
+                      hypotheticalFontWeightValueInPseudoClassStates.value
+                    );
                     for (
                       let fontWeight = Math.min(fontWeight1, fontWeight2) + 100;
                       fontWeight < Math.max(fontWeight1, fontWeight2);

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -392,7 +392,12 @@ function getMemoizedElementStyleResolver(
                         customPropertyName,
                         0,
                         hypotheticalValue.predicates
-                      ) || [{ value: undefined, predicates: {} }];
+                      ) || [
+                        {
+                          value: undefined,
+                          predicates: hypotheticalValue.predicates
+                        }
+                      ];
                     seenCustomProperties.add(customPropertyName);
                   }
                 }

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -1183,9 +1183,9 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
   //     ...
   // ]
 
-  const seenPermutationByKey = {};
+  // Extract longhand property values from font shorthands
   for (const styledText of styledTexts) {
-    for (const prop of ['font-family', 'font-weight']) {
+    for (const prop of ['font-family', 'font-weight', 'font-style']) {
       for (const [i, hypotheticalValue] of styledText[prop].entries()) {
         let value = hypotheticalValue.value;
 
@@ -1198,10 +1198,12 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
           }
           if (prop === 'font-family') {
             value = unquote(Array.isArray(value) ? value[0] : value);
-          } else if (/^\d+$/.test(value)) {
-            value = Number(value);
-          } else {
-            value = cssFontWeightNames[value] || value;
+          } else if (prop === 'font-weight') {
+            if (/^\d+$/.test(value)) {
+              value = Number(value);
+            } else {
+              value = cssFontWeightNames[value] || value;
+            }
           }
           if (value !== hypotheticalValue.value) {
             styledText[prop].splice(i, 1, {
@@ -1214,6 +1216,8 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
       }
     }
   }
+
+  const seenPermutationByKey = {};
   const multipliedStyledTexts = _.flatten(
     styledTexts.map(styledText =>
       expandPermutations(styledText)

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -293,8 +293,6 @@ function getMemoizedElementStyleResolver(
                 NAME_CONVERSIONS[prop][declaration.value]
               ) {
                 value = NAME_CONVERSIONS[prop][declaration.value];
-              } else if (prop === 'font-weight') {
-                value = Number(declaration.value);
               } else if (prop !== 'content' || hasPseudoElement) {
                 // content: ... is not inherited, has to be applied directly to the pseudo element
                 value = declaration.value;
@@ -828,41 +826,17 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
   const conditionalCommentStack = [];
   const noscriptStack = [];
 
-  function unquoteFontFamily(computedStyle) {
-    let hasCopied = false;
-    let fontFamilies = computedStyle['font-family'];
-    for (const [i, hypotheticalValue] of fontFamilies.entries()) {
-      const unquoted = unquote(hypotheticalValue.value);
-      if (unquoted !== hypotheticalValue.value) {
-        if (!hasCopied) {
-          computedStyle = { ...computedStyle };
-          fontFamilies = computedStyle['font-family'] = [
-            ...computedStyle['font-family']
-          ];
-          hasCopied = true;
-        }
-        fontFamilies[i] = {
-          value: unquoted,
-          predicates: hypotheticalValue.predicates
-        };
-      }
-    }
-    return computedStyle;
-  }
-
   function expandComputedStyle(computedStyle) {
-    return unquoteFontFamily(
-      expandListIndicators(
-        expandCustomProperties(
-          expandTransitions(
-            expandAnimations(computedStyle, fontPropRules.keyframes)
-          )
-        ),
-        fontPropRules.counterStyles,
-        possibleNextListItemNumberStack[
-          possibleNextListItemNumberStack.length - 1
-        ]
-      )
+    return expandListIndicators(
+      expandCustomProperties(
+        expandTransitions(
+          expandAnimations(computedStyle, fontPropRules.keyframes)
+        )
+      ),
+      fontPropRules.counterStyles,
+      possibleNextListItemNumberStack[
+        possibleNextListItemNumberStack.length - 1
+      ]
     );
   }
 
@@ -1201,6 +1175,19 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
   // ]
 
   const seenPermutationByKey = {};
+  for (const styledText of styledTexts) {
+    for (const fontFamily of styledText['font-family']) {
+      fontFamily.value = unquote(fontFamily.value);
+    }
+    for (const fontWeight of styledText['font-weight']) {
+      if (
+        typeof fontWeight.value === 'string' &&
+        /^\d+$/.test(fontWeight.value)
+      ) {
+        fontWeight.value = Number(fontWeight.value);
+      }
+    }
+  }
   const multipliedStyledTexts = _.flatten(
     styledTexts.map(styledText =>
       expandPermutations(styledText)

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -57,10 +57,6 @@ const INHERITED = {
   'white-space': true
 };
 
-const NAME_CONVERSIONS = {
-  'font-weight': cssFontWeightNames
-};
-
 function createPredicatePermutations(predicatesToVary, predicates, i) {
   if (typeof i !== 'number') {
     i = 0;
@@ -292,11 +288,6 @@ function getMemoizedElementStyleResolver(
               let value;
               if (declaration.value === 'initial') {
                 value = initialValueByProp[prop];
-              } else if (
-                NAME_CONVERSIONS[prop] &&
-                NAME_CONVERSIONS[prop][declaration.value]
-              ) {
-                value = NAME_CONVERSIONS[prop][declaration.value];
               } else if (prop !== 'content' || hasPseudoElement) {
                 // content: ... is not inherited, has to be applied directly to the pseudo element
                 value = declaration.value;
@@ -457,25 +448,20 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
                   let values = seenValuesByProp[prop];
                   if (prop === 'font-weight') {
                     // https://drafts.csswg.org/css-transitions/#animtype-font-weight
-                    const sortedValues = values
-                      .map(
-                        value =>
-                          cssFontWeightNames[value] || parseInt(value, 10)
-                      )
-                      .sort();
+                    const sortedValues = values.sort();
                     values = [];
                     for (
                       let fontWeight = sortedValues[0];
                       fontWeight <= sortedValues[sortedValues.length - 1];
                       fontWeight += 100
                     ) {
-                      values.push(fontWeight);
+                      values.push(String(fontWeight));
                     }
                   }
                   values.forEach(value => {
                     (extraValuesByProp[prop] =
                       extraValuesByProp[prop] || []).push({
-                      prop, // Maybe?
+                      prop,
                       value,
                       predicates: permutation['animation-name'].predicates
                     });
@@ -548,7 +534,7 @@ function expandTransitions(computedStyle) {
                       if (combinedPredicates) {
                         extraHypotheticalFontWeightValues.push({
                           prop: 'font-weight',
-                          value: fontWeight,
+                          value: String(fontWeight),
                           predicates: combinedPredicates
                         });
                       }
@@ -1198,12 +1184,6 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
           }
           if (prop === 'font-family') {
             value = unquote(Array.isArray(value) ? value[0] : value);
-          } else if (prop === 'font-weight') {
-            if (/^\d+$/.test(value)) {
-              value = Number(value);
-            } else {
-              value = cssFontWeightNames[value] || value;
-            }
           }
           if (value !== hypotheticalValue.value) {
             styledText[prop].splice(i, 1, {

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -352,7 +352,7 @@ function getMemoizedElementStyleResolver(
               });
               hypotheticalValues = multipliedHypotheticalValues;
             }
-            return expandCustomProperties(hypotheticalValues, prop, traceProp);
+            return hypotheticalValues;
           }
         }
         if (!nonInheritingTags.includes(node.tagName)) {
@@ -409,8 +409,10 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
       keyframesDefinitions.forEach(keyframesDefinition => {
         if (keyframesDefinition.name === animationNameValue.value) {
           keyframesDefinition.node.walkDecls(decl => {
-            // TODO: Include custom properties?
-            if (CSS_PROPS_TO_TRACE.includes(decl.prop)) {
+            if (
+              /^--/.test(decl.prop) ||
+              CSS_PROPS_TO_TRACE.includes(decl.prop)
+            ) {
               isAnimatedByPropertyName[decl.prop] = true;
             }
           });
@@ -439,8 +441,10 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
                   seenValuesByProp[prop] = [permutation[prop].value];
                 });
                 keyframesDefinition.node.walkDecls(decl => {
-                  // TODO: Include custom properties?
-                  if (CSS_PROPS_TO_TRACE.includes(decl.prop)) {
+                  if (
+                    /^--/.test(decl.prop) ||
+                    CSS_PROPS_TO_TRACE.includes(decl.prop)
+                  ) {
                     seenValuesByProp[decl.prop].push(decl.value);
                   }
                 });
@@ -824,18 +828,41 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
   const conditionalCommentStack = [];
   const noscriptStack = [];
 
-  function expandComputedStyle(computedStyle) {
-    for (const hypotheticalValue of computedStyle['font-family']) {
-      hypotheticalValue.value = unquote(hypotheticalValue.value);
+  function unquoteFontFamily(computedStyle) {
+    let hasCopied = false;
+    let fontFamilies = computedStyle['font-family'];
+    for (const [i, hypotheticalValue] of fontFamilies.entries()) {
+      const unquoted = unquote(hypotheticalValue.value);
+      if (unquoted !== hypotheticalValue.value) {
+        if (!hasCopied) {
+          computedStyle = { ...computedStyle };
+          fontFamilies = computedStyle['font-family'] = [
+            ...computedStyle['font-family']
+          ];
+          hasCopied = true;
+        }
+        fontFamilies[i] = {
+          value: unquoted,
+          predicates: hypotheticalValue.predicates
+        };
+      }
     }
-    return expandListIndicators(
-      expandTransitions(
-        expandAnimations(computedStyle, fontPropRules.keyframes)
-      ),
-      fontPropRules.counterStyles,
-      possibleNextListItemNumberStack[
-        possibleNextListItemNumberStack.length - 1
-      ]
+    return computedStyle;
+  }
+
+  function expandComputedStyle(computedStyle) {
+    return unquoteFontFamily(
+      expandListIndicators(
+        expandCustomProperties(
+          expandTransitions(
+            expandAnimations(computedStyle, fontPropRules.keyframes)
+          )
+        ),
+        fontPropRules.counterStyles,
+        possibleNextListItemNumberStack[
+          possibleNextListItemNumberStack.length - 1
+        ]
+      )
     );
   }
 

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -3,7 +3,6 @@ const defaultStylesheets = require('./defaultStylesheets');
 const stylePropObjectComparator = require('./stylePropObjectComparator');
 const unquote = require('./unquote');
 const memoizeSync = require('memoizesync');
-const postCssValuesParser = require('postcss-values-parser');
 const cssFontWeightNames = require('css-font-weight-names');
 const capitalize = require('capitalize');
 const cssPseudoElementRegExp = require('../cssPseudoElementRegExp');
@@ -17,6 +16,8 @@ const getCounterCharacters = require('./getCounterCharacters');
 const expandPermutations = require('../expandPermutations');
 const combinePredicates = require('./combinePredicates');
 const arePredicatesExhaustive = require('../arePredicatesExhaustive');
+const initialValueByProp = require('./initialValueByProp');
+const expandCustomProperties = require('./expandCustomProperties');
 
 const FONT_PROPS = ['font-family', 'font-style', 'font-weight'];
 
@@ -37,24 +38,6 @@ const CSS_PROPS_TO_TRACE = [
 ];
 
 const CSS_PROPS_TO_TRACE_AND_TEXT = ['text', ...CSS_PROPS_TO_TRACE];
-
-const INITIAL_VALUES = {
-  // 'font-family': 'serif'
-  'font-weight': 400,
-  'font-style': 'normal',
-  content: 'normal',
-  quotes: '"«" "»" "‹" "›" "‘" "’" "\'" "\'" "\\"" "\\""', // Wide default set to account for browser differences
-  'list-style-type': 'none',
-  display: 'inline',
-  'animation-name': 'none',
-  'text-transform': 'none',
-  'transition-property': 'all',
-  'transition-duration': '0s',
-  'counter-increment': 'none',
-  'counter-reset': 'none',
-  'counter-set': 'none',
-  'white-space': 'normal'
-};
 
 const INHERITED = {
   'font-family': true,
@@ -181,7 +164,7 @@ function getMemoizedElementStyleResolver(
       // Stop condition. We moved above <HTML>
       if (!node.tagName) {
         cssPropsAndCustomPropsToTrace.forEach(prop => {
-          result[prop] = [{ value: INITIAL_VALUES[prop], predicates }];
+          result[prop] = [{ value: initialValueByProp[prop], predicates }];
         });
         return result;
       }
@@ -304,7 +287,7 @@ function getMemoizedElementStyleResolver(
             } else {
               let value;
               if (declaration.value === 'initial') {
-                value = INITIAL_VALUES[prop];
+                value = initialValueByProp[prop];
               } else if (
                 NAME_CONVERSIONS[prop] &&
                 NAME_CONVERSIONS[prop][declaration.value]
@@ -369,103 +352,7 @@ function getMemoizedElementStyleResolver(
               });
               hypotheticalValues = multipliedHypotheticalValues;
             }
-            const hypotheticalValuesByCustomProp = {};
-            for (let i = 0; i < hypotheticalValues.length; i += 1) {
-              const hypotheticalValue = hypotheticalValues[i];
-              // Quick test for whether the value contains custom properties:
-              if (/var\(--[^)]+\)/.test(hypotheticalValue.value)) {
-                const tokens = postCssValuesParser(hypotheticalValue.value)
-                  .tokens;
-                const seenCustomProperties = new Set();
-                for (let j = 0; j < tokens.length - 3; j += 1) {
-                  if (
-                    tokens[j][1] === 'var' &&
-                    tokens[j + 1][0] === '(' &&
-                    tokens[j + 2][1] === '--' &&
-                    tokens[j + 3][0] === 'word'
-                  ) {
-                    const customPropertyName = '--' + tokens[j + 3][1];
-                    hypotheticalValuesByCustomProp[
-                      customPropertyName
-                    ] = hypotheticalValuesByCustomProp[customPropertyName] ||
-                      traceProp(
-                        customPropertyName,
-                        0,
-                        hypotheticalValue.predicates
-                      ) || [
-                        {
-                          value: undefined,
-                          predicates: hypotheticalValue.predicates
-                        }
-                      ];
-                    seenCustomProperties.add(customPropertyName);
-                  }
-                }
-                if (seenCustomProperties.size === 0) {
-                  // The quick regexp test was a false positive
-                  continue;
-                }
-                const replacementHypotheticalValues = [];
-                for (const permutation of expandPermutations(
-                  hypotheticalValuesByCustomProp
-                )) {
-                  const predicates = combinePredicates([
-                    hypotheticalValue.predicates,
-                    ...Object.values(permutation).map(v => v.predicates)
-                  ]);
-                  let value = '';
-                  for (let j = 0; j < tokens.length; j += 1) {
-                    if (
-                      tokens[j][1] === 'var' &&
-                      tokens[j + 1][0] === '(' &&
-                      tokens[j + 2][1] === '--' &&
-                      tokens[j + 3][0] === 'word'
-                    ) {
-                      const customPropertyName = `--${tokens[j + 3][1]}`;
-                      if (
-                        permutation[customPropertyName] &&
-                        permutation[customPropertyName].value
-                      ) {
-                        value += permutation[customPropertyName].value;
-                        while (j < tokens.length && tokens[j][0] !== ')') {
-                          j += 1;
-                        }
-                      } else if (
-                        j < tokens.length &&
-                        tokens[j + 4][0] === 'comma'
-                      ) {
-                        // Undefined property, but there is a default value
-                        j += 5;
-                        while (j < tokens.length && tokens[j][0] === 'space') {
-                          j += 1;
-                        }
-                        while (j < tokens.length && tokens[j][0] !== ')') {
-                          value += tokens[j][1];
-                          j += 1;
-                        }
-                      } else {
-                        // Reference to an undefined custom property and no default value
-                        value = INITIAL_VALUES[prop];
-                        break;
-                      }
-                    } else {
-                      value += tokens[j][1];
-                    }
-                  }
-                  replacementHypotheticalValues.push({
-                    predicates,
-                    value
-                  });
-                }
-                hypotheticalValues.splice(
-                  i,
-                  1,
-                  ...replacementHypotheticalValues
-                );
-                i -= 1;
-              }
-            }
-            return hypotheticalValues;
+            return expandCustomProperties(hypotheticalValues, prop, traceProp);
           }
         }
         if (!nonInheritingTags.includes(node.tagName)) {
@@ -478,7 +365,7 @@ function getMemoizedElementStyleResolver(
               predicates
             ))[prop];
         } else {
-          return [{ value: INITIAL_VALUES[prop], predicates }];
+          return [{ value: initialValueByProp[prop], predicates }];
         }
       }
 

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -3,6 +3,7 @@ const defaultStylesheets = require('./defaultStylesheets');
 const stylePropObjectComparator = require('./stylePropObjectComparator');
 const unquote = require('./unquote');
 const memoizeSync = require('memoizesync');
+const postCssValuesParser = require('postcss-values-parser');
 const cssFontWeightNames = require('css-font-weight-names');
 const capitalize = require('capitalize');
 const cssPseudoElementRegExp = require('../cssPseudoElementRegExp');
@@ -19,7 +20,7 @@ const arePredicatesExhaustive = require('../arePredicatesExhaustive');
 
 const FONT_PROPS = ['font-family', 'font-style', 'font-weight'];
 
-const ALL_PROPS_TO_TRACE = [
+const CSS_PROPS_TO_TRACE = [
   ...FONT_PROPS,
   'content',
   'quotes',
@@ -35,7 +36,7 @@ const ALL_PROPS_TO_TRACE = [
   'white-space'
 ];
 
-const ALL_PROPS_TO_TRACE_AND_TEXT = ['text', ...ALL_PROPS_TO_TRACE];
+const CSS_PROPS_TO_TRACE_AND_TEXT = ['text', ...CSS_PROPS_TO_TRACE];
 
 const INITIAL_VALUES = {
   // 'font-family': 'serif'
@@ -111,7 +112,7 @@ function getFontRulesWithDefaultStylesheetApplied(
   ]
     .map(stylesheetAndIncomingMedia =>
       memoizedGetCssRulesByProperty(
-        ALL_PROPS_TO_TRACE,
+        CSS_PROPS_TO_TRACE,
         stylesheetAndIncomingMedia.text,
         stylesheetAndIncomingMedia.predicates
       )
@@ -166,6 +167,11 @@ function getMemoizedElementStyleResolver(
 ) {
   const nonInheritingTags = ['BUTTON', 'INPUT', 'OPTION', 'TEXTAREA'];
 
+  const cssPropsAndCustomPropsToTrace = [
+    ...CSS_PROPS_TO_TRACE,
+    ...Object.keys(fontPropRules).filter(prop => /^--/.test(prop))
+  ];
+
   const getComputedStyle = memoizeSync(
     (node, idArray, pseudoElementName, parentTrace, predicates) => {
       predicates = predicates || {};
@@ -174,7 +180,7 @@ function getMemoizedElementStyleResolver(
 
       // Stop condition. We moved above <HTML>
       if (!node.tagName) {
-        ALL_PROPS_TO_TRACE.forEach(prop => {
+        cssPropsAndCustomPropsToTrace.forEach(prop => {
           result[prop] = [{ value: INITIAL_VALUES[prop], predicates }];
         });
         return result;
@@ -182,7 +188,7 @@ function getMemoizedElementStyleResolver(
 
       if (node.getAttribute('style')) {
         const attributeStyles = memoizedGetCssRulesByProperty(
-          ALL_PROPS_TO_TRACE,
+          cssPropsAndCustomPropsToTrace,
           'bogusselector { ' + node.getAttribute('style') + ' }',
           [],
           []
@@ -205,9 +211,9 @@ function getMemoizedElementStyleResolver(
 
       function traceProp(prop, startIndex, predicates) {
         startIndex = startIndex || 0;
-
-        for (let i = startIndex; i < localFontPropRules[prop].length; i += 1) {
-          const declaration = localFontPropRules[prop][i];
+        const propDeclarations = localFontPropRules[prop] || [];
+        for (let i = startIndex; i < propDeclarations.length; i += 1) {
+          const declaration = propDeclarations[i];
           // Skip to the next rule if we are doing a trace where one of true predicates is already assumed false,
           // or one of the false predicates is already assumed true:
           if (
@@ -252,7 +258,12 @@ function getMemoizedElementStyleResolver(
             continue;
           }
 
-          if (!INHERITED[prop] && !hasPseudoElement && pseudoElementName) {
+          if (
+            !prop.startsWith('--') &&
+            !INHERITED[prop] &&
+            !hasPseudoElement &&
+            pseudoElementName
+          ) {
             continue;
           }
 
@@ -301,8 +312,6 @@ function getMemoizedElementStyleResolver(
                 value = NAME_CONVERSIONS[prop][declaration.value];
               } else if (prop === 'font-weight') {
                 value = Number(declaration.value);
-              } else if (prop === 'font-family') {
-                value = unquote(declaration.value);
               } else if (prop !== 'content' || hasPseudoElement) {
                 // content: ... is not inherited, has to be applied directly to the pseudo element
                 value = declaration.value;
@@ -360,10 +369,100 @@ function getMemoizedElementStyleResolver(
               });
               hypotheticalValues = multipliedHypotheticalValues;
             }
+            const hypotheticalValuesByCustomProp = {};
+            for (let i = 0; i < hypotheticalValues.length; i += 1) {
+              const hypotheticalValue = hypotheticalValues[i];
+              // Quick test for whether the value contains custom properties:
+              if (/var\(--[^)]+\)/.test(hypotheticalValue.value)) {
+                const tokens = postCssValuesParser(hypotheticalValue.value)
+                  .tokens;
+                const seenCustomProperties = new Set();
+                for (let j = 0; j < tokens.length - 3; j += 1) {
+                  if (
+                    tokens[j][1] === 'var' &&
+                    tokens[j + 1][0] === '(' &&
+                    tokens[j + 2][1] === '--' &&
+                    tokens[j + 3][0] === 'word'
+                  ) {
+                    const customPropertyName = '--' + tokens[j + 3][1];
+                    hypotheticalValuesByCustomProp[
+                      customPropertyName
+                    ] = hypotheticalValuesByCustomProp[customPropertyName] ||
+                      traceProp(
+                        customPropertyName,
+                        0,
+                        hypotheticalValue.predicates
+                      ) || [{ value: undefined, predicates: {} }];
+                    seenCustomProperties.add(customPropertyName);
+                  }
+                }
+                if (seenCustomProperties.size === 0) {
+                  // The quick regexp test was a false positive
+                  continue;
+                }
+                const replacementHypotheticalValues = [];
+                for (const permutation of expandPermutations(
+                  hypotheticalValuesByCustomProp
+                )) {
+                  const predicates = combinePredicates([
+                    hypotheticalValue.predicates,
+                    ...Object.values(permutation).map(v => v.predicates)
+                  ]);
+                  let value = '';
+                  for (let j = 0; j < tokens.length; j += 1) {
+                    if (
+                      tokens[j][1] === 'var' &&
+                      tokens[j + 1][0] === '(' &&
+                      tokens[j + 2][1] === '--' &&
+                      tokens[j + 3][0] === 'word'
+                    ) {
+                      const customPropertyName = `--${tokens[j + 3][1]}`;
+                      if (
+                        permutation[customPropertyName] &&
+                        permutation[customPropertyName].value
+                      ) {
+                        value += permutation[customPropertyName].value;
+                        while (j < tokens.length && tokens[j][0] !== ')') {
+                          j += 1;
+                        }
+                      } else if (
+                        j < tokens.length &&
+                        tokens[j + 4][0] === 'comma'
+                      ) {
+                        // Undefined property, but there is a default value
+                        j += 5;
+                        while (j < tokens.length && tokens[j][0] === 'space') {
+                          j += 1;
+                        }
+                        while (j < tokens.length && tokens[j][0] !== ')') {
+                          value += tokens[j][1];
+                          j += 1;
+                        }
+                      } else {
+                        // Reference to an undefined custom property and no default value
+                        value = INITIAL_VALUES[prop];
+                        break;
+                      }
+                    } else {
+                      value += tokens[j][1];
+                    }
+                  }
+                  replacementHypotheticalValues.push({
+                    predicates,
+                    value
+                  });
+                }
+                hypotheticalValues.splice(
+                  i,
+                  1,
+                  ...replacementHypotheticalValues
+                );
+                i -= 1;
+              }
+            }
             return hypotheticalValues;
           }
         }
-
         if (!nonInheritingTags.includes(node.tagName)) {
           return (parentTrace ||
             getComputedStyle(
@@ -378,7 +477,7 @@ function getMemoizedElementStyleResolver(
         }
       }
 
-      ALL_PROPS_TO_TRACE.forEach(prop => {
+      cssPropsAndCustomPropsToTrace.forEach(prop => {
         result[prop] = traceProp(prop, 0, predicates);
       });
       if (pseudoElementName && !foundPseudoElement) {
@@ -418,7 +517,8 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
       keyframesDefinitions.forEach(keyframesDefinition => {
         if (keyframesDefinition.name === animationNameValue.value) {
           keyframesDefinition.node.walkDecls(decl => {
-            if (ALL_PROPS_TO_TRACE.includes(decl.prop)) {
+            // TODO: Include custom properties?
+            if (CSS_PROPS_TO_TRACE.includes(decl.prop)) {
               isAnimatedByPropertyName[decl.prop] = true;
             }
           });
@@ -447,7 +547,8 @@ function expandAnimations(computedStyle, keyframesDefinitions) {
                   seenValuesByProp[prop] = [permutation[prop].value];
                 });
                 keyframesDefinition.node.walkDecls(decl => {
-                  if (ALL_PROPS_TO_TRACE.includes(decl.prop)) {
+                  // TODO: Include custom properties?
+                  if (CSS_PROPS_TO_TRACE.includes(decl.prop)) {
                     seenValuesByProp[decl.prop].push(decl.value);
                   }
                 });
@@ -832,6 +933,9 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
   const noscriptStack = [];
 
   function expandComputedStyle(computedStyle) {
+    for (const hypotheticalValue of computedStyle['font-family']) {
+      hypotheticalValue.value = unquote(hypotheticalValue.value);
+    }
     return expandListIndicators(
       expandTransitions(
         expandAnimations(computedStyle, fontPropRules.keyframes)
@@ -1182,14 +1286,14 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     styledTexts.map(styledText =>
       expandPermutations(styledText)
         .filter(function removeImpossibleCombinations(hypotheticalValueByProp) {
-          return ALL_PROPS_TO_TRACE_AND_TEXT.every(prop =>
+          return CSS_PROPS_TO_TRACE_AND_TEXT.every(prop =>
             Object.keys(hypotheticalValueByProp[prop].predicates).every(
               predicate => {
                 const predicateValue =
                   hypotheticalValueByProp[prop].predicates[predicate];
                 return (
                   predicateValue === false ||
-                  ALL_PROPS_TO_TRACE_AND_TEXT.every(
+                  CSS_PROPS_TO_TRACE_AND_TEXT.every(
                     otherProp =>
                       hypotheticalValueByProp[otherProp].predicates[
                         predicate
@@ -1202,7 +1306,7 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         })
         .map(hypotheticalValueByProp => {
           const props = {};
-          ALL_PROPS_TO_TRACE_AND_TEXT.forEach(prop => {
+          CSS_PROPS_TO_TRACE_AND_TEXT.forEach(prop => {
             props[prop] = hypotheticalValueByProp[prop].value;
           });
           // Apply text-transform:

--- a/lib/util/fonts/initialValueByProp.js
+++ b/lib/util/fonts/initialValueByProp.js
@@ -1,0 +1,17 @@
+module.exports = {
+  // 'font-family': 'serif'
+  'font-weight': 400,
+  'font-style': 'normal',
+  content: 'normal',
+  quotes: '"«" "»" "‹" "›" "‘" "’" "\'" "\'" "\\"" "\\""', // Wide default set to account for browser differences
+  'list-style-type': 'none',
+  display: 'inline',
+  'animation-name': 'none',
+  'text-transform': 'none',
+  'transition-property': 'all',
+  'transition-duration': '0s',
+  'counter-increment': 'none',
+  'counter-reset': 'none',
+  'counter-set': 'none',
+  'white-space': 'normal'
+};

--- a/lib/util/fonts/initialValueByProp.js
+++ b/lib/util/fonts/initialValueByProp.js
@@ -1,6 +1,6 @@
 module.exports = {
   // 'font-family': 'serif'
-  'font-weight': 400,
+  'font-weight': 'normal',
   'font-style': 'normal',
   'font-stretch': 'normal',
   content: 'normal',

--- a/lib/util/fonts/initialValueByProp.js
+++ b/lib/util/fonts/initialValueByProp.js
@@ -2,6 +2,7 @@ module.exports = {
   // 'font-family': 'serif'
   'font-weight': 400,
   'font-style': 'normal',
+  'font-stretch': 'normal',
   content: 'normal',
   quotes: '"«" "»" "‹" "›" "‘" "’" "\'" "\'" "\\"" "\\""', // Wide default set to account for browser differences
   'list-style-type': 'none',

--- a/lib/util/fonts/injectSubsetDefinitions.js
+++ b/lib/util/fonts/injectSubsetDefinitions.js
@@ -1,0 +1,44 @@
+const postCssValuesParser = require('postcss-values-parser');
+const unquote = require('./unquote');
+
+function injectSubsetDefinitions(cssValue, webfontNameMap) {
+  const subsetFontNames = new Set(Object.values(webfontNameMap));
+  const tokens = postCssValuesParser(cssValue).tokens;
+  let resultStr = '';
+  let isPreceededByWords = false;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    let possibleFontFamily;
+    if (token[0] === 'string') {
+      possibleFontFamily = unquote(token[1]);
+    } else if (token[0] === 'word') {
+      if (!isPreceededByWords) {
+        const wordSequence = [];
+        for (let j = i; j < tokens.length; j += 1) {
+          if (tokens[j][0] === 'word') {
+            wordSequence.push(tokens[j][1]);
+          } else if (tokens[j][0] !== 'space') {
+            break;
+          }
+        }
+        possibleFontFamily = wordSequence.join(' ');
+      }
+      isPreceededByWords = true;
+    } else if (token[0] !== 'space') {
+      isPreceededByWords = false;
+    }
+    if (possibleFontFamily) {
+      // Bail out, a subset font is already listed
+      if (subsetFontNames.has(possibleFontFamily)) {
+        return cssValue;
+      } else if (webfontNameMap[possibleFontFamily]) {
+        resultStr +=
+          "'" + webfontNameMap[possibleFontFamily].replace(/'/g, "\\'") + "', ";
+      }
+    }
+    resultStr += token[1];
+  }
+  return resultStr;
+}
+
+module.exports = injectSubsetDefinitions;

--- a/lib/util/fonts/normalizeFontWeight.js
+++ b/lib/util/fonts/normalizeFontWeight.js
@@ -1,6 +1,11 @@
 const cssFontWeightNames = require('css-font-weight-names');
 
 function normalizeFontWeight(value) {
+  if (typeof value === 'string') {
+    // FIXME: Stripping the +bolder... suffix here will not always yield the correct result
+    // when expanding animations and transitions
+    value = value.replace(/\+.*$/, '');
+  }
   return parseInt(cssFontWeightNames[value] || value);
 }
 

--- a/lib/util/fonts/normalizeFontWeight.js
+++ b/lib/util/fonts/normalizeFontWeight.js
@@ -1,0 +1,7 @@
+const cssFontWeightNames = require('css-font-weight-names');
+
+function normalizeFontWeight(value) {
+  return parseInt(cssFontWeightNames[value] || value);
+}
+
+module.exports = normalizeFontWeight;

--- a/lib/util/fonts/resolveFontWeight.js
+++ b/lib/util/fonts/resolveFontWeight.js
@@ -12,8 +12,6 @@ function ascending(a, b) {
  * @return {Number} Resulting font-weight after snapping to available weights
  */
 function resolveFontWeight(desiredWeight, availableWeights) {
-  desiredWeight = parseInt(desiredWeight);
-
   if (availableWeights.includes(desiredWeight)) {
     return desiredWeight;
   }

--- a/lib/util/fonts/snapToAvailableFontProperties.js
+++ b/lib/util/fonts/snapToAvailableFontProperties.js
@@ -2,6 +2,13 @@
 const _ = require('lodash');
 const unquote = require('./unquote');
 const resolveFontWeight = require('./resolveFontWeight');
+const normalizeFontWeight = require('./normalizeFontWeight');
+const initialValueByProp = _.pick(require('./initialValueByProp'), [
+  'font-family',
+  'font-stretch',
+  'font-weight',
+  'font-style'
+]);
 
 const fontStretchValues = [
   'ultra-condensed',
@@ -22,13 +29,6 @@ const styleLookupOrder = {
   oblique: ['oblique', 'italic', 'normal']
 };
 
-const INITIAL_VALUES = {
-  'font-family': undefined,
-  'font-stretch': 'normal',
-  'font-weight': 400,
-  'font-style': 'normal'
-};
-
 function ascending(a, b) {
   return a - b;
 }
@@ -37,7 +37,7 @@ function ascending(a, b) {
  * @typedef {Object} FontFaceDeclaration
  * @property {String} font-family - CSS [font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) property
  * @property {String} font-stretch - CSS [font-stretch](https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch) property
- * @property {Number} font-weight - CSS [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) property, must be normalized to numbers
+ * @property {String} font-weight - CSS [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) property, must be normalized to numbers
  * @property {String} font-style - CSS [font-style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style) property
  */
 
@@ -52,7 +52,6 @@ function snapToAvailableFontProperties(fontFaceDeclarations, propsToSnap) {
   if (!Array.isArray(fontFaceDeclarations)) {
     throw new TypeError('fontFaceDeclarations must be an array');
   }
-
   if (
     typeof propsToSnap !== 'object' ||
     Array.isArray(propsToSnap) ||
@@ -63,10 +62,10 @@ function snapToAvailableFontProperties(fontFaceDeclarations, propsToSnap) {
 
   // Fill in initial values for missing properties
   fontFaceDeclarations = fontFaceDeclarations.map(fontFaceDeclaration => ({
-    ...INITIAL_VALUES,
+    ...initialValueByProp,
     ...fontFaceDeclaration
   }));
-  propsToSnap = { ...INITIAL_VALUES, ...propsToSnap };
+  propsToSnap = { ...initialValueByProp, ...propsToSnap };
 
   // System font, we can't know about the full properties. Early exit
   if (typeof propsToSnap['font-family'] === 'undefined') {
@@ -132,32 +131,28 @@ function snapToAvailableFontProperties(fontFaceDeclarations, propsToSnap) {
   // Find the best font-weight
   const desiredWeight = propsToSnap['font-weight'];
   const availableFontWeights = styleMatches
-    .map(m => m['font-weight'])
+    .map(m => normalizeFontWeight(m['font-weight']))
     .sort(ascending);
   let resolvedWeight;
 
-  if (typeof desiredWeight === 'string') {
-    // Non-standard syntax from Assetgraph font tooling:
-    // '400+lighter+lighter'
-    // '200+bolder+bolder'
-    const operations = desiredWeight.split('+');
-    const startWeight = resolveFontWeight(
-      operations.shift(),
-      availableFontWeights
-    );
+  const [value, ...operations] = desiredWeight.split('+');
+  const startWeight = resolveFontWeight(
+    normalizeFontWeight(value),
+    availableFontWeights
+  );
 
-    resolvedWeight = operations.reduce((result, current) => {
-      const indexModifier = current === 'lighter' ? -1 : +1;
-      const nextIndex = availableFontWeights.indexOf(result) + indexModifier;
+  // Non-standard syntax from Assetgraph font tooling:
+  // '400+lighter+lighter'
+  // '200+bolder+bolder'
+  resolvedWeight = operations.reduce((result, current) => {
+    const indexModifier = current === 'lighter' ? -1 : +1;
+    const nextIndex = availableFontWeights.indexOf(result) + indexModifier;
 
-      return availableFontWeights[nextIndex] || result;
-    }, startWeight);
-  } else {
-    resolvedWeight = resolveFontWeight(desiredWeight, availableFontWeights);
-  }
-
+    return availableFontWeights[nextIndex] || result;
+  }, startWeight);
   return styleMatches.find(
-    styleMatch => styleMatch['font-weight'] === resolvedWeight
+    styleMatch =>
+      normalizeFontWeight(styleMatch['font-weight']) === resolvedWeight
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "normalizeurl": "^1.0.0",
     "perfectionist": "^2.4.0",
     "postcss": "^6.0.14",
+    "postcss-values-parser": "^1.5.0",
     "read-pkg-up": "^4.0.0",
     "repeat-string": "^1.5.4",
     "schemes": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "systemjs-builder": "^0.16.12",
     "unexpected": "^10.36.2",
     "unexpected-dom": "^4.0.0",
+    "unexpected-set": "^1.1.0",
     "unexpected-sinon": "^10.7.0",
     "webpack": "^4.8.3",
     "yui-compressor": "^0.1.3"

--- a/test/unexpected-with-plugins.js
+++ b/test/unexpected-with-plugins.js
@@ -2,5 +2,6 @@ module.exports = require('unexpected')
   .clone()
   .use(require('unexpected-sinon'))
   .use(require('unexpected-dom'))
+  .use(require('unexpected-set'))
   .use(require('./unexpectedAssetGraph'))
   .use(require('magicpen-prism'));

--- a/test/util/fonts/findCustomPropertyDefinitions.js
+++ b/test/util/fonts/findCustomPropertyDefinitions.js
@@ -1,0 +1,129 @@
+const expect = require('../../unexpected-with-plugins');
+const findCustomPropertyDefinitions = require('../../../lib/util/fonts/findCustomPropertyDefinitions');
+const AssetGraph = require('../../../lib/AssetGraph');
+
+describe('findCustomPropertyDefinitions', function() {
+  it('should find a single property', function() {
+    const assetGraph = new AssetGraph();
+    const cssAsset = assetGraph.addAsset({
+      type: 'Css',
+      text: `
+        :root {
+          --foo: abc;
+        }
+      `
+    });
+    expect(findCustomPropertyDefinitions([cssAsset]), 'to satisfy', {
+      '--foo': [{ value: 'abc' }]
+    });
+  });
+
+  it('should find multiple definitions of the same custom property', function() {
+    const assetGraph = new AssetGraph();
+    const cssAsset = assetGraph.addAsset({
+      type: 'Css',
+      text: `
+        :root {
+          --foo: abc;
+        }
+
+        html {
+          --foo: def;
+        }
+      `
+    });
+    expect(findCustomPropertyDefinitions([cssAsset]), 'to satisfy', {
+      '--foo': [{ value: 'abc' }, { value: 'def' }]
+    });
+  });
+
+  it('should include the definitions of custom properties that contribute', function() {
+    const assetGraph = new AssetGraph();
+    const cssAsset = assetGraph.addAsset({
+      type: 'Css',
+      text: `
+        :root {
+          --quux: def;
+          --bar: var(--quux);
+        }
+
+        html {
+          --foo: var(--bar);
+        }
+      `
+    });
+    expect(findCustomPropertyDefinitions([cssAsset]), 'to satisfy', {
+      '--foo': [
+        { prop: '--foo', value: 'var(--bar)' },
+        { prop: '--bar', value: 'var(--quux)' }
+      ],
+      '--bar': [
+        { prop: '--bar', value: 'var(--quux)' },
+        { prop: '--quux', value: 'def' }
+      ],
+      '--quux': [{ prop: '--quux', value: 'def' }]
+    });
+  });
+
+  it('should ignore custom property look-alikes inside strings', function() {
+    const assetGraph = new AssetGraph();
+    const cssAsset = assetGraph.addAsset({
+      type: 'Css',
+      text: `
+        :root {
+          --quux: def;
+          --bar: 'var(--quux)';
+        }
+
+        html {
+          --foo: var(--bar);
+        }
+      `
+    });
+    expect(findCustomPropertyDefinitions([cssAsset]), 'to satisfy', {
+      '--foo': [
+        { prop: '--foo', value: 'var(--bar)' },
+        { prop: '--bar', value: "'var(--quux)'" }
+      ],
+      '--bar': [{ prop: '--bar', value: "'var(--quux)'" }],
+      '--quux': [{ prop: '--quux', value: 'def' }]
+    });
+  });
+
+  it('should not break when there is a cyclic definition', function() {
+    const assetGraph = new AssetGraph();
+    const cssAsset = assetGraph.addAsset({
+      type: 'Css',
+      text: `
+        :root {
+          --foo: var(--bar);
+        }
+
+        html {
+          --bar: var(--foo);
+        }
+      `
+    });
+    expect(findCustomPropertyDefinitions([cssAsset]), 'to satisfy', {
+      '--foo': [
+        { prop: '--foo', value: 'var(--bar)' },
+        { prop: '--bar', value: 'var(--foo)' }
+      ]
+    });
+  });
+
+  it('should not break when an undefined custom property is referenced', function() {
+    const assetGraph = new AssetGraph();
+    const cssAsset = assetGraph.addAsset({
+      type: 'Css',
+      text: `
+        :root {
+          --foo: var(--bar);
+        }
+      `
+    });
+    expect(findCustomPropertyDefinitions([cssAsset]), 'to satisfy', {
+      '--foo': [{ prop: '--foo', value: 'var(--bar)' }]
+    });
+  });
+});

--- a/test/util/fonts/getCssRulesByProperty.js
+++ b/test/util/fonts/getCssRulesByProperty.js
@@ -116,21 +116,6 @@ describe('util/fonts/getCssRulesByProperty', function() {
   });
 
   describe('shorthand font-property', function() {
-    it('should ignore invalid shorthands', function() {
-      var result = getRules(
-        ['font-family', 'font-size'],
-        'h1 { font: 15px; }',
-        []
-      );
-
-      expect(result, 'to exhaustively satisfy', {
-        counterStyles: [],
-        keyframes: [],
-        'font-family': [],
-        'font-size': []
-      });
-    });
-
     it('register the longhand value from a valid shorthand', function() {
       var result = getRules(
         ['font-family', 'font-size'],
@@ -146,8 +131,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-family',
-            value: 'serif',
+            prop: 'font',
+            value: '15px serif',
             important: false
           }
         ],
@@ -156,8 +141,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-size',
-            value: '15px',
+            prop: 'font',
+            value: '15px serif',
             important: false
           }
         ]
@@ -179,8 +164,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-family',
-            value: 'serif',
+            prop: 'font',
+            value: '15px serif',
             important: false
           }
         ],
@@ -189,8 +174,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-size',
-            value: '15px',
+            prop: 'font',
+            value: '15px serif',
             important: false
           }
         ],
@@ -199,8 +184,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-style',
-            value: 'normal',
+            prop: 'font',
+            value: '15px serif',
             important: false
           }
         ],
@@ -209,8 +194,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-weight',
-            value: 400,
+            prop: 'font',
+            value: '15px serif',
             important: false
           }
         ]
@@ -232,8 +217,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-family',
-            value: 'serif',
+            prop: 'font',
+            value: '15px serif',
             important: false
           }
         ],
@@ -250,8 +235,8 @@ describe('util/fonts/getCssRulesByProperty', function() {
             selector: 'h1',
             predicates: {},
             specificityArray: [0, 0, 0, 1],
-            prop: 'font-size',
-            value: '15px',
+            prop: 'font',
+            value: '15px serif',
             important: false
           },
           {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4474,11 +4474,11 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
       });
     });
 
-    describe.skip('with custom properties in the font shorthand value', function() {
+    describe('with custom properties in the font shorthand value', function() {
       it('should support a simple font-family value', function() {
         var htmlText = [
           '<style>:root { --my-prop: foo; }</style>',
-          '<style>div { font: var(--my-prop) }</style>',
+          '<style>div { font: 12px var(--my-prop) }</style>',
           '<div>bar</div>'
         ].join('\n');
 

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4473,5 +4473,37 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         );
       });
     });
+
+    it('should support custom property expansion in the content property', function() {
+      var htmlText = [
+        "<style>:root { --my-prop: 'the value'; }</style>",
+        "<style>@media projection { :root { --my-prop: 'the other value'; } }</style>",
+        '<style>div:after { content: var(--my-prop) }</style>',
+        '<div></div>'
+      ].join('\n');
+
+      return expect(
+        htmlText,
+        'to exhaustively satisfy computed font properties',
+        [
+          {
+            text: 'the other value',
+            props: {
+              'font-family': undefined,
+              'font-weight': 400,
+              'font-style': 'normal'
+            }
+          },
+          {
+            text: 'the value',
+            props: {
+              'font-family': undefined,
+              'font-weight': 400,
+              'font-style': 'normal'
+            }
+          }
+        ]
+      );
+    });
   });
 });

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4331,6 +4331,59 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
       });
     });
 
+    describe('with circular references', function() {
+      it('should expand to the initial value when a custom property is defined in terms of itself', async function() {
+        await expect(
+          `
+            <style>
+              :root {
+                --my-font: var(--my-font);
+              }
+            </style>
+
+            <div>quux</div>
+          `,
+          'to exhaustively satisfy computed font properties',
+          [
+            {
+              text: 'quux',
+              props: {
+                'font-family': undefined,
+                'font-style': 'normal',
+                'font-weight': 400
+              }
+            }
+          ]
+        );
+      });
+
+      it('should expand to the initial value when there is a circular reference', async function() {
+        await expect(
+          `
+            <style>
+              :root {
+                --my-font: var(--my-other-font);
+                --my-other-font: var(--my-font);
+              }
+            </style>
+
+            <div>quux</div>
+          `,
+          'to exhaustively satisfy computed font properties',
+          [
+            {
+              text: 'quux',
+              props: {
+                'font-family': undefined,
+                'font-style': 'normal',
+                'font-weight': 400
+              }
+            }
+          ]
+        );
+      });
+    });
+
     describe('combined with CSS animations', function() {
       it('should pick up all values of font-style used in an animation', function() {
         var htmlText = [

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -134,7 +134,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
     );
   });
 
-  it('should unquote single quoted font-family', function() {
+  it('should trace a single quoted font-family', function() {
     var htmlText = [
       "<style>body { font-family: 'font 1'; }</style>",
       'text'
@@ -147,7 +147,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         {
           text: 'text',
           props: {
-            'font-family': 'font 1',
+            'font-family': "'font 1'",
             'font-weight': 'normal',
             'font-style': 'normal'
           }
@@ -156,7 +156,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
     );
   });
 
-  it('should unquote double quoted font-family', function() {
+  it('should trace a double quoted font-family', function() {
     var htmlText = [
       '<style>body { font-family: "font 1"; }</style>',
       'text'
@@ -169,7 +169,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         {
           text: 'text',
           props: {
-            'font-family': 'font 1',
+            'font-family': '"font 1"',
             'font-weight': 'normal',
             'font-style': 'normal'
           }
@@ -1790,7 +1790,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           {
             text: 'foo',
             props: {
-              'font-family': 'myClass',
+              'font-family': '"myClass"',
               'font-weight': '900',
               'font-style': 'normal'
             }
@@ -1798,7 +1798,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           {
             text: 'foo',
             props: {
-              'font-family': 'myClass',
+              'font-family': '"myClass"',
               'font-weight': 'normal',
               'font-style': 'normal'
             }
@@ -2805,7 +2805,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           {
             text: 'foo',
             props: {
-              'font-family': 'famfam',
+              'font-family': '"famfam"',
               'font-weight': 'bold',
               'font-style': 'normal'
             }
@@ -2827,7 +2827,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           {
             text: 'foo',
             props: {
-              'font-family': 'famfam',
+              'font-family': '"famfam"',
               'font-weight': 'normal',
               'font-style': 'normal'
             }
@@ -4266,7 +4266,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             {
               text: 'quux',
               props: {
-                'font-family': 'foo',
+                'font-family': "'foo'",
                 'font-style': 'normal',
                 'font-weight': 'normal'
               }
@@ -4295,7 +4295,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             {
               text: 'quux',
               props: {
-                'font-family': 'bar',
+                'font-family': "'bar'",
                 'font-style': 'normal',
                 'font-weight': 'normal'
               }
@@ -4380,7 +4380,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             {
               text: 'quux',
               props: {
-                'font-family': 'var(--my-font)',
+                'font-family': "'var(--my-font)'",
                 'font-style': 'normal',
                 'font-weight': 'normal'
               }

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4474,6 +4474,23 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
       });
     });
 
+    it('should support custom property expansion in the font shorthand property', function() {
+      var htmlText = [
+        "<style>:root { --my-prop: 'foo'; }</style>",
+        '<style>div { font: var(--my-prop) }</style>',
+        '<div>bar</div>'
+      ].join('\n');
+
+      return expect(htmlText, 'to satisfy computed font properties', [
+        {
+          text: 'bar',
+          props: {
+            'font-family': 'foo'
+          }
+        }
+      ]);
+    });
+
     it('should support custom property expansion in the content property', function() {
       var htmlText = [
         "<style>:root { --my-prop: 'the value'; }</style>",

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4190,6 +4190,47 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
       );
     });
 
+    it('should not break when expanding custom properties that lead to impossible predicate combinations', async function() {
+      await expect(
+        `
+          <style>
+            :root {
+              --my-font: bar;
+              font: normal 12px var(--my-font);
+            }
+
+            @media 3dglasses {
+              :root {
+                --my-font: foo;
+                font: bold 14px var(--my-font);
+              }
+            }
+          </style>
+
+          <div>baz</div>
+        `,
+        'to exhaustively satisfy computed font properties',
+        [
+          {
+            text: 'baz',
+            props: {
+              'font-family': 'foo',
+              'font-style': 'normal',
+              'font-weight': 700
+            }
+          },
+          {
+            text: 'baz',
+            props: {
+              'font-family': 'bar',
+              'font-style': 'normal',
+              'font-weight': 400
+            }
+          }
+        ]
+      );
+    });
+
     describe('with a default value', function() {
       it('should use the default value when the custom property is not defined', async function() {
         await expect(

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4505,5 +4505,25 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ]
       );
     });
+
+    it('should support custom property expansion in the counter-increment property', function() {
+      var htmlText = [
+        '<html><head>',
+        '<style>:root { --my-increment: 10; }</style>',
+        '<style>@media screen { :root { --my-increment: 8; } }</style>',
+        '<style>html { counter-reset: section 0; }</style>',
+        '<style>div:before { content: counter(section, decimal); }</style>',
+        '<style>div { font-family: font1; counter-increment: section var(--my-increment); }</style>',
+        '</head><body>',
+        '<div></div>',
+        '<div></div>',
+        '</body></html>'
+      ].join('\n');
+
+      return expect(htmlText, 'to satisfy computed font properties', [
+        { text: '810' },
+        { text: '161820' }
+      ]);
+    });
   });
 });

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4330,5 +4330,47 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         );
       });
     });
+
+    describe('combined with CSS animations', function() {
+      it('should pick up all values of font-style used in an animation', function() {
+        var htmlText = [
+          '<style>:root { --my-font-style: normal }</style>',
+          '<style>@keyframes foo { 50% { --my-font-style: oblique } 100% { --my-font-style: italic } }</style>',
+          '<style>h1 { font-style: var(--my-font-style); animation-name: foo; }</style>',
+          '<h1>bar</h1>'
+        ].join('\n');
+
+        return expect(
+          htmlText,
+          'to exhaustively satisfy computed font properties',
+          [
+            {
+              text: 'bar',
+              props: {
+                'font-family': undefined,
+                'font-weight': 700,
+                'font-style': 'normal'
+              }
+            },
+            {
+              text: 'bar',
+              props: {
+                'font-family': undefined,
+                'font-weight': 700,
+                'font-style': 'oblique'
+              }
+            },
+            {
+              text: 'bar',
+              props: {
+                'font-family': undefined,
+                'font-weight': 700,
+                'font-style': 'italic'
+              }
+            }
+          ]
+        );
+      });
+    });
   });
 });

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -40,7 +40,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'div',
           props: {
             'font-family': undefined,
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           }
         }
@@ -59,7 +59,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'div',
           props: {
             'font-family': undefined,
-            'font-weight': 700,
+            'font-weight': 'bold',
             'font-style': 'normal'
           }
         }
@@ -81,7 +81,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'div',
           props: {
             'font-family': undefined,
-            'font-weight': 700,
+            'font-weight': 'bold',
             'font-style': 'normal'
           }
         }
@@ -102,7 +102,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'div',
           props: {
             'font-family': undefined,
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           }
         },
@@ -110,7 +110,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'strong',
           props: {
             'font-family': undefined,
-            'font-weight': '400+bolder',
+            'font-weight': 'normal+bolder',
             'font-style': 'normal'
           }
         },
@@ -118,7 +118,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'strong',
           props: {
             'font-family': undefined,
-            'font-weight': 700,
+            'font-weight': 'bold',
             'font-style': 'normal'
           }
         },
@@ -126,7 +126,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'em',
           props: {
             'font-family': undefined,
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'italic'
           }
         }
@@ -148,7 +148,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'text',
           props: {
             'font-family': 'font 1',
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           }
         }
@@ -170,7 +170,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'text',
           props: {
             'font-family': 'font 1',
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           }
         }
@@ -178,7 +178,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
     );
   });
 
-  it('should return font-weight as a number', function() {
+  it('should return font-weight as a string', function() {
     var htmlText = ['<style>body { font-weight: 500; }</style>', 'text'].join(
       '\n'
     );
@@ -191,7 +191,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'text',
           props: {
             'font-family': undefined,
-            'font-weight': 500,
+            'font-weight': '500',
             'font-style': 'normal'
           }
         }
@@ -214,7 +214,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'h1',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -236,7 +236,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'div',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -258,7 +258,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'div',
             props: {
               'font-family': undefined,
-              'font-weight': 300,
+              'font-weight': 'light',
               'font-style': 'normal'
             }
           }
@@ -280,7 +280,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'div',
             props: {
               'font-family': undefined,
-              'font-weight': 300,
+              'font-weight': 'light',
               'font-style': 'normal'
             }
           }
@@ -302,7 +302,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'div',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -324,7 +324,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'div',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -346,7 +346,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'div',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -368,7 +368,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'div',
             props: {
               'font-family': undefined,
-              'font-weight': 300,
+              'font-weight': 'light',
               'font-style': 'normal'
             }
           }
@@ -392,7 +392,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -400,7 +400,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -421,7 +421,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         {
           props: {
             'font-family': undefined,
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           },
           text: 'button'
@@ -429,7 +429,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         {
           props: {
             'font-family': undefined,
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           },
           text: 'option'
@@ -437,7 +437,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         {
           props: {
             'font-family': undefined,
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           },
           text: 'textarea'
@@ -445,7 +445,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         {
           props: {
             'font-family': undefined,
-            'font-weight': 400,
+            'font-weight': 'normal',
             'font-style': 'normal'
           },
           text: 'input'
@@ -540,7 +540,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'span',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -564,7 +564,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'span',
             props: {
               'font-family': undefined,
-              'font-weight': '400+lighter',
+              'font-weight': 'normal+lighter',
               'font-style': 'normal'
             }
           }
@@ -666,7 +666,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'span',
             props: {
               'font-family': undefined,
-              'font-weight': '400+bolder',
+              'font-weight': 'normal+bolder',
               'font-style': 'normal'
             }
           }
@@ -945,7 +945,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'bar',
           props: {
             'font-family': 'font2',
-            'font-weight': 700,
+            'font-weight': 'bold',
             'font-style': 'normal'
           }
         },
@@ -953,7 +953,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           text: 'foo',
           props: {
             'font-family': 'font1',
-            'font-weight': 700,
+            'font-weight': 'bold',
             'font-style': 'normal'
           }
         }
@@ -976,7 +976,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'h1',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -984,7 +984,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'after',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -1035,7 +1035,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '<',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1058,7 +1058,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '>]',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1082,7 +1082,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '(',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1090,7 +1090,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '<',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1109,7 +1109,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '«‹‘\'"',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1117,7 +1117,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '»›’\'"',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1141,7 +1141,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'h1',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -1149,7 +1149,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'after',
             props: {
               'font-family': 'font2',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -1172,7 +1172,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'h1',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -1180,7 +1180,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'after',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -1203,7 +1203,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'h1',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -1211,7 +1211,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'after',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -1236,7 +1236,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'p',
             props: {
               'font-family': undefined,
-              'font-weight': 200,
+              'font-weight': '200',
               'font-style': 'normal'
             }
           },
@@ -1244,7 +1244,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'after',
             props: {
               'font-family': 'font1',
-              'font-weight': 200,
+              'font-weight': '200',
               'font-style': 'normal'
             }
           },
@@ -1252,7 +1252,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'article',
             props: {
               'font-family': undefined,
-              'font-weight': 600,
+              'font-weight': '600',
               'font-style': 'normal'
             }
           },
@@ -1260,7 +1260,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'after',
             props: {
               'font-family': 'font1',
-              'font-weight': 600,
+              'font-weight': '600',
               'font-style': 'normal'
             }
           }
@@ -1282,7 +1282,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -1308,7 +1308,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -1316,7 +1316,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -1343,7 +1343,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '1.',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1369,7 +1369,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'I.',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1396,7 +1396,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓐ.',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1420,7 +1420,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '0.',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1445,7 +1445,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '0.',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1470,7 +1470,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓐ',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1478,7 +1478,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1501,7 +1501,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'a',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1509,7 +1509,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'b',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1517,7 +1517,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'c',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1525,7 +1525,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'd',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1533,7 +1533,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '"',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1541,7 +1541,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: "'",
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1549,7 +1549,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '7',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1572,7 +1572,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'pⒶsq',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1595,7 +1595,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓐ',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1603,7 +1603,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1611,7 +1611,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'II',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1635,7 +1635,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓐ',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1643,7 +1643,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓓ',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1670,7 +1670,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓐ',
               props: {
                 'font-family': 'font2',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1678,7 +1678,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓓ',
               props: {
                 'font-family': 'font2',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -1686,7 +1686,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'Ⓐ',
               props: {
                 'font-family': 'font1',
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -1717,7 +1717,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
                 text: 'Ⓓ',
                 props: {
                   'font-family': 'font1',
-                  'font-weight': 400,
+                  'font-weight': 'normal',
                   'font-style': 'normal'
                 }
               },
@@ -1725,7 +1725,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
                 text: 'Ⓕ',
                 props: {
                   'font-family': 'font1',
-                  'font-weight': 400,
+                  'font-weight': 'normal',
                   'font-style': 'normal'
                 }
               },
@@ -1733,7 +1733,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
                 text: 'VIII',
                 props: {
                   'font-family': 'font1',
-                  'font-weight': 400,
+                  'font-weight': 'normal',
                   'font-style': 'normal'
                 }
               }
@@ -1757,7 +1757,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bazbaryadda',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -1783,7 +1783,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'text',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -1791,7 +1791,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'myClass',
-              'font-weight': 900,
+              'font-weight': '900',
               'font-style': 'normal'
             }
           },
@@ -1799,7 +1799,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'myClass',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -1807,7 +1807,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -1830,7 +1830,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'h1',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -1838,7 +1838,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -1846,7 +1846,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -1869,7 +1869,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'before',
             props: {
               'font-family': 'font2',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -1877,7 +1877,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'h1',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -1885,7 +1885,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'after',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -1901,8 +1901,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'f', props: { 'font-weight': 700 } },
-          { text: 'oo', props: { 'font-weight': 400 } }
+          { text: 'f', props: { 'font-weight': '700' } },
+          { text: 'oo', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -1913,8 +1913,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'f', props: { 'font-weight': 700 } },
-          { text: 'oo', props: { 'font-weight': 400 } }
+          { text: 'f', props: { 'font-weight': '700' } },
+          { text: 'oo', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -1925,7 +1925,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'foo', props: { 'font-weight': 400 } }
+          { text: 'foo', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -1936,8 +1936,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'foo', props: { 'font-weight': 400 } },
-          { text: 'bar', props: { 'font-weight': 400 } }
+          { text: 'foo', props: { 'font-weight': 'normal' } },
+          { text: 'bar', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -1948,8 +1948,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: '"f', props: { 'font-weight': 700 } },
-          { text: 'oo', props: { 'font-weight': 400 } }
+          { text: '"f', props: { 'font-weight': '700' } },
+          { text: 'oo', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -1961,8 +1961,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: '"a', props: { 'font-weight': 700 } },
-          { text: 'foo', props: { 'font-weight': 400 } }
+          { text: '"a', props: { 'font-weight': '700' } },
+          { text: 'foo', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -1974,8 +1974,14 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'a', props: { 'font-weight': 700, 'font-style': 'italic' } },
-          { text: 'foo', props: { 'font-weight': 400, 'font-style': 'normal' } }
+          {
+            text: 'a',
+            props: { 'font-weight': '700', 'font-style': 'italic' }
+          },
+          {
+            text: 'foo',
+            props: { 'font-weight': 'normal', 'font-style': 'normal' }
+          }
         ]);
       });
 
@@ -1987,7 +1993,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: '"a', props: { 'font-weight': 700 } }
+          { text: '"a', props: { 'font-weight': '700' } }
         ]);
       });
 
@@ -2000,8 +2006,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: '"', props: { 'font-weight': 700 } },
-          { text: 'foo', props: { 'font-weight': 400 } }
+          { text: '"', props: { 'font-weight': '700' } },
+          { text: 'foo', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -2013,9 +2019,9 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'b', props: { 'font-weight': 700 } },
-          { text: 'ar', props: { 'font-weight': 200 } },
-          { text: 'foo', props: { 'font-weight': 400 } }
+          { text: 'b', props: { 'font-weight': '700' } },
+          { text: 'ar', props: { 'font-weight': '200' } },
+          { text: 'foo', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -2027,8 +2033,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'f', props: { 'font-weight': 700 } },
-          { text: 'oo', props: { 'font-weight': 200 } }
+          { text: 'f', props: { 'font-weight': '700' } },
+          { text: 'oo', props: { 'font-weight': '200' } }
         ]);
       });
 
@@ -2040,10 +2046,10 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'a', props: { 'font-weight': 700 } },
-          { text: 'f', props: { 'font-weight': 700 } },
-          { text: 'bc', props: { 'font-weight': 400 } },
-          { text: 'oo', props: { 'font-weight': 400 } }
+          { text: 'a', props: { 'font-weight': '700' } },
+          { text: 'f', props: { 'font-weight': '700' } },
+          { text: 'bc', props: { 'font-weight': 'normal' } },
+          { text: 'oo', props: { 'font-weight': 'normal' } }
         ]);
       });
     });
@@ -2056,8 +2062,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'foo bar quux', props: { 'font-weight': 700 } },
-          { text: 'foo bar quux', props: { 'font-weight': 400 } }
+          { text: 'foo bar quux', props: { 'font-weight': '700' } },
+          { text: 'foo bar quux', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -2069,10 +2075,22 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'f', props: { 'font-weight': 700, 'font-style': 'italic' } },
-          { text: 'f', props: { 'font-weight': 700, 'font-style': 'normal' } },
-          { text: 'oo', props: { 'font-weight': 200, 'font-style': 'italic' } },
-          { text: 'oo', props: { 'font-weight': 400, 'font-style': 'normal' } }
+          {
+            text: 'f',
+            props: { 'font-weight': '700', 'font-style': 'italic' }
+          },
+          {
+            text: 'f',
+            props: { 'font-weight': '700', 'font-style': 'normal' }
+          },
+          {
+            text: 'oo',
+            props: { 'font-weight': '200', 'font-style': 'italic' }
+          },
+          {
+            text: 'oo',
+            props: { 'font-weight': 'normal', 'font-style': 'normal' }
+          }
         ]);
       });
 
@@ -2083,8 +2101,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'foo bar', props: { 'font-weight': 700 } },
-          { text: 'foo bar\nquux', props: { 'font-weight': 400 } }
+          { text: 'foo bar', props: { 'font-weight': '700' } },
+          { text: 'foo bar\nquux', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -2095,8 +2113,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'foo bar', props: { 'font-weight': 700 } },
-          { text: 'foo bar\nquux', props: { 'font-weight': 400 } }
+          { text: 'foo bar', props: { 'font-weight': '700' } },
+          { text: 'foo bar\nquux', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -2107,8 +2125,8 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'foo bar', props: { 'font-weight': 700 } },
-          { text: 'foo bar\nquux', props: { 'font-weight': 400 } }
+          { text: 'foo bar', props: { 'font-weight': '700' } },
+          { text: 'foo bar\nquux', props: { 'font-weight': 'normal' } }
         ]);
       });
 
@@ -2122,19 +2140,19 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         return expect(htmlText, 'to satisfy computed font properties', [
           {
             text: 'foo bar',
-            props: { 'font-weight': 700, 'font-style': 'italic' }
+            props: { 'font-weight': '700', 'font-style': 'italic' }
           },
           {
             text: 'foo bar quux',
-            props: { 'font-weight': 700, 'font-style': 'normal' }
+            props: { 'font-weight': '700', 'font-style': 'normal' }
           },
           {
             text: 'foo bar\nquux',
-            props: { 'font-weight': 400, 'font-style': 'italic' }
+            props: { 'font-weight': 'normal', 'font-style': 'italic' }
           },
           {
             text: 'foo bar quux',
-            props: { 'font-weight': 400, 'font-style': 'normal' }
+            props: { 'font-weight': 'normal', 'font-style': 'normal' }
           }
         ]);
       });
@@ -2148,12 +2166,12 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
         ].join('\n');
 
         return expect(htmlText, 'to satisfy computed font properties', [
-          { text: 'foo', props: { 'font-weight': 700 } },
-          { text: 'bar', props: { 'font-weight': 700 } },
-          { text: 'quux', props: { 'font-weight': 700 } },
-          { text: 'foo', props: { 'font-weight': 400 } },
-          { text: 'bar', props: { 'font-weight': 400 } },
-          { text: 'quux', props: { 'font-weight': 400 } }
+          { text: 'foo', props: { 'font-weight': '700' } },
+          { text: 'bar', props: { 'font-weight': '700' } },
+          { text: 'quux', props: { 'font-weight': '700' } },
+          { text: 'foo', props: { 'font-weight': 'normal' } },
+          { text: 'bar', props: { 'font-weight': 'normal' } },
+          { text: 'quux', props: { 'font-weight': 'normal' } }
         ]);
       });
     });
@@ -2198,7 +2216,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '1.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2206,7 +2224,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2228,7 +2246,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2236,7 +2254,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2258,7 +2276,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2266,7 +2284,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2288,7 +2306,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'yeah',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2296,7 +2314,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2318,7 +2336,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2326,7 +2344,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2348,7 +2366,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2371,7 +2389,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           },
@@ -2379,7 +2397,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '1.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           },
@@ -2387,7 +2405,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'Hello',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           }
@@ -2410,7 +2428,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '1.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2418,7 +2436,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '2.',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'normal'
             }
           },
@@ -2426,7 +2444,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '2.3.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2434,7 +2452,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '3.4.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2458,7 +2476,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2466,7 +2484,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2474,7 +2492,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2496,7 +2514,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -2504,7 +2522,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2526,7 +2544,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 500,
+              'font-weight': '500',
               'font-style': 'normal'
             }
           },
@@ -2534,7 +2552,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           }
@@ -2556,7 +2574,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2564,7 +2582,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2572,7 +2590,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2580,7 +2598,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2604,7 +2622,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 500,
+              'font-weight': '500',
               'font-style': 'normal'
             }
           },
@@ -2612,7 +2630,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           }
@@ -2635,7 +2653,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font2',
-              'font-weight': 800,
+              'font-weight': '800',
               'font-style': 'normal'
             }
           },
@@ -2643,7 +2661,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'font1',
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           }
@@ -2666,7 +2684,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-style': 'normal',
-              'font-weight': 800,
+              'font-weight': '800',
               'font-family': 'font2'
             }
           },
@@ -2674,7 +2692,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-style': 'normal',
-              'font-weight': 500,
+              'font-weight': '500',
               'font-family': 'font2'
             }
           },
@@ -2682,7 +2700,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-style': 'normal',
-              'font-weight': 400,
+              'font-weight': '400',
               'font-family': 'font1'
             }
           }
@@ -2705,7 +2723,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-style': 'normal',
-              'font-weight': 800,
+              'font-weight': '800',
               'font-family': 'font2'
             }
           },
@@ -2713,7 +2731,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-style': 'normal',
-              'font-weight': 500,
+              'font-weight': '500',
               'font-family': 'font2'
             }
           },
@@ -2721,7 +2739,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-style': 'normal',
-              'font-weight': 400,
+              'font-weight': '400',
               'font-family': 'font1'
             }
           }
@@ -2748,7 +2766,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 500,
+              'font-weight': '500',
               'font-style': 'normal'
             }
           },
@@ -2756,7 +2774,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 600,
+              'font-weight': '600',
               'font-style': 'normal'
             }
           },
@@ -2764,7 +2782,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'normal'
             }
           }
@@ -2788,7 +2806,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'famfam',
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -2810,7 +2828,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': 'famfam',
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2835,7 +2853,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 100,
+              'font-weight': '100',
               'font-style': 'normal'
             }
           },
@@ -2843,7 +2861,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 200,
+              'font-weight': '200',
               'font-style': 'normal'
             }
           },
@@ -2851,7 +2869,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 300,
+              'font-weight': '300',
               'font-style': 'normal'
             }
           },
@@ -2859,7 +2877,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           }
@@ -2882,7 +2900,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -2890,7 +2908,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'oblique'
             }
           },
@@ -2898,7 +2916,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'italic'
             }
           }
@@ -2921,7 +2939,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'quux',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2929,7 +2947,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '1.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2937,7 +2955,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -2945,7 +2963,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -2968,7 +2986,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 100,
+              'font-weight': '100',
               'font-style': 'normal'
             }
           },
@@ -2976,7 +2994,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 200,
+              'font-weight': '200',
               'font-style': 'normal'
             }
           },
@@ -2984,7 +3002,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 300,
+              'font-weight': '300',
               'font-style': 'normal'
             }
           },
@@ -2992,7 +3010,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           }
@@ -3016,7 +3034,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -3024,7 +3042,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -3048,7 +3066,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': '400',
               'font-style': 'normal'
             }
           },
@@ -3056,7 +3074,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 100,
+              'font-weight': '100',
               'font-style': 'normal'
             }
           },
@@ -3064,7 +3082,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 200,
+              'font-weight': '200',
               'font-style': 'normal'
             }
           },
@@ -3072,7 +3090,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 300,
+              'font-weight': '300',
               'font-style': 'normal'
             }
           },
@@ -3080,7 +3098,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 500,
+              'font-weight': '500',
               'font-style': 'normal'
             }
           },
@@ -3088,7 +3106,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 600,
+              'font-weight': '600',
               'font-style': 'normal'
             }
           },
@@ -3096,7 +3114,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'normal'
             }
           }
@@ -3122,7 +3140,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             },
@@ -3130,7 +3148,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': '400',
                 'font-style': 'normal'
               }
             },
@@ -3138,7 +3156,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 500,
+                'font-weight': '500',
                 'font-style': 'normal'
               }
             },
@@ -3146,7 +3164,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 600,
+                'font-weight': '600',
                 'font-style': 'normal'
               }
             }
@@ -3171,7 +3189,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             },
@@ -3179,7 +3197,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': '400',
                 'font-style': 'normal'
               }
             },
@@ -3187,7 +3205,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 500,
+                'font-weight': '500',
                 'font-style': 'normal'
               }
             },
@@ -3195,7 +3213,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 600,
+                'font-weight': '600',
                 'font-style': 'normal'
               }
             }
@@ -3218,7 +3236,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             },
@@ -3226,7 +3244,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': '400',
                 'font-style': 'normal'
               }
             },
@@ -3234,7 +3252,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 500,
+                'font-weight': '500',
                 'font-style': 'normal'
               }
             },
@@ -3242,7 +3260,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 600,
+                'font-weight': '600',
                 'font-style': 'normal'
               }
             }
@@ -3265,7 +3283,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             },
@@ -3273,7 +3291,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': '400',
                 'font-style': 'normal'
               }
             }
@@ -3303,7 +3321,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             }
@@ -3326,7 +3344,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3352,7 +3370,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             }
@@ -3378,7 +3396,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '1.',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -3386,7 +3404,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'I.II.',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3410,7 +3428,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             },
@@ -3418,7 +3436,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3445,7 +3463,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'italic'
               }
             },
@@ -3453,7 +3471,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3480,7 +3498,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'italic'
               }
             },
@@ -3488,7 +3506,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'italic'
               }
             },
@@ -3496,7 +3514,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             },
@@ -3504,7 +3522,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3528,7 +3546,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             }
@@ -3549,7 +3567,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3575,7 +3593,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             }
@@ -3601,7 +3619,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: '1.',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             },
@@ -3609,7 +3627,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'I.II.',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3631,7 +3649,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'normal'
               }
             },
@@ -3639,7 +3657,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3662,7 +3680,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': '700',
                 'font-style': 'italic'
               }
             },
@@ -3670,7 +3688,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'foo',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -3694,7 +3712,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'italic'
             }
           },
@@ -3702,7 +3720,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'normal'
             }
           }
@@ -3726,7 +3744,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'normal'
             }
           }
@@ -3745,7 +3763,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -3771,7 +3789,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'normal'
             }
           }
@@ -3797,7 +3815,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: '1.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -3805,7 +3823,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'I.II.',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -3827,7 +3845,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'normal'
             }
           },
@@ -3835,7 +3853,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -3858,7 +3876,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': '700',
               'font-style': 'italic'
             }
           },
@@ -3866,7 +3884,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }
@@ -3895,7 +3913,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': '700+bolder',
+              'font-weight': 'bold+bolder',
               'font-style': 'normal'
             }
           },
@@ -3903,7 +3921,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'bar',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           },
@@ -3911,7 +3929,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'foo',
             props: {
               'font-family': undefined,
-              'font-weight': 700,
+              'font-weight': 'bold',
               'font-style': 'normal'
             }
           }
@@ -3934,7 +3952,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           props: {
             'font-family': undefined,
             'font-style': 'normal',
-            'font-weight': 700
+            'font-weight': 'bold'
           }
         }
       ]
@@ -3964,7 +3982,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'foo',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4001,7 +4019,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'bar',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           },
           {
@@ -4009,7 +4027,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'foo',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4046,7 +4064,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'bar',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           },
           {
@@ -4054,7 +4072,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'foo',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4087,7 +4105,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'foo',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4123,7 +4141,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'bar',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           },
           {
@@ -4131,7 +4149,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'foo',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           },
           {
@@ -4139,7 +4157,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': undefined,
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4175,7 +4193,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'foo',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           },
           {
@@ -4183,7 +4201,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'bar',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4216,7 +4234,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'foo',
               'font-style': 'normal',
-              'font-weight': 700
+              'font-weight': 'bold'
             }
           },
           {
@@ -4224,7 +4242,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': 'bar',
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4250,7 +4268,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               props: {
                 'font-family': 'foo',
                 'font-style': 'normal',
-                'font-weight': 400
+                'font-weight': 'normal'
               }
             }
           ]
@@ -4279,7 +4297,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               props: {
                 'font-family': 'bar',
                 'font-style': 'normal',
-                'font-weight': 400
+                'font-weight': 'normal'
               }
             }
           ]
@@ -4305,7 +4323,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             props: {
               'font-family': undefined,
               'font-style': 'normal',
-              'font-weight': 400
+              'font-weight': 'normal'
             }
           }
         ]
@@ -4335,7 +4353,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               props: {
                 'font-family': undefined,
                 'font-style': 'normal',
-                'font-weight': 400
+                'font-weight': 'normal'
               }
             }
           ]
@@ -4364,7 +4382,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               props: {
                 'font-family': 'var(--my-font)',
                 'font-style': 'normal',
-                'font-weight': 400
+                'font-weight': 'normal'
               }
             }
           ]
@@ -4391,7 +4409,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               props: {
                 'font-family': undefined,
                 'font-style': 'normal',
-                'font-weight': 400
+                'font-weight': 'normal'
               }
             }
           ]
@@ -4417,7 +4435,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               props: {
                 'font-family': undefined,
                 'font-style': 'normal',
-                'font-weight': 400
+                'font-weight': 'normal'
               }
             }
           ]
@@ -4442,7 +4460,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': 'bold',
                 'font-style': 'normal'
               }
             },
@@ -4450,7 +4468,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': 'bold',
                 'font-style': 'oblique'
               }
             },
@@ -4458,7 +4476,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 700,
+                'font-weight': 'bold',
                 'font-style': 'italic'
               }
             }
@@ -4482,7 +4500,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 100,
+                'font-weight': '100',
                 'font-style': 'normal'
               }
             },
@@ -4490,7 +4508,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 200,
+                'font-weight': '200',
                 'font-style': 'normal'
               }
             },
@@ -4498,7 +4516,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 300,
+                'font-weight': '300',
                 'font-style': 'normal'
               }
             },
@@ -4506,7 +4524,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
               text: 'bar',
               props: {
                 'font-family': undefined,
-                'font-weight': 400,
+                'font-weight': 'normal',
                 'font-style': 'normal'
               }
             }
@@ -4567,7 +4585,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'the other value',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           },
@@ -4575,7 +4593,7 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
             text: 'the value',
             props: {
               'font-family': undefined,
-              'font-weight': 400,
+              'font-weight': 'normal',
               'font-style': 'normal'
             }
           }

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4474,21 +4474,40 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
       });
     });
 
-    it('should support custom property expansion in the font shorthand property', function() {
-      var htmlText = [
-        "<style>:root { --my-prop: 'foo'; }</style>",
-        '<style>div { font: var(--my-prop) }</style>',
-        '<div>bar</div>'
-      ].join('\n');
+    describe.skip('with custom properties in the font shorthand value', function() {
+      it('should support a simple font-family value', function() {
+        var htmlText = [
+          '<style>:root { --my-prop: foo; }</style>',
+          '<style>div { font: var(--my-prop) }</style>',
+          '<div>bar</div>'
+        ].join('\n');
 
-      return expect(htmlText, 'to satisfy computed font properties', [
-        {
-          text: 'bar',
-          props: {
-            'font-family': 'foo'
+        return expect(htmlText, 'to satisfy computed font properties', [
+          {
+            text: 'bar',
+            props: {
+              'font-family': 'foo'
+            }
           }
-        }
-      ]);
+        ]);
+      });
+
+      it('should a complex value', function() {
+        var htmlText = [
+          '<style>:root { --my-prop: ultra-expanded 12px foo; }</style>',
+          '<style>div { font: var(--my-prop) }</style>',
+          '<div>bar</div>'
+        ].join('\n');
+
+        return expect(htmlText, 'to satisfy computed font properties', [
+          {
+            text: 'bar',
+            props: {
+              'font-family': 'foo'
+            }
+          }
+        ]);
+      });
     });
 
     it('should support custom property expansion in the content property', function() {

--- a/test/util/fonts/getTextByFontProperties.js
+++ b/test/util/fonts/getTextByFontProperties.js
@@ -4424,6 +4424,54 @@ describe('lib/util/fonts/getTextByFontProperties', function() {
           ]
         );
       });
+
+      it.skip('should trace the intermediate values of font-weight', function() {
+        var htmlText = [
+          '<style>:root { --my-font-weight: 100 }</style>',
+          '<style>@keyframes foo { 100% { --my-font-weight: 400 } }</style>',
+          '<style>h1 { font-weight: var(--my-font-weight); animation-name: foo; }</style>',
+          '<h1>bar</h1>'
+        ].join('\n');
+
+        return expect(
+          htmlText,
+          'to exhaustively satisfy computed font properties',
+          [
+            {
+              text: 'bar',
+              props: {
+                'font-family': undefined,
+                'font-weight': 100,
+                'font-style': 'normal'
+              }
+            },
+            {
+              text: 'bar',
+              props: {
+                'font-family': undefined,
+                'font-weight': 200,
+                'font-style': 'normal'
+              }
+            },
+            {
+              text: 'bar',
+              props: {
+                'font-family': undefined,
+                'font-weight': 300,
+                'font-style': 'normal'
+              }
+            },
+            {
+              text: 'bar',
+              props: {
+                'font-family': undefined,
+                'font-weight': 400,
+                'font-style': 'normal'
+              }
+            }
+          ]
+        );
+      });
     });
   });
 });

--- a/test/util/fonts/injectSubsetDefinitions.js
+++ b/test/util/fonts/injectSubsetDefinitions.js
@@ -1,0 +1,77 @@
+const expect = require('../../unexpected-with-plugins');
+const injectSubsetDefinitions = require('../../../lib/util/fonts/injectSubsetDefinitions');
+
+describe('injectSubsetDefinitions', function() {
+  const webfontNameMap = {
+    'times new roman': 'times new roman__subset'
+  };
+
+  it('should inject before a doublequoted font family name', function() {
+    expect(
+      injectSubsetDefinitions('"times new roman"', webfontNameMap),
+      'to equal',
+      '\'times new roman__subset\', "times new roman"'
+    );
+  });
+
+  it('should inject before a singlequoted font family name', function() {
+    expect(
+      injectSubsetDefinitions("'times new roman'", webfontNameMap),
+      'to equal',
+      "'times new roman__subset', 'times new roman'"
+    );
+  });
+
+  it('should inject before a "bareword" font family name', function() {
+    expect(
+      injectSubsetDefinitions('times new roman', webfontNameMap),
+      'to equal',
+      "'times new roman__subset', times new roman"
+    );
+  });
+
+  it('should tolerate multiple spaces between words', function() {
+    expect(
+      injectSubsetDefinitions('times   new   roman', webfontNameMap),
+      'to equal',
+      "'times new roman__subset', times   new   roman"
+    );
+  });
+
+  it('should ignore occurrences that are immediately preceeded by other barewords', function() {
+    expect(
+      injectSubsetDefinitions('sorry times new roman, other', webfontNameMap),
+      'to equal',
+      'sorry times new roman, other'
+    );
+  });
+
+  it('should ignore occurrences that are succeeded by other barewords', function() {
+    expect(
+      injectSubsetDefinitions('times new roman yeah', webfontNameMap),
+      'to equal',
+      'times new roman yeah'
+    );
+  });
+
+  it('should not inject the subset into a value that already has it', function() {
+    expect(
+      injectSubsetDefinitions(
+        "'times new roman__subset', times new roman",
+        webfontNameMap
+      ),
+      'to equal',
+      "'times new roman__subset', times new roman"
+    );
+  });
+
+  it('should escape singlequotes in the subset font name', function() {
+    expect(
+      injectSubsetDefinitions('"times new roman"', {
+        'times new roman': "times'new'roman__subset"
+      }),
+      'to equal',
+      "'times\\'new\\'roman__subset', \"times new roman\""
+    );
+  });
+});

--- a/test/util/fonts/snapToAvailableFontProperties.js
+++ b/test/util/fonts/snapToAvailableFontProperties.js
@@ -28,7 +28,7 @@ describe('snapToAvailableFontProperties', function() {
       'font-family': 'Tahoma',
       'font-stretch': 'normal',
       'font-style': 'normal',
-      'font-weight': 400
+      'font-weight': '400'
     });
 
     expect(snapped, 'to be undefined');
@@ -41,13 +41,13 @@ describe('snapToAvailableFontProperties', function() {
           'font-family': 'Tahoma',
           'font-stretch': 'normal',
           'font-style': 'normal',
-          'font-weight': 400
+          'font-weight': '400'
         }
       ],
       {
         'font-family': 'Tahoma',
         'font-style': 'normal',
-        'font-weight': 400
+        'font-weight': '400'
       }
     );
 
@@ -55,7 +55,7 @@ describe('snapToAvailableFontProperties', function() {
       'font-family': 'Tahoma',
       'font-stretch': 'normal',
       'font-style': 'normal',
-      'font-weight': 400
+      'font-weight': '400'
     });
   });
 
@@ -66,13 +66,13 @@ describe('snapToAvailableFontProperties', function() {
           'font-family': 'Tahoma',
           'font-stretch': 'normal',
           'font-style': 'normal',
-          'font-weight': 400
+          'font-weight': '400'
         }
       ],
       {
         'font-family': 'Tahoma',
         'font-stretch': 'normal',
-        'font-weight': 400
+        'font-weight': '400'
       }
     );
 
@@ -80,7 +80,7 @@ describe('snapToAvailableFontProperties', function() {
       'font-family': 'Tahoma',
       'font-stretch': 'normal',
       'font-style': 'normal',
-      'font-weight': 400
+      'font-weight': '400'
     });
   });
 
@@ -91,7 +91,7 @@ describe('snapToAvailableFontProperties', function() {
           'font-family': 'Tahoma',
           'font-stretch': 'normal',
           'font-style': 'normal',
-          'font-weight': 400
+          'font-weight': '400'
         }
       ],
       {
@@ -105,7 +105,7 @@ describe('snapToAvailableFontProperties', function() {
       'font-family': 'Tahoma',
       'font-stretch': 'normal',
       'font-style': 'normal',
-      'font-weight': 400
+      'font-weight': '400'
     });
   });
 
@@ -570,9 +570,9 @@ describe('snapToAvailableFontProperties', function() {
       it('should snap to the exact value', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 400 },
-            { 'font-family': 'foo', 'font-weight': 500 },
-            { 'font-family': 'foo', 'font-weight': 600 }
+            { 'font-family': 'foo', 'font-weight': '400' },
+            { 'font-family': 'foo', 'font-weight': '500' },
+            { 'font-family': 'foo', 'font-weight': '600' }
           ],
           {
             'font-family': 'foo',
@@ -580,15 +580,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 500 });
+        expect(snapped, 'to satisfy', { 'font-weight': '500' });
       });
 
       it('should snap to the best available lighter value', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 100 },
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 500 }
+            { 'font-family': 'foo', 'font-weight': '100' },
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '500' }
           ],
           {
             'font-family': 'foo',
@@ -596,15 +596,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 200 });
+        expect(snapped, 'to satisfy', { 'font-weight': '200' });
       });
 
       it('should snap to the best available bolder value', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 500 },
-            { 'font-family': 'foo', 'font-weight': 700 },
-            { 'font-family': 'foo', 'font-weight': 800 }
+            { 'font-family': 'foo', 'font-weight': '500' },
+            { 'font-family': 'foo', 'font-weight': '700' },
+            { 'font-family': 'foo', 'font-weight': '800' }
           ],
           {
             'font-family': 'foo',
@@ -612,15 +612,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 700 });
+        expect(snapped, 'to satisfy', { 'font-weight': '700' });
       });
 
       it('should snap to the exact value plus 1 lighter', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 500 },
-            { 'font-family': 'foo', 'font-weight': 700 },
-            { 'font-family': 'foo', 'font-weight': 800 }
+            { 'font-family': 'foo', 'font-weight': '500' },
+            { 'font-family': 'foo', 'font-weight': '700' },
+            { 'font-family': 'foo', 'font-weight': '800' }
           ],
           {
             'font-family': 'foo',
@@ -628,15 +628,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 500 });
+        expect(snapped, 'to satisfy', { 'font-weight': '500' });
       });
 
       it('should snap to the exact value plus 2 lighter', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 500 },
-            { 'font-family': 'foo', 'font-weight': 700 },
-            { 'font-family': 'foo', 'font-weight': 800 }
+            { 'font-family': 'foo', 'font-weight': '500' },
+            { 'font-family': 'foo', 'font-weight': '700' },
+            { 'font-family': 'foo', 'font-weight': '800' }
           ],
           {
             'font-family': 'foo',
@@ -644,15 +644,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 500 });
+        expect(snapped, 'to satisfy', { 'font-weight': '500' });
       });
 
       it('should snap to the best available value plus 1 lighter', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 500 },
-            { 'font-family': 'foo', 'font-weight': 700 },
-            { 'font-family': 'foo', 'font-weight': 800 }
+            { 'font-family': 'foo', 'font-weight': '500' },
+            { 'font-family': 'foo', 'font-weight': '700' },
+            { 'font-family': 'foo', 'font-weight': '800' }
           ],
           {
             'font-family': 'foo',
@@ -660,15 +660,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 700 });
+        expect(snapped, 'to satisfy', { 'font-weight': '700' });
       });
 
       it('should snap to the best available value plus 2 lighter', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 500 },
-            { 'font-family': 'foo', 'font-weight': 700 },
-            { 'font-family': 'foo', 'font-weight': 800 }
+            { 'font-family': 'foo', 'font-weight': '500' },
+            { 'font-family': 'foo', 'font-weight': '700' },
+            { 'font-family': 'foo', 'font-weight': '800' }
           ],
           {
             'font-family': 'foo',
@@ -676,15 +676,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 500 });
+        expect(snapped, 'to satisfy', { 'font-weight': '500' });
       });
 
       it('should not snap to a lighter weight than what is available', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 300 },
-            { 'font-family': 'foo', 'font-weight': 400 }
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '300' },
+            { 'font-family': 'foo', 'font-weight': '400' }
           ],
           {
             'font-family': 'foo',
@@ -692,15 +692,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 200 });
+        expect(snapped, 'to satisfy', { 'font-weight': '200' });
       });
 
       it('should snap to the exact value plus 1 bolder', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 300 },
-            { 'font-family': 'foo', 'font-weight': 400 }
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '300' },
+            { 'font-family': 'foo', 'font-weight': '400' }
           ],
           {
             'font-family': 'foo',
@@ -708,15 +708,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 400 });
+        expect(snapped, 'to satisfy', { 'font-weight': '400' });
       });
 
       it('should snap to the exact value plus 2 bolder', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 300 },
-            { 'font-family': 'foo', 'font-weight': 400 }
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '300' },
+            { 'font-family': 'foo', 'font-weight': '400' }
           ],
           {
             'font-family': 'foo',
@@ -724,15 +724,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 400 });
+        expect(snapped, 'to satisfy', { 'font-weight': '400' });
       });
 
       it('should snap to best available value plus 1 bolder', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 300 },
-            { 'font-family': 'foo', 'font-weight': 400 }
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '300' },
+            { 'font-family': 'foo', 'font-weight': '400' }
           ],
           {
             'font-family': 'foo',
@@ -740,15 +740,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 300 });
+        expect(snapped, 'to satisfy', { 'font-weight': '300' });
       });
 
       it('should snap to best available value plus 2 bolder', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 300 },
-            { 'font-family': 'foo', 'font-weight': 400 }
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '300' },
+            { 'font-family': 'foo', 'font-weight': '400' }
           ],
           {
             'font-family': 'foo',
@@ -756,15 +756,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 400 });
+        expect(snapped, 'to satisfy', { 'font-weight': '400' });
       });
 
       it('should not snap to a bolder weight than what is available', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 300 },
-            { 'font-family': 'foo', 'font-weight': 400 }
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '300' },
+            { 'font-family': 'foo', 'font-weight': '400' }
           ],
           {
             'font-family': 'foo',
@@ -772,15 +772,15 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 400 });
+        expect(snapped, 'to satisfy', { 'font-weight': '400' });
       });
 
       it('should snap to the corect value given both lighter and bolder modifications', function() {
         var snapped = snap(
           [
-            { 'font-family': 'foo', 'font-weight': 200 },
-            { 'font-family': 'foo', 'font-weight': 300 },
-            { 'font-family': 'foo', 'font-weight': 400 }
+            { 'font-family': 'foo', 'font-weight': '200' },
+            { 'font-family': 'foo', 'font-weight': '300' },
+            { 'font-family': 'foo', 'font-weight': '400' }
           ],
           {
             'font-family': 'foo',
@@ -788,7 +788,7 @@ describe('snapToAvailableFontProperties', function() {
           }
         );
 
-        expect(snapped, 'to satisfy', { 'font-weight': 300 });
+        expect(snapped, 'to satisfy', { 'font-weight': '300' });
       });
     });
   });

--- a/testdata/transforms/subsetFonts/font-shorthand-with-custom-property/index.html
+++ b/testdata/transforms/subsetFonts/font-shorthand-with-custom-property/index.html
@@ -1,0 +1,24 @@
+<style>
+    @import 'https://fonts.googleapis.com/css?family=Open+Sans';
+
+    :root {
+      --unrelated-property: 'Open Sans', Helvetica;
+      --the-font: 'Open Sans', Helvetica;
+      --the-font-family: 'Open Sans', Helvetica;
+      --my-font: var(--the-font);
+      --fallback-font: sans-serif;
+    }
+
+    body {
+      font: 12px 'Open Sans', var(--fallback-font);
+      font-family: 'Open Sans', var(--fallback-font);
+    }
+
+    h1 {
+      font: 12px/18px var(--the-font);
+      font-family: var(--the-font-family);
+    }
+</style>
+<body>
+  <h1>Hello</h1>
+</body>


### PR DESCRIPTION
Fixes https://github.com/Munter/subfont/issues/23

Includes a more consistent handling of the `font` shorthand and removes number-ification of font weights from getTextBy...

I think this is getting there now. Please suggest more test cases :)

TODO:
- [x] ~~~animating `font-weight` via a custom property (see the skipped test). We can skip this as it's a pretty obscure edge case~~~
- [x] `var(--foo)` references in the `content` property
- [x] `var(--foo)` references in the `counter-increment` property (example: https://jsfiddle.net/psuwgexq/)
- [x] `var(--foo)` references in the `font` shorthand. Seems like this will require us to trace the font property separately, and I'm not totally sure how that'll work.