### PR TITLE
Jsdocto .d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .DS_Store
 /.nyc_output/
 /jsdoc/
+
+types.d.ts

--- a/jsdoc.typedefs.json
+++ b/jsdoc.typedefs.json
@@ -1,0 +1,13 @@
+{
+  "opts": {
+    "template": "node_modules/tsd-jsdoc/dist",
+    "encoding": "utf8",
+    "destination": ".",
+    "recurse": true
+  },
+
+  "source": {
+    "include": "lib",
+    "includePattern": ".js$"
+  }
+}

--- a/lib/util/fonts/downloadGoogleFonts.js
+++ b/lib/util/fonts/downloadGoogleFonts.js
@@ -9,9 +9,9 @@ const formatOrder = ['woff2', 'woff', 'truetype', 'opentype'];
 /**
  * Webfont properties object containing the main differentiators for a separate font file.
  * @typedef {Object} FontProps
- * @property {string} font-family [CSS font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family), unquoted
- * @property {string} font-weight [CSS font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
- * @property {string} font-style [CSS font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style)
+ * @property {string} 'font-family' [CSS font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family), unquoted
+ * @property {string} 'font-weight' [CSS font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight)
+ * @property {string} 'font-style' [CSS font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style)
  */
 
 /**

--- a/lib/util/fonts/snapToAvailableFontProperties.js
+++ b/lib/util/fonts/snapToAvailableFontProperties.js
@@ -43,10 +43,10 @@ function ascending(a, b) {
 
 /**
  * @typedef {Object} FontFaceDeclaration
- * @property {String} font-family - CSS [font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) property
- * @property {String} font-stretch - CSS [font-stretch](https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch) property
- * @property {String} font-weight - CSS [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) property, must be normalized to numbers
- * @property {String} font-style - CSS [font-style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style) property
+ * @property {String} 'font-family' - CSS [font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) property
+ * @property {String} 'font-stretch' - CSS [font-stretch](https://developer.mozilla.org/en-US/docs/Web/CSS/font-stretch) property
+ * @property {String} 'font-weight' - CSS [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) property, must be normalized to numbers
+ * @property {String} 'font-style' - CSS [font-style](https://developer.mozilla.org/en-US/docs/Web/CSS/font-style) property
  */
 
 /**

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "specificity": "^0.4.0",
     "sw-precache": "^5.2.0",
     "teepee": "^2.31.1",
+    "tsd-jsdoc": "^2.1.2",
     "uglify-js": "3.4.9",
     "urltools": "^0.4.1",
     "xmldom": "^0.1.27"
@@ -106,12 +107,15 @@
     "yui-compressor": "^0.1.3"
   },
   "main": "lib/AssetGraph.js",
+  "types": "types.d.ts",
   "scripts": {
     "lint": "eslint .",
     "test": "npm run lint && mocha",
     "ci": "npm run lint && npm run coverage",
     "docs": "jsdoc -c jsdoc.json",
-    "coverage": "NODE_ENV=test nyc --reporter=lcov --reporter=text --all -- mocha --reporter dot && echo google-chrome coverage/lcov-report/index.html"
+    "typedefs": "jsdoc -c jsdoc.typedefs.json",
+    "coverage": "NODE_ENV=test nyc --reporter=lcov --reporter=text --all -- mocha --reporter dot && echo google-chrome coverage/lcov-report/index.html",
+    "preversion": "npm run typedefs"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
This is an attempt at automatically generating typescript definitions from the existing jsdoc comments.

It seems like `types.d.ts` gets output correctly, but I haven't yet succeeded in actually getting vscode to pick the definitions up while doing local development or linking projects across the file system.

Example output: https://gist.github.com/Munter/06b6eb424867f2e333f20d93550fb3c7