### PR TITLE
getTextByFontProperties: Don't require the AssetGraph instance

### DIFF
--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -7,6 +7,7 @@ const compileQuery = require('../compileQuery');
 
 const AssetGraph = require('../../');
 
+const gatherStylesheetsWithPredicates = require('../util/fonts/gatherStylesheetsWithPredicates');
 const getTextByFontProperties = require('../util/fonts/getTextByFontProperties');
 const getGoogleIdForFontProps = require('../util/fonts/getGoogleIdForFontProps');
 const snapToAvailableFontProperties = require('../util/fonts/snapToAvailableFontProperties');
@@ -658,6 +659,8 @@ module.exports = ({
         }
 
         const textByProps = getTextByFontProperties(
+          htmlAsset.parseTree,
+          gatherStylesheetsWithPredicates(htmlAsset.assetGraph, htmlAsset),
           htmlAsset,
           memoizedGetCssRulesByProperty
         );

--- a/lib/util/fonts/getTextByFontProperties.js
+++ b/lib/util/fonts/getTextByFontProperties.js
@@ -6,7 +6,6 @@ const memoizeSync = require('memoizesync');
 const capitalize = require('capitalize');
 const cssPseudoElementRegExp = require('../cssPseudoElementRegExp');
 const stripPseudoClassesFromSelector = require('./stripPseudoClassesFromSelector');
-const gatherStylesheetsWithPredicates = require('./gatherStylesheetsWithPredicates');
 const getCssRulesByProperty = require('./getCssRulesByProperty');
 const extractTextFromContentPropertyValue = require('./extractTextFromContentPropertyValue');
 const counterRendererByListStyleType = require('./counterRendererByListStyleType');
@@ -85,13 +84,10 @@ function createPredicatePermutations(predicatesToVary, predicates, i) {
 const excludedNodes = ['HEAD', 'STYLE', 'SCRIPT'];
 
 function getFontRulesWithDefaultStylesheetApplied(
-  htmlAsset,
+  stylesheetsWithPredicates,
   memoizedGetCssRulesByProperty
 ) {
-  const fontPropRules = [
-    ...defaultStylesheets,
-    ...gatherStylesheetsWithPredicates(htmlAsset.assetGraph, htmlAsset)
-  ]
+  const fontPropRules = [...defaultStylesheets, ...stylesheetsWithPredicates]
     .map(stylesheetAndIncomingMedia =>
       memoizedGetCssRulesByProperty(
         CSS_PROPS_TO_TRACE,
@@ -637,17 +633,18 @@ function normalizeTextNodeValues(textNodeValues, whiteSpaceValue) {
     .join('');
 }
 
-// memoizedGetCssRulesByProperty is optional
-function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
-  if (!htmlAsset || htmlAsset.type !== 'Html' || !htmlAsset.assetGraph) {
-    throw new Error('htmlAsset must be a Html-asset and be in an assetGraph');
-  }
-
+// htmlAsset and memoizedGetCssRulesByProperty are optional
+function getTextByFontProperties(
+  document,
+  stylesheetsWithPredicates,
+  htmlAsset,
+  memoizedGetCssRulesByProperty
+) {
   memoizedGetCssRulesByProperty =
     memoizedGetCssRulesByProperty || getCssRulesByProperty;
 
   const fontPropRules = getFontRulesWithDefaultStylesheetApplied(
-    htmlAsset,
+    stylesheetsWithPredicates,
     memoizedGetCssRulesByProperty
   );
   const getComputedStyle = getMemoizedElementStyleResolver(
@@ -663,8 +660,6 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
       predicates: counterStyle.predicates
     });
   }
-
-  const document = htmlAsset.parseTree;
 
   const visualValueInputTypes = [
     'date',
@@ -956,7 +951,10 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
     if (node.nodeType === node.TEXT_NODE) {
       const textContent = node.nodeValue
         .replace(/⋖\d+⋗/g, templatePlaceholder => {
-          if (htmlAsset._templateReplacements[templatePlaceholder]) {
+          if (
+            htmlAsset &&
+            htmlAsset._templateReplacements[templatePlaceholder]
+          ) {
             return '';
           } else {
             return templatePlaceholder;
@@ -975,54 +973,55 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
         conditionalCommentStack.pop();
       } else {
         // See if this is a conditional comment where the markup is in the comment value:
-        htmlAsset.outgoingRelations.some(relation => {
-          if (
-            relation.type === 'HtmlConditionalComment' &&
-            relation.node === node
-          ) {
-            conditionalCommentStack.push(true);
-            const conditionalCommentDocument = relation.to.parseTree;
-            let isWithinBody = false;
-            for (
-              let i = 0;
-              i < conditionalCommentDocument.childNodes.length;
-              i += 1
+        htmlAsset &&
+          htmlAsset.outgoingRelations.some(relation => {
+            if (
+              relation.type === 'HtmlConditionalComment' &&
+              relation.node === node
             ) {
-              const childNode = conditionalCommentDocument.childNodes[i];
-              // Don't proceed unless we're between
-              // <!--ASSETGRAPH DOCUMENT START MARKER--> and <!--ASSETGRAPH DOCUMENT END MARKER-->
-              if (childNode.nodeType === childNode.COMMENT_NODE) {
-                if (
-                  childNode.nodeValue === 'ASSETGRAPH DOCUMENT START MARKER'
-                ) {
-                  isWithinBody = true;
+              conditionalCommentStack.push(true);
+              const conditionalCommentDocument = relation.to.parseTree;
+              let isWithinBody = false;
+              for (
+                let i = 0;
+                i < conditionalCommentDocument.childNodes.length;
+                i += 1
+              ) {
+                const childNode = conditionalCommentDocument.childNodes[i];
+                // Don't proceed unless we're between
+                // <!--ASSETGRAPH DOCUMENT START MARKER--> and <!--ASSETGRAPH DOCUMENT END MARKER-->
+                if (childNode.nodeType === childNode.COMMENT_NODE) {
+                  if (
+                    childNode.nodeValue === 'ASSETGRAPH DOCUMENT START MARKER'
+                  ) {
+                    isWithinBody = true;
+                    continue;
+                  } else if (
+                    childNode.nodeValue === 'ASSETGRAPH DOCUMENT END MARKER'
+                  ) {
+                    break;
+                  }
+                } else if (!isWithinBody) {
                   continue;
-                } else if (
-                  childNode.nodeValue === 'ASSETGRAPH DOCUMENT END MARKER'
-                ) {
-                  break;
                 }
-              } else if (!isWithinBody) {
-                continue;
+                // Fake that the node in the conditional comment has the parent element of the comment as its parentElement
+                // so that the correct CSS selectors match:
+                Object.defineProperty(childNode, 'parentElement', {
+                  configurable: true,
+                  get() {
+                    return node.parentElement;
+                  }
+                });
+                textNodeValues.push(
+                  ...traversePreOrder(childNode, [...idArray, i])
+                );
+                delete childNode.parentElement;
               }
-              // Fake that the node in the conditional comment has the parent element of the comment as its parentElement
-              // so that the correct CSS selectors match:
-              Object.defineProperty(childNode, 'parentElement', {
-                configurable: true,
-                get() {
-                  return node.parentElement;
-                }
-              });
-              textNodeValues.push(
-                ...traversePreOrder(childNode, [...idArray, i])
-              );
-              delete childNode.parentElement;
+              conditionalCommentStack.pop();
+              // Short circuit
+              return true;
             }
-            conditionalCommentStack.pop();
-            // Short circuit
-            return true;
-          }
-        });
+          });
       }
     } else if (
       node.nodeType === node.ELEMENT_NODE &&
@@ -1033,30 +1032,31 @@ function getTextByFontProperties(htmlAsset, memoizedGetCssRulesByProperty) {
       }
 
       if (node.tagName === 'NOSCRIPT') {
-        htmlAsset.outgoingRelations.some(relation => {
-          if (relation.type === 'HtmlNoscript' && relation.node === node) {
-            noscriptStack.push(true);
-            const noscriptDocument = relation.to.parseTree;
-            for (let i = 0; i < noscriptDocument.childNodes.length; i += 1) {
-              const childNode = noscriptDocument.childNodes[i];
-              // Fake that the top-level node in the inline asset has the <noscript> as its parentNode
-              // so that the correct CSS selectors match:
-              Object.defineProperty(childNode, 'parentElement', {
-                configurable: true,
-                get() {
-                  return node;
-                }
-              });
-              textNodeValues.push(
-                ...traversePreOrder(childNode, [...idArray, i])
-              );
-              delete childNode.parentElement;
+        htmlAsset &&
+          htmlAsset.outgoingRelations.some(relation => {
+            if (relation.type === 'HtmlNoscript' && relation.node === node) {
+              noscriptStack.push(true);
+              const noscriptDocument = relation.to.parseTree;
+              for (let i = 0; i < noscriptDocument.childNodes.length; i += 1) {
+                const childNode = noscriptDocument.childNodes[i];
+                // Fake that the top-level node in the inline asset has the <noscript> as its parentNode
+                // so that the correct CSS selectors match:
+                Object.defineProperty(childNode, 'parentElement', {
+                  configurable: true,
+                  get() {
+                    return node;
+                  }
+                });
+                textNodeValues.push(
+                  ...traversePreOrder(childNode, [...idArray, i])
+                );
+                delete childNode.parentElement;
+              }
+              noscriptStack.pop();
+              // Short circuit
+              return true;
             }
-            noscriptStack.pop();
-            // Short circuit
-            return true;
-          }
-        });
+          });
       } else if (
         node.tagName === 'INPUT' &&
         visualValueInputTypes.includes(node.type || 'text')


### PR DESCRIPTION
Makes it possible to use it in a browser.