### PR TITLE
Handle non-ascii characters in urls

### DIFF
--- a/lib/AssetGraph.js
+++ b/lib/AssetGraph.js
@@ -209,6 +209,15 @@ class AssetGraph extends EventEmitter {
         }
         assetConfig.url = assetConfig.url.replace(/#.*$/, '');
 
+        if (!/^data:/i.test(assetConfig.url)) {
+          // Browsers interpret control chars and non-ASCII chars in urls as to percent-encoded utf-8 octets
+          // Make the same transformation early so we treat these urls as identical
+          assetConfig.url = assetConfig.url.replace(
+            /[^\x21-\x7f]/g,
+            encodeURIComponent
+          );
+        }
+
         if (this.canonicalRoot) {
           if (assetConfig.url.startsWith(this.canonicalRoot)) {
             assetConfig.url = assetConfig.url.replace(

--- a/test/resolvers/file.js
+++ b/test/resolvers/file.js
@@ -11,6 +11,13 @@ describe('resolvers/file', function() {
     await assetGraph.loadAssets('spaces, unsafe chars & ñøń-ÃßÇ¡¡.html');
     await assetGraph.populate();
 
-    expect(assetGraph, 'to contain asset');
+    expect(assetGraph, 'to contain asset', {
+      type: 'Html',
+      url: `${
+        assetGraph.root
+      }spaces,%20unsafe%20chars%20&%20%C3%B1%C3%B8%C5%84-%C3%83%C3%9F%C3%87%C2%A1%C2%A1.html`,
+
+      isLoaded: true
+    });
   });
 });


### PR DESCRIPTION
Browsers tolerate it, so let's try to handle them the same way.

Avoids the `[ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped character` error that caused confusion in https://github.com/webpack/webpack.js.org/pull/2759