### PR TITLE
Check for missing glyphs in available formats

### DIFF
--- a/lib/transforms/subsetFonts.js
+++ b/lib/transforms/subsetFonts.js
@@ -741,8 +741,9 @@ module.exports = ({
     for (const { htmlAsset, fontUsages } of htmlAssetTextsWithProps) {
       for (const fontUsage of fontUsages) {
         if (fontUsage.subsets) {
-          const characterSet = fontkit.create(fontUsage.subsets.woff)
-            .characterSet;
+          const characterSet = fontkit.create(
+            Object.values(fontUsage.subsets)[0]
+          ).characterSet;
 
           for (const char of [...fontUsage.pageText]) {
             // Turns out that browsers don't mind that these are missing:

--- a/test/transforms/subsetFonts.js
+++ b/test/transforms/subsetFonts.js
@@ -3086,6 +3086,38 @@ describe('transforms/subsetFonts', function() {
       });
     });
 
+    it('should check for missing glyphs in any subset format', async function() {
+      httpception();
+
+      const warnSpy = sinon.spy().named('warn');
+      const assetGraph = new AssetGraph({
+        root: pathModule.resolve(
+          __dirname,
+          '../../testdata/transforms/subsetFonts/missing-glyphs/'
+        )
+      });
+      assetGraph.on('warn', warnSpy);
+      await assetGraph.loadAssets('index.html');
+      await assetGraph.populate({
+        followRelations: {
+          crossorigin: false
+        }
+      });
+      await assetGraph.subsetFonts({
+        inlineSubsets: false,
+        formats: [`woff2`]
+      });
+
+      expect(warnSpy, 'to have calls satisfying', function() {
+        warnSpy({
+          message: expect
+            .it('to contain', 'Missing glyph fallback detected')
+            .and('to contain', '\\u{4e2d} (中)')
+            .and('to contain', '\\u{56fd} (国)')
+        });
+      });
+    });
+
     // Some fonts don't contain these, but browsers don't seem to mind, so the warnings would just be noise
     it('should not warn about tab and newline missing from the font being subset', async function() {
       httpception();


### PR DESCRIPTION
If you want to subset a font to only `woff2`, assetgraph will throw an error due to hardcoding the missing glyph check for only the `woff` subset. This just checks the first subset as all glyphs will be in both subsets.

I also added a quick test case for the issue.