### PR TITLE
Added function to download google fonts

### DIFF
--- a/lib/util/downloadGoogleFonts.js
+++ b/lib/util/downloadGoogleFonts.js
@@ -103,11 +103,11 @@ async function downloadGoogleFonts(
   return results.map(result => {
     const declarationStrings = [];
 
-    Object.entries(result).map(([property, value]) => {
+    for (const [property, value] of Object.entries(result)) {
       if (property !== 'src') {
         declarationStrings.push(`  ${property}: ${value};`);
       }
-    });
+    }
 
     const sources = result.src.map(([font, format]) => {
       return `url('${font.dataUrl}') format('${format}')`;

--- a/lib/util/downloadGoogleFonts.js
+++ b/lib/util/downloadGoogleFonts.js
@@ -1,0 +1,120 @@
+const fontkit = require('fontkit');
+
+const AssetGraph = require('../AssetGraph');
+const getGoogleIdForFontProps = require('./fonts/getGoogleIdForFontProps');
+const unicodeRange = require('./fonts/unicode-range');
+
+const formatOrder = ['woff2', 'woff', 'truetype', 'opentype'];
+
+/**
+ * Webfont properties object containing the main differentiators for a separate font file.
+ * @typedef {Object} FontProps
+ * @property {string} font-family [CSS font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family), unquoted
+ * @property {string} font-weight [CSS font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
+ * @property {string} font-style [CSS font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style)
+ */
+
+/**
+ * User agent strings by desired font format.
+ * @readonly
+ * @enum {string}
+ */
+const formatAgents = {
+  eot:
+    'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)',
+  ttf:
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.59.8 (KHTML, like Gecko) Version/5.1.9 Safari/534.59.8',
+  woff:
+    'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; rv:11.0) like Gecko',
+  woff2:
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64; ServiceUI 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393'
+};
+
+/**
+ * Download google fonts for self-hosting
+ *
+ * @async
+ * @param  {FontProps[]} fontProps List of CSS font properties to get fonts for
+ * @param  {Object} options
+ * @param  {String[]} [options.formats=['woff2', 'woff']] List of formats that should be inclued in the output
+ * @param  {String} [options.fontDisplay='swap'] CSS font-display value in returned CSS blocks
+ * @param  {String} [options.text] Text to create a subset with
+ * @return {String[]} CSS assets with inlined google fonts
+ */
+async function downloadGoogleFonts(
+  fontProps,
+  { formats = ['woff2', 'woff'], fontDisplay = 'swap', text } = {}
+) {
+  const sortedFormats = [];
+
+  for (const format of formatOrder) {
+    if (formats.includes(format)) {
+      sortedFormats.push(format);
+    }
+  }
+
+  const results = await Promise.all(
+    fontProps.map(async originalProps => {
+      const fontProps = {};
+      const googleFontId = getGoogleIdForFontProps(originalProps);
+      let fontCssUrl = `https://fonts.googleapis.com/css?family=${googleFontId}`;
+
+      if (text) {
+        fontCssUrl += `&text=${encodeURIComponent(text)}`;
+      }
+
+      fontProps.src = await Promise.all(
+        sortedFormats.map(async format => {
+          const assetGraph = new AssetGraph();
+          assetGraph.teepee.headers['User-Agent'] = formatAgents[format];
+
+          const [cssAsset] = await assetGraph.loadAssets(fontCssUrl);
+
+          await assetGraph.populate();
+
+          const [fontRelation] = assetGraph.findRelations({
+            from: cssAsset,
+            type: 'CssFontFaceSrc'
+          });
+
+          fontRelation.node.each(decl => {
+            if (decl.prop !== 'src') {
+              fontProps[decl.prop] = decl.value;
+            }
+          });
+
+          return [fontRelation.to, fontRelation.format];
+        })
+      );
+
+      if (!('unicode-range' in fontProps)) {
+        const font = fontProps.src[0][0];
+        fontProps['unicode-range'] = unicodeRange(
+          fontkit.create(font.rawSrc).characterSet
+        );
+      }
+
+      return fontProps;
+    })
+  );
+
+  return results.map(result => {
+    const declarationStrings = [];
+
+    Object.entries(result).map(([property, value]) => {
+      if (property !== 'src') {
+        declarationStrings.push(`  ${property}: ${value};`);
+      }
+    });
+
+    const sources = result.src.map(([font, format]) => {
+      return `url('${font.dataUrl}') format('${format}')`;
+    });
+
+    declarationStrings.push(`  src: \n       ${sources.join(',\n       ')};`);
+
+    return ['@font-face {', ...declarationStrings, '}'].join('\n');
+  });
+}
+
+module.exports = downloadGoogleFonts;

--- a/lib/util/downloadGoogleFonts.js
+++ b/lib/util/downloadGoogleFonts.js
@@ -94,6 +94,8 @@ async function downloadGoogleFonts(
         );
       }
 
+      fontProps['font-display'] = fontDisplay;
+
       return fontProps;
     })
   );

--- a/lib/util/fonts/downloadGoogleFonts.js
+++ b/lib/util/fonts/downloadGoogleFonts.js
@@ -1,8 +1,8 @@
 const fontkit = require('fontkit');
 
-const AssetGraph = require('../AssetGraph');
-const getGoogleIdForFontProps = require('./fonts/getGoogleIdForFontProps');
-const unicodeRange = require('./fonts/unicode-range');
+const AssetGraph = require('../../AssetGraph');
+const getGoogleIdForFontProps = require('./getGoogleIdForFontProps');
+const unicodeRange = require('./unicode-range');
 
 const formatOrder = ['woff2', 'woff', 'truetype', 'opentype'];
 

--- a/lib/util/fonts/downloadGoogleFonts.js
+++ b/lib/util/fonts/downloadGoogleFonts.js
@@ -34,12 +34,12 @@ const formatAgents = {
  * Download google fonts for self-hosting
  *
  * @async
- * @param  {FontProps[]} fontProps List of CSS font properties to get fonts for
+ * @param  {FontProps} fontProps CSS font properties to get font for
  * @param  {Object} options
  * @param  {String[]} [options.formats=['woff2', 'woff']] List of formats that should be inclued in the output
  * @param  {String} [options.fontDisplay='swap'] CSS font-display value in returned CSS blocks
  * @param  {String} [options.text] Text to create a subset with
- * @return {String[]} CSS assets with inlined google fonts
+ * @return {String} CSS asset with inlined google fonts
  */
 async function downloadGoogleFonts(
   fontProps,
@@ -53,70 +53,63 @@ async function downloadGoogleFonts(
     }
   }
 
-  const results = await Promise.all(
-    fontProps.map(async originalProps => {
-      const fontProps = {};
-      const googleFontId = getGoogleIdForFontProps(originalProps);
-      let fontCssUrl = `https://fonts.googleapis.com/css?family=${googleFontId}`;
+  const result = {};
+  const googleFontId = getGoogleIdForFontProps(fontProps);
+  let fontCssUrl = `https://fonts.googleapis.com/css?family=${googleFontId}`;
 
-      if (text) {
-        fontCssUrl += `&text=${encodeURIComponent(text)}`;
-      }
+  if (text) {
+    fontCssUrl += `&text=${encodeURIComponent(text)}`;
+  }
 
-      fontProps.src = await Promise.all(
-        sortedFormats.map(async format => {
-          const assetGraph = new AssetGraph();
-          assetGraph.teepee.headers['User-Agent'] = formatAgents[format];
+  result.src = await Promise.all(
+    sortedFormats.map(async format => {
+      const assetGraph = new AssetGraph();
+      assetGraph.teepee.headers['User-Agent'] = formatAgents[format];
 
-          const [cssAsset] = await assetGraph.loadAssets(fontCssUrl);
+      const [cssAsset] = await assetGraph.loadAssets(fontCssUrl);
 
-          await assetGraph.populate();
+      await assetGraph.populate();
 
-          const [fontRelation] = assetGraph.findRelations({
-            from: cssAsset,
-            type: 'CssFontFaceSrc'
-          });
+      const [fontRelation] = assetGraph.findRelations({
+        from: cssAsset,
+        type: 'CssFontFaceSrc'
+      });
 
-          fontRelation.node.each(decl => {
-            if (decl.prop !== 'src') {
-              fontProps[decl.prop] = decl.value;
-            }
-          });
+      fontRelation.node.each(decl => {
+        if (decl.prop !== 'src') {
+          result[decl.prop] = decl.value;
+        }
+      });
 
-          return [fontRelation.to, fontRelation.format];
-        })
-      );
-
-      if (!('unicode-range' in fontProps)) {
-        const font = fontProps.src[0][0];
-        fontProps['unicode-range'] = unicodeRange(
-          fontkit.create(font.rawSrc).characterSet
-        );
-      }
-
-      fontProps['font-display'] = fontDisplay;
-
-      return fontProps;
+      return [fontRelation.to, fontRelation.format];
     })
   );
 
-  return results.map(result => {
-    const declarationStrings = [];
+  if (!('unicode-range' in result)) {
+    const font = result.src[0][0];
+    result['unicode-range'] = unicodeRange(
+      fontkit.create(font.rawSrc).characterSet
+    );
+  }
 
-    for (const [property, value] of Object.entries(result)) {
-      if (property !== 'src') {
-        declarationStrings.push(`  ${property}: ${value};`);
-      }
+  result['font-display'] = fontDisplay;
+
+  // Output font face declaration object as CSS
+  const declarationStrings = [];
+
+  for (const [property, value] of Object.entries(result)) {
+    if (property !== 'src') {
+      declarationStrings.push(`  ${property}: ${value};`);
     }
+  }
 
-    const sources = result.src.map(([font, format]) => {
-      return `url('${font.dataUrl}') format('${format}')`;
-    });
-
-    declarationStrings.push(`  src: \n       ${sources.join(',\n       ')};`);
-
-    return ['@font-face {', ...declarationStrings, '}'].join('\n');
+  const sources = result.src.map(([font, format]) => {
+    return `url('${font.dataUrl}') format('${format}')`;
   });
+
+  declarationStrings.push(`  src: \n       ${sources.join(',\n       ')};`);
+
+  return ['@font-face {', ...declarationStrings, '}'].join('\n');
 }
 
 module.exports = downloadGoogleFonts;

--- a/lib/util/fonts/getGoogleIdForFontProps.js
+++ b/lib/util/fonts/getGoogleIdForFontProps.js
@@ -5,7 +5,7 @@ function getGoogleIdForFontProps(fontProps) {
     fontProps['font-family'].split(',')[0].replace(' ', '+')
   );
 
-  const weight = fontProps['font-weight'];
+  const weight = fontProps['font-weight'] || '400';
 
   const italic = fontProps['font-style'] === 'italic';
 

--- a/test/util/fonts/downloadGoogleFonts.js
+++ b/test/util/fonts/downloadGoogleFonts.js
@@ -46,12 +46,10 @@ describe('downloadGoogleFonts', () => {
       }
     ]);
 
-    const [result] = await downloadGoogleFonts(
-      [
-        {
-          'font-family': 'Roboto'
-        }
-      ],
+    const result = await downloadGoogleFonts(
+      {
+        'font-family': 'Roboto'
+      },
       {
         formats: ['woff2']
       }

--- a/test/util/fonts/downloadGoogleFonts.js
+++ b/test/util/fonts/downloadGoogleFonts.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const pathModule = require('path');
+const expect = require('unexpected').clone();
+const httpception = require('httpception');
+const downloadGoogleFonts = require('../../../lib/util/fonts/downloadGoogleFonts');
+
+const reponses = {
+  'Roboto:400': `@font-face {
+  font-family: 'Roboto';
+  font-weight: 400;
+  font-style: normal;
+  src: local(foo), local(bar), url('https://fonts.gstatic.com/l/font?kit=Roboto:400') format('woff2');
+}`
+};
+
+describe('downloadGoogleFonts', () => {
+  before(() => {
+    httpception();
+  });
+
+  it('should download Roboto:400', async () => {
+    httpception([
+      {
+        request: 'GET https://fonts.googleapis.com/css?family=Roboto:400',
+        response: {
+          headers: {
+            'Content-Type': 'text/css'
+          },
+          body: reponses['Roboto:400']
+        }
+      },
+
+      {
+        request: 'GET https://fonts.gstatic.com/l/font?kit=Roboto:400',
+        response: {
+          headers: {
+            'Content-Type': 'font/woff2'
+          },
+          body: fs.readFileSync(
+            pathModule.resolve(
+              __dirname,
+              '../../../testdata/transforms/subsetFonts/Roboto-500.woff2'
+            )
+          )
+        }
+      }
+    ]);
+
+    const [result] = await downloadGoogleFonts(
+      [
+        {
+          'font-family': 'Roboto'
+        }
+      ],
+      {
+        formats: ['woff2']
+      }
+    );
+
+    expect(result.split('\n'), 'to satisfy', [
+      `@font-face {`,
+      `  font-family: 'Roboto';`,
+      `  font-weight: 400;`,
+      `  font-style: normal;`,
+      `  unicode-range: U+0,U+64-7E,U+D,U+A0-FF,U+131,U+20-21,U+152-153,U+22-47,U+2C6,U+48-49,U+2DA,U+2DC,U+4A-52,U+2013-2014,U+2018-201A,U+201C-201E,U+2022,U+2026,U+2039-203A,U+2044,U+53,U+2074,U+20AC,U+54-57,U+2212,U+58-63;`,
+      `  font-display: swap;`,
+      `  src: `,
+      expect
+        .it('to begin with', `       url('data:font/woff2;base64,`)
+        .and('to end with', `') format('woff2');`),
+      `}`
+    ]);
+  });
+});


### PR DESCRIPTION
I opted for a setup where I create a google font id for each passed in `fontProps` object, but use the google response CSS to populate the resulting CSS properties. This is to ensure that the response keeps in sync with what google interprets the fontProps as.

I added unicode-range and font-display setting ability right away, and also a subsetting ability.

Even though were going to have a few stringifications and parsings of the fonts I think it's worth it to keep the function agnostic. We can make a transform that takes the resulting CSS font-face declaration stylesheets, concats them and extracts the fonts to a given URL later.