### PR TITLE
Skip bundleWebpack when no <script> is present

### DIFF
--- a/lib/transforms/bundleWebpack.js
+++ b/lib/transforms/bundleWebpack.js
@@ -127,6 +127,15 @@ module.exports = (queryObj, { configPath } = {}) => {
           );
         });
 
+      if (potentialBundlePaths.length === 0) {
+        assetGraph.info(
+          new Error(
+            'No potential webpack bundles found, skipping'
+          )
+        );
+        return;
+      }
+
       /* eslint-disable no-inner-declarations */
       function createAbsolutePath(name) {
         return pathModule.resolve(

--- a/test/transforms/bundleWebpack.js
+++ b/test/transforms/bundleWebpack.js
@@ -37,6 +37,21 @@ describe('bundleWebpack', function() {
     );
   });
 
+  it('should create a bundle when no webpack bundle is referenced', async function() {
+    const assetGraph = new AssetGraph({
+      root: pathModule.resolve(
+        __dirname,
+        '../../testdata/transforms/bundleWebpack/unusedwebpack/'
+      )
+    });
+    await assetGraph
+      .loadAssets('index.html')
+      .bundleWebpack()
+      .populate();
+
+    expect(assetGraph, 'to contain no relation', 'HtmlScript');
+  });
+
   it('should create a bundle consisting of a single file with a different publicPath', async function() {
     const assetGraph = new AssetGraph({
       root: pathModule.resolve(

--- a/testdata/transforms/bundleWebpack/unusedwebpack/index.html
+++ b/testdata/transforms/bundleWebpack/unusedwebpack/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+    <head></head>
+    <body>
+    </body>
+</html>


### PR DESCRIPTION
This change avoids exception in the following case:

```
touch webpack.config.js
touch index.html

buildProduction  --outroot dist index.html 
Guessing --root from input files: file:///private/tmp/
 ✔ 0.003 secs: logEvents
 ✔ 0.110 secs: loadAssets
(node:11727) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: bundleWebpack transform: The "path" argument must be of type string. Received type undefined
    at assertPath (path.js:39:11)
    at Object.resolve (path.js:1090:7)
    at createAbsolutePath (/Users/mrc/Projects/whydobirds/unicorn/node_modules/assetgraph/lib/transforms/bundleWebpack.js:132:27)
    at bundleWebpack (/Users/mrc/Projects/whydobirds/unicorn/node_modules/assetgraph/lib/transforms/bundleWebpack.js:161:43)
(node:11727) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:11727) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Use case: building static error pages (eg. 404.html) that reference no JavaScript at all. 