### PR TITLE
downloadGoogleFonts: Fix retrieval of .ttf fonts

### DIFF
--- a/lib/util/fonts/downloadGoogleFonts.js
+++ b/lib/util/fonts/downloadGoogleFonts.js
@@ -22,8 +22,7 @@ const formatOrder = ['woff2', 'woff', 'truetype', 'opentype'];
 const formatAgents = {
   eot:
     'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)',
-  ttf:
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.59.8 (KHTML, like Gecko) Version/5.1.9 Safari/534.59.8',
+  ttf: '',
   woff:
     'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; rv:11.0) like Gecko',
   woff2:


### PR DESCRIPTION
Sending an empty User-Agent causes GWF to deliver a ttf font without hints stripped.

The previous User-Agent was a mac one (so hints would be stripped) and actually caused GWF to send a .woff file.