### PR TITLE
JavaScript#strict => isStrict, and make it a getter so it doesn't get populated as a side effect of finding outgoing relations

### DIFF
--- a/lib/assets/JavaScript.js
+++ b/lib/assets/JavaScript.js
@@ -289,6 +289,21 @@ class JavaScript extends Text {
     return this.parseTree.body.length === 0;
   }
 
+  get isStrict() {
+    return this.parseTree.body.some(
+      node =>
+        node.type === 'ExpressionStatement' &&
+        node.expression.type === 'Literal' &&
+        node.expression.value === 'use strict'
+    );
+  }
+
+  // Deprecated
+  // FIXME: Remove in next major version
+  get strict() {
+    return this.isStrict;
+  }
+
   _cloneParseTree() {
     return espurify.customize({
       extra: [
@@ -405,16 +420,6 @@ class JavaScript extends Text {
 
         const stack = this.parents();
         stack.push(node);
-
-        // Detect global 'use strict' directives
-        if (
-          parentNode === that.parseTree &&
-          node.type === 'ExpressionStatement' &&
-          node.expression.type === 'Literal' &&
-          node.expression.value === 'use strict'
-        ) {
-          that.strict = true;
-        }
 
         if (
           node.type === 'ImportExpression' &&

--- a/lib/assets/JavaScript.js
+++ b/lib/assets/JavaScript.js
@@ -19,10 +19,6 @@ class JavaScript extends Text {
   init(config) {
     super.init(config);
     this.serializationOptions = this.serializationOptions || {};
-
-    // Boolean indicating if the asset has a global "use strict"; statement
-    // Useful for wrapping the asset in an IIFE when concatenating in order to avoid leakage
-    this.strict = false;
   }
 
   _getEscodegenOptions() {
@@ -289,6 +285,8 @@ class JavaScript extends Text {
     return this.parseTree.body.length === 0;
   }
 
+  // Whether the asset has a global "use strict"; statement
+  // Useful for wrapping the asset in an IIFE when concatenating in order to avoid leakage
   get isStrict() {
     return this.parseTree.body.some(
       node =>

--- a/lib/transforms/bundleRelations.js
+++ b/lib/transforms/bundleRelations.js
@@ -62,7 +62,7 @@ module.exports = (
           }
         }
       } else if (relation.type === 'HtmlScript') {
-        if (relation.to.isStrict) {
+        if (relation.to.isLoaded && relation.to.isStrict) {
           discriminatorFragments.push('strict');
           const warning = new Error(
             'Global "use strict"-directive. Splitting into multiple bundles to avoid side effects.'

--- a/lib/transforms/bundleRelations.js
+++ b/lib/transforms/bundleRelations.js
@@ -62,7 +62,7 @@ module.exports = (
           }
         }
       } else if (relation.type === 'HtmlScript') {
-        if (relation.to.strict) {
+        if (relation.to.isStrict) {
           discriminatorFragments.push('strict');
           const warning = new Error(
             'Global "use strict"-directive. Splitting into multiple bundles to avoid side effects.'


### PR DESCRIPTION
Leave a `strict` getter for backwards compatibility for now.