### PR TITLE
Resolve canonical URL's with no trailing slash as the assetgraph root

### DIFF
--- a/lib/AssetGraph.js
+++ b/lib/AssetGraph.js
@@ -245,6 +245,12 @@ class AssetGraph extends EventEmitter {
               this.root
             );
           }
+
+          // Canonical urls always end in slash, but should also match urls with no path or trailing slash.
+          // Make a direct equality comparison without the slash
+          if (assetConfig.url === this.canonicalRoot.slice(0, -1)) {
+            assetConfig.url = this.root;
+          }
         }
         if (/^data:/.test(assetConfig.url)) {
           const parsedDataUrl = resolveDataUrl(assetConfig.url);

--- a/test/addAsset.js
+++ b/test/addAsset.js
@@ -367,4 +367,47 @@ describe('AssetGraph#addAsset', function() {
       });
     });
   });
+
+  describe('with a canonicalRoot on the graph', function() {
+    it('should resolve a canonical URL with no path to the graph root', async function() {
+      const assetGraph = new AssetGraph({
+        root: '/myRoot',
+        canonicalRoot: 'https://my.production.domain'
+      });
+
+      const asset = await assetGraph.addAsset('https://my.production.domain');
+
+      expect(asset, 'to satisfy', {
+        url: 'file:///myRoot/'
+      });
+    });
+
+    it('should resolve a canonical URL with a `/` as path to the graph root', async function() {
+      const assetGraph = new AssetGraph({
+        root: '/myRoot',
+        canonicalRoot: 'https://my.production.domain'
+      });
+
+      const asset = await assetGraph.addAsset('https://my.production.domain/');
+
+      expect(asset, 'to satisfy', {
+        url: 'file:///myRoot/'
+      });
+    });
+
+    it('should resolve a canonical URL with a path to the graph root relative path', async function() {
+      const assetGraph = new AssetGraph({
+        root: '/myRoot',
+        canonicalRoot: 'https://my.production.domain'
+      });
+
+      const asset = await assetGraph.addAsset(
+        'https://my.production.domain/page.html'
+      );
+
+      expect(asset, 'to satisfy', {
+        url: 'file:///myRoot/page.html'
+      });
+    });
+  });
 });


### PR DESCRIPTION
…. Relates to https://github.com/Munter/hyperlink/issues/158

Previously a canonical URL without a trailing slash would not be resolved to the local file system, causing the graph to detour around live sites.

I'm thinking that we should probably also have some sort of resolution so it hits `/index.html` somehow. Currently `/index.html` and `/` are two different assets if I read this correctly