### PR TITLE
subsetFonts: Allow passing in per-page font traces

### DIFF
--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -574,7 +574,8 @@ module.exports = ({
   inlineSubsets,
   inlineCss,
   fontDisplay,
-  onlyInfo
+  onlyInfo,
+  tracesByAsset
 } = {}) => {
   if (!validFontDisplayValues.includes(fontDisplay)) {
     fontDisplay = undefined;
@@ -682,12 +683,14 @@ module.exports = ({
           seenFontFaceCombos.add(key);
         }
 
-        const textByProps = fontTracer(
-          htmlAsset.parseTree,
-          gatherStylesheetsWithPredicates(htmlAsset.assetGraph, htmlAsset),
-          memoizedGetCssRulesByProperty,
-          htmlAsset
-        );
+        const textByProps = tracesByAsset
+          ? tracesByAsset.get(htmlAsset) || []
+          : fontTracer(
+              htmlAsset.parseTree,
+              gatherStylesheetsWithPredicates(htmlAsset.assetGraph, htmlAsset),
+              memoizedGetCssRulesByProperty,
+              htmlAsset
+            );
 
         htmlAssetTextsWithProps.push({
           htmlAsset,

--- a/test/transforms/subsetFonts.js
+++ b/test/transforms/subsetFonts.js
@@ -4237,6 +4237,51 @@ describe('transforms/subsetFonts', function() {
         expect(cssAsset.text, 'not to contain', 'font-style:italic');
       });
     });
+
+    it('should accept a Map of existing traces', async function() {
+      const assetGraph = new AssetGraph({
+        root: pathModule.resolve(
+          __dirname,
+          '../../testdata/transforms/subsetFonts/local-single/'
+        )
+      });
+      const [htmlAsset] = await assetGraph.loadAssets('index.html');
+      const tracesByAsset = new Map();
+      tracesByAsset.set(htmlAsset, [
+        {
+          text: 'Something that it does not actually say on the page',
+          props: {
+            'font-family': "'Open Sans'",
+            'font-style': 'normal',
+            'font-weight': 'bold'
+          }
+        }
+      ]);
+      await assetGraph.populate();
+      const { fontInfo } = await assetGraph.subsetFonts({
+        inlineSubsets: false,
+        tracesByAsset
+      });
+      expect(fontInfo, 'to satisfy', [
+        {
+          fontUsages: [
+            {
+              texts: ['Something that it does not actually say on the page'],
+              pageText: ' Sacdeghilmnopstuy',
+              text: ' Sacdeghilmnopstuy',
+              props: {
+                'font-stretch': 'normal',
+                'font-weight': '400',
+                'font-style': 'normal',
+                'font-family': 'Open Sans',
+                src:
+                  "local('Open Sans Regular'), local('OpenSans-Regular'), url(OpenSans.ttf) format('truetype')"
+              }
+            }
+          ]
+        }
+      ]);
+    });
   });
 
   describe('with non-truetype fonts in the mix', function() {


### PR DESCRIPTION
Aims towards decoupling of the tracing and the assetgraph gymnastics, and allows subfont to make additional traces in a headless browser.