### PR TITLE
Remove Bluebird

### DIFF
--- a/lib/AssetGraph.js
+++ b/lib/AssetGraph.js
@@ -1,5 +1,4 @@
-const Promise = require('bluebird');
-const fs = Promise.promisifyAll(require('fs'));
+const fs = require('fs');
 const os = require('os');
 const glob = require('glob');
 const _ = require('lodash');

--- a/lib/TransformQueue.js
+++ b/lib/TransformQueue.js
@@ -1,5 +1,3 @@
-const Promise = require('bluebird');
-
 function TransformQueue(assetGraph) {
   this.assetGraph = assetGraph;
   this.transforms = [];

--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -1,6 +1,8 @@
 const pathModule = require('path');
-const Promise = require('bluebird');
-const fs = Promise.promisifyAll(require('fs'));
+const { promisify } = require('util');
+const fs = require('fs');
+const stat = promisify(fs.stat);
+const readFile = promisify(fs.readFile);
 const EventEmitter = require('events').EventEmitter;
 const crypto = require('crypto');
 const _ = require('lodash');
@@ -355,7 +357,7 @@ class Asset extends EventEmitter {
         if (protocol === 'file') {
           const pathname = urlTools.fileUrlToFsPath(url);
           if (metadataOnly) {
-            const stats = await fs.statAsync(pathname);
+            const stats = await stat(pathname);
             if (stats.isDirectory()) {
               this.fileRedirectTargetUrl = urlTools.fsFilePathToFileUrl(
                 pathname.replace(/(\/)?$/, '/index.html')
@@ -365,7 +367,7 @@ class Asset extends EventEmitter {
             }
           } else {
             try {
-              this._rawSrc = await fs.readFileAsync(pathname);
+              this._rawSrc = await readFile(pathname);
               this._updateRawSrcAndLastKnownByteLength(this._rawSrc);
             } catch (err) {
               if (err.code === 'EISDIR' || err.code === 'EINVAL') {

--- a/lib/assets/Css.js
+++ b/lib/assets/Css.js
@@ -1,6 +1,3 @@
-// FIXME
-global.Promise = require('bluebird');
-
 const AssetGraph = require('../AssetGraph');
 const postcss = require('postcss');
 const perfectionist = require('perfectionist');

--- a/lib/transforms/addDataVersionAttributeToHtmlElement.js
+++ b/lib/transforms/addDataVersionAttributeToHtmlElement.js
@@ -1,21 +1,19 @@
 const childProcess = require('child_process');
 const { promisify } = require('util');
+const exec = promisify(childProcess.exec);
 
 module.exports = (queryObj, version) => {
   return async function addDataVersionAttributeToHtmlElement(assetGraph) {
     if (typeof version === 'undefined') {
       // Try to derive a version tag from git:
       try {
-        const rawVersion = await promisify(cb =>
-          childProcess.exec(
-            'git describe --long --tags --always --dirty',
-            {
-              encoding: 'utf-8'
-            },
-            cb
-          )
-        )();
-        version = rawVersion.replace(/^[\s\n\r]+|[\s\r\n]+$/g, '');
+        const { stdout } = await exec(
+          'git describe --long --tags --always --dirty',
+          {
+            encoding: 'utf-8'
+          }
+        );
+        version = stdout.replace(/^[\s\n\r]+|[\s\r\n]+$/g, '');
       } catch (e) {}
     }
     if (version) {

--- a/lib/transforms/addDataVersionAttributeToHtmlElement.js
+++ b/lib/transforms/addDataVersionAttributeToHtmlElement.js
@@ -1,16 +1,20 @@
 const childProcess = require('child_process');
+const { promisify } = require('util');
 
 module.exports = (queryObj, version) => {
   return async function addDataVersionAttributeToHtmlElement(assetGraph) {
     if (typeof version === 'undefined') {
       // Try to derive a version tag from git:
       try {
-        const rawVersion = childProcess.execSync(
-          'git describe --long --tags --always --dirty',
-          {
-            encoding: 'utf-8'
-          }
-        );
+        const rawVersion = await promisify(cb =>
+          childProcess.exec(
+            'git describe --long --tags --always --dirty',
+            {
+              encoding: 'utf-8'
+            },
+            cb
+          )
+        )();
         version = rawVersion.replace(/^[\s\n\r]+|[\s\r\n]+$/g, '');
       } catch (e) {}
     }

--- a/lib/transforms/addDataVersionAttributeToHtmlElement.js
+++ b/lib/transforms/addDataVersionAttributeToHtmlElement.js
@@ -1,20 +1,17 @@
 const childProcess = require('child_process');
-const Promise = require('bluebird');
 
 module.exports = (queryObj, version) => {
   return async function addDataVersionAttributeToHtmlElement(assetGraph) {
     if (typeof version === 'undefined') {
       // Try to derive a version tag from git:
       try {
-        const [stdout] = await Promise.fromNode(
-          cb =>
-            childProcess.exec(
-              'git describe --long --tags --always --dirty',
-              cb
-            ),
-          { multiArgs: true }
+        const rawVersion = childProcess.execSync(
+          'git describe --long --tags --always --dirty',
+          {
+            encoding: 'utf-8'
+          }
         );
-        version = stdout.replace(/^[\s\n\r]+|[\s\r\n]+$/g, '');
+        version = rawVersion.replace(/^[\s\n\r]+|[\s\r\n]+$/g, '');
       } catch (e) {}
     }
     if (version) {

--- a/lib/transforms/addPrecacheServiceWorker.js
+++ b/lib/transforms/addPrecacheServiceWorker.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const urlTools = require('urltools');
 const swPrecache = require('sw-precache');
 const commonPathPrefix = require('common-path-prefix');
-const Promise = require('bluebird');
+const Bluebird = require('bluebird');
 const pathModule = require('path');
 const readPkgUp = require('read-pkg-up');
 
@@ -214,7 +214,7 @@ module.exports = (
     } else {
       batches = entryPointHtmlAssets.map(asset => [asset]);
     }
-    await Promise.map(batches, generateAndAttachPrecacheServiceWorkerAsync, {
+    await Bluebird.map(batches, generateAndAttachPrecacheServiceWorkerAsync, {
       concurrency: 1
     });
   };

--- a/lib/transforms/addPrecacheServiceWorker.js
+++ b/lib/transforms/addPrecacheServiceWorker.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const urlTools = require('urltools');
 const swPrecache = require('sw-precache');
 const commonPathPrefix = require('common-path-prefix');
-const Bluebird = require('bluebird');
+const pMap = require('p-map');
 const pathModule = require('path');
 const readPkgUp = require('read-pkg-up');
 
@@ -214,7 +214,7 @@ module.exports = (
     } else {
       batches = entryPointHtmlAssets.map(asset => [asset]);
     }
-    await Bluebird.map(batches, generateAndAttachPrecacheServiceWorkerAsync, {
+    await pMap(batches, generateAndAttachPrecacheServiceWorkerAsync, {
       concurrency: 1
     });
   };

--- a/lib/transforms/bundleRequireJs.js
+++ b/lib/transforms/bundleRequireJs.js
@@ -5,8 +5,11 @@ const urlTools = require('urltools');
 const getTemporaryFilePath = require('gettemporaryfilepath');
 const estraverse = require('estraverse-fb');
 const esanimate = require('esanimate');
-const Promise = require('bluebird');
-const fs = Promise.promisifyAll(require('fs'));
+const { promisify } = require('util');
+const fs = require('fs');
+const stat = promisify(fs.stat);
+const readFile = promisify(fs.readFile);
+const unlink = promisify(fs.unlink);
 
 function extractRequireJsConfigFragments(parseTree, htmlAsset) {
   const requireJsConfigFragments = [];
@@ -191,8 +194,8 @@ module.exports = () => {
             requireJs.optimize(requireJsOptimizeOptions, resolve)
           ); // Does not pass err as the first parameter
 
-          let contents = await fs.readFileAsync(outBundleFile, 'utf-8');
-          await fs.unlinkAsync(outBundleFile);
+          let contents = await readFile(outBundleFile, 'utf-8');
+          await unlink(outBundleFile);
 
           let sourceMapFileName;
           contents = contents.replace(
@@ -210,11 +213,11 @@ module.exports = () => {
             dataMain ? `${dataMain}-` : ''
           }bundle.js`;
           if (sourceMapFileName) {
-            const sourceMapContents = await fs.readFileAsync(
+            const sourceMapContents = await readFile(
               sourceMapFileName,
               'utf-8'
             );
-            await fs.unlinkAsync(sourceMapFileName);
+            await unlink(sourceMapFileName);
             sourceMap = JSON.parse(sourceMapContents);
             sourceMap.file = `/${urlTools.buildRelativeUrl(
               assetGraph.root,
@@ -245,10 +248,10 @@ module.exports = () => {
 
           let stats;
           try {
-            stats = await fs.statAsync(outCssFileName);
+            stats = await stat(outCssFileName);
           } catch (e) {}
           if (stats && stats.isFile()) {
-            const cssContents = await fs.readFileAsync(outCssFileName, 'utf-8');
+            const cssContents = await readFile(outCssFileName, 'utf-8');
             if (cssContents) {
               const existingHtmlStyles = assetGraph.findRelations({
                 from: htmlScript.from,
@@ -272,7 +275,7 @@ module.exports = () => {
                 lastExistingHtmlStyle
               );
             }
-            await fs.unlinkAsync(outCssFileName);
+            await unlink(outCssFileName);
           }
         }
 

--- a/lib/transforms/bundleSystemJs.js
+++ b/lib/transforms/bundleSystemJs.js
@@ -1,6 +1,5 @@
 /* jshint unused:false */
 const _ = require('lodash');
-const Promise = require('bluebird');
 const esanimate = require('esanimate');
 const estraverse = require('estraverse-fb');
 const urlTools = require('urltools');
@@ -325,102 +324,106 @@ async function bundleStrategy(builder, entryPoints, options) {
 
   // Trace the deferred entry points to get all entry points
   if (options.deferredImports) {
-    await Promise.map(entryPoints, async entryPoint => {
-      const tree = await builder.trace(entryPoint.name, options);
-      const deferredImports = await builder.getDeferredImports(tree);
-      allEntryPoints.push(
-        ...deferredImports.map(deferredImport => ({
-          name: deferredImport.name,
-          deferredParent: entryPoint.name
-        }))
-      );
-    });
+    await Promise.all(
+      entryPoints.map(async entryPoint => {
+        const tree = await builder.trace(entryPoint.name, options);
+        const deferredImports = await builder.getDeferredImports(tree);
+        allEntryPoints.push(
+          ...deferredImports.map(deferredImport => ({
+            name: deferredImport.name,
+            deferredParent: entryPoint.name
+          }))
+        );
+      })
+    );
   }
 
   // populate entryPointModules from allEntryPoints
   // based on determining conditional variations and associated modules
   // { name, deferredParent, conditions, modules }
-  await Promise.map(allEntryPoints, async entryPoint => {
-    conditionalEnv = await builder.traceConditionalEnv(
-      entryPoint.name,
-      Object.assign({ inlineConditions }, options)
-    );
-
-    // remove set conditions from conditionalEnv
-    for (const condition of Object.keys(options.conditions || {})) {
-      delete conditionalEnv[condition];
-    }
-
-    // generate conditional combinations recursively (for general case of arbitrarily many conditional combinations)
-    function generateVariationsOverConditions(conditionList) {
-      const curCondition = conditionList[0];
-
-      if (!curCondition) {
-        return [];
-      }
-
-      // get combinations from the n - 1th dimension
-      const nextVariations = generateVariationsOverConditions(
-        conditionList.slice(1)
-      );
-      const variations = [];
-
-      if (!nextVariations.length) {
-        for (const curConditionValue of conditionalEnv[curCondition]) {
-          const variationConditions = {};
-          variationConditions[curCondition] = curConditionValue;
-          variations.push(variationConditions);
-        }
-      }
-
-      // multiply the combinations of the n - 1 dimension by the cominations of this nth dimension
-      for (const nextVariation of nextVariations) {
-        for (const curConditionValue of conditionalEnv[curCondition]) {
-          const variationConditions = Object.assign({}, nextVariation);
-          variationConditions[curCondition] = curConditionValue;
-          variations.push(variationConditions);
-        }
-      }
-
-      return variations;
-    }
-
-    const conditionsCombinations = generateVariationsOverConditions(
-      Object.keys(conditionalEnv)
-    );
-
-    if (conditionsCombinations.length === 0) {
-      const modules = await getModuleTrace(
+  await Promise.all(
+    allEntryPoints.map(async entryPoint => {
+      conditionalEnv = await builder.traceConditionalEnv(
         entryPoint.name,
         Object.assign({ inlineConditions }, options)
       );
+
+      // remove set conditions from conditionalEnv
+      for (const condition of Object.keys(options.conditions || {})) {
+        delete conditionalEnv[condition];
+      }
+
+      // generate conditional combinations recursively (for general case of arbitrarily many conditional combinations)
+      function generateVariationsOverConditions(conditionList) {
+        const curCondition = conditionList[0];
+
+        if (!curCondition) {
+          return [];
+        }
+
+        // get combinations from the n - 1th dimension
+        const nextVariations = generateVariationsOverConditions(
+          conditionList.slice(1)
+        );
+        const variations = [];
+
+        if (!nextVariations.length) {
+          for (const curConditionValue of conditionalEnv[curCondition]) {
+            const variationConditions = {};
+            variationConditions[curCondition] = curConditionValue;
+            variations.push(variationConditions);
+          }
+        }
+
+        // multiply the combinations of the n - 1 dimension by the cominations of this nth dimension
+        for (const nextVariation of nextVariations) {
+          for (const curConditionValue of conditionalEnv[curCondition]) {
+            const variationConditions = Object.assign({}, nextVariation);
+            variationConditions[curCondition] = curConditionValue;
+            variations.push(variationConditions);
+          }
+        }
+
+        return variations;
+      }
+
+      const conditionsCombinations = generateVariationsOverConditions(
+        Object.keys(conditionalEnv)
+      );
+
+      if (conditionsCombinations.length === 0) {
+        const modules = await getModuleTrace(
+          entryPoint.name,
+          Object.assign({ inlineConditions }, options)
+        );
+        entryPointModules.push({
+          name: entryPoint.name,
+          deferredParent: entryPoint.deferredParent,
+          modules
+        });
+        return;
+      }
+
+      // trace conditional variations
+      const conditionalVariations = [];
       entryPointModules.push({
         name: entryPoint.name,
         deferredParent: entryPoint.deferredParent,
-        modules
+        conditionalVariations
       });
-      return;
-    }
 
-    // trace conditional variations
-    const conditionalVariations = [];
-    entryPointModules.push({
-      name: entryPoint.name,
-      deferredParent: entryPoint.deferredParent,
-      conditionalVariations
-    });
-
-    for (const [i, conditions] of conditionsCombinations.entries()) {
-      const modules = await getModuleTrace(
-        entryPoint.name,
-        Object.assign(Object.assign({}, options), {
-          inlineConditions,
-          conditions: Object.assign({}, conditions)
-        })
-      );
-      conditionalVariations[i] = { modules, conditions };
-    }
-  });
+      for (const [i, conditions] of conditionsCombinations.entries()) {
+        const modules = await getModuleTrace(
+          entryPoint.name,
+          Object.assign(Object.assign({}, options), {
+            inlineConditions,
+            conditions: Object.assign({}, conditions)
+          })
+        );
+        conditionalVariations[i] = { modules, conditions };
+      }
+    })
+  );
 
   // We now have a four-layer optimization:
   // - common bundle
@@ -797,16 +800,18 @@ async function bundleStrategy(builder, entryPoints, options) {
 
   // finally, now that we have all bundles calculated, generate the bundle sources
 
-  await Promise.map(Object.keys(bundles), async bundleName => {
-    const bundle = bundles[bundleName];
-    const output = await builder.bundle(
-      bundle.modules,
-      Object.assign({ inlineConditions }, options)
-    );
-    bundle.source = output.source;
-    bundle.sourceMap = output.sourceMap;
-    bundle.assetList = output.assetList;
-  });
+  await Promise.all(
+    Object.keys(bundles).map(async bundleName => {
+      const bundle = bundles[bundleName];
+      const output = await builder.bundle(
+        bundle.modules,
+        Object.assign({ inlineConditions }, options)
+      );
+      bundle.source = output.source;
+      bundle.sourceMap = output.sourceMap;
+      bundle.assetList = output.assetList;
+    })
+  );
 
   return bundles;
 }

--- a/lib/transforms/bundleWebpack.js
+++ b/lib/transforms/bundleWebpack.js
@@ -1,5 +1,5 @@
 const pathModule = require('path');
-const Promise = require('bluebird');
+const { promisify } = require('util');
 const urlTools = require('urltools');
 const estraverse = require('estraverse-fb');
 const readPkgUp = require('read-pkg-up');
@@ -184,7 +184,7 @@ module.exports = (queryObj, { configPath } = {}) => {
     const compiler = webpack(config);
     const outputFileSystem = new webpack.MemoryOutputFileSystem();
     compiler.outputFileSystem = outputFileSystem;
-    const stats = await Promise.fromNode(cb => compiler.run(cb));
+    const stats = await promisify(compiler.run.bind(compiler))();
     if (stats.compilation && stats.compilation.errors) {
       for (const error of stats.compilation.errors) {
         assetGraph.warn(error);

--- a/lib/transforms/compressJavaScript.js
+++ b/lib/transforms/compressJavaScript.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const os = require('os');
 const { promisify } = require('util');
-const Bluebird = require('bluebird');
+const pMap = require('p-map');
 const errors = require('../errors');
 const compressorByName = {};
 
@@ -147,7 +147,7 @@ module.exports = (queryObj, compressorName = 'terser', compressorOptions) => {
     );
   }
   return async function compressJavaScript(assetGraph) {
-    await Bluebird.map(
+    await pMap(
       assetGraph.findAssets({ type: 'JavaScript', ...queryObj }),
       async javaScript => {
         try {

--- a/lib/transforms/compressJavaScript.js
+++ b/lib/transforms/compressJavaScript.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const os = require('os');
-const Promise = require('bluebird');
+const { promisify } = require('util');
+const Bluebird = require('bluebird');
 const errors = require('../errors');
 const compressorByName = {};
 
@@ -108,8 +109,9 @@ compressorByName.yuicompressor = async (
   return {
     type: 'JavaScript',
     copyrightNoticeComments: javaScript.copyrightNoticeComments,
-    text: await Promise.fromNode(cb =>
-      yuicompressor.compile(javaScript.text, compressorOptions, cb)
+    text: await promisify(yuicompressor.compile)(
+      javaScript.text,
+      compressorOptions
     )
   };
 };
@@ -131,8 +133,9 @@ compressorByName.closurecompiler = async (
   return {
     type: 'JavaScript',
     copyrightNoticeComments: javaScript.copyrightNoticeComments,
-    text: await Promise.fromNode(cb =>
-      closurecompiler.compile(javaScript.text, compressorOptions, cb)
+    text: await promisify(closurecompiler.compile)(
+      javaScript.text,
+      compressorOptions
     )
   };
 };
@@ -144,7 +147,7 @@ module.exports = (queryObj, compressorName = 'terser', compressorOptions) => {
     );
   }
   return async function compressJavaScript(assetGraph) {
-    await Promise.map(
+    await Bluebird.map(
       assetGraph.findAssets({ type: 'JavaScript', ...queryObj }),
       async javaScript => {
         try {

--- a/lib/transforms/drawGraph.js
+++ b/lib/transforms/drawGraph.js
@@ -138,17 +138,17 @@ module.exports = targetFileName => {
     ]);
     dotProcess.stdin.end(dotSrc);
     dotProcess.stderr.on('data', chunk => console.warn(`dot STDERR: ${chunk}`));
-    await new Promise(resolve => {
+    await new Promise((resolve, reject) => {
       dotProcess.on('error', error => {
         if (error.code === 'ENOENT') {
-          throw new Error('"dot" not found. Please install graphviz.');
+          reject(new Error('"dot" not found. Please install graphviz.'));
         } else {
-          throw error;
+          reject(error);
         }
       });
       dotProcess.on('exit', exitCode => {
         if (exitCode) {
-          throw new Error(`dot exited with code: ${exitCode}`);
+          reject(new Error(`dot exited with code: ${exitCode}`));
         } else {
           resolve();
         }

--- a/lib/transforms/drawGraph.js
+++ b/lib/transforms/drawGraph.js
@@ -1,5 +1,4 @@
 const Path = require('path');
-const Promise = require('bluebird');
 const childProcess = require('child_process');
 const _ = require('lodash');
 const relationLabelByType = {
@@ -139,19 +138,19 @@ module.exports = targetFileName => {
     ]);
     dotProcess.stdin.end(dotSrc);
     dotProcess.stderr.on('data', chunk => console.warn(`dot STDERR: ${chunk}`));
-    await Promise.fromNode(cb => {
+    await new Promise(resolve => {
       dotProcess.on('error', error => {
         if (error.code === 'ENOENT') {
-          cb(new Error('"dot" not found. Please install graphviz.'));
+          throw new Error('"dot" not found. Please install graphviz.');
         } else {
-          cb(error);
+          throw error;
         }
       });
       dotProcess.on('exit', exitCode => {
         if (exitCode) {
-          cb(new Error(`dot exited with code: ${exitCode}`));
+          throw new Error(`dot exited with code: ${exitCode}`);
         } else {
-          cb();
+          resolve();
         }
       });
     });

--- a/lib/transforms/gzip.js
+++ b/lib/transforms/gzip.js
@@ -1,4 +1,5 @@
-const Promise = require('bluebird');
+const { promisify } = require('util');
+const Bluebird = require('bluebird');
 
 module.exports = queryObj => {
   return async function gzip(assetGraph) {
@@ -9,25 +10,23 @@ module.exports = queryObj => {
 
     if (gzipAssets.length > 0) {
       try {
-        compress = require('node-zopfli');
+        compress = promisify(require('node-zopfli'));
       } catch (e) {
         assetGraph.info(
           new Error(
             'node-zopfli is not available, using less efficient zlib compression'
           )
         );
-        compress = require('zlib');
+        compress = promisify(require('zlib'));
       }
     }
 
-    await Promise.map(
+    await Bluebird.map(
       gzipAssets,
       async asset => {
         // http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
         if (asset.type !== 'SourceMap' && asset.rawSrc.length > 860) {
-          const gzippedRawSrc = await Promise.fromNode(cb =>
-            compress.gzip(asset.rawSrc, cb)
-          );
+          const gzippedRawSrc = await compress.gzip(asset.rawSrc);
           if (gzippedRawSrc.length < asset.rawSrc.length) {
             assetGraph.addAsset({
               url: asset.url.replace(/(?=[?#]|$)/, '.gz'),

--- a/lib/transforms/gzip.js
+++ b/lib/transforms/gzip.js
@@ -1,5 +1,5 @@
 const { promisify } = require('util');
-const Bluebird = require('bluebird');
+const pMap = require('p-map');
 
 module.exports = queryObj => {
   return async function gzip(assetGraph) {
@@ -23,7 +23,7 @@ module.exports = queryObj => {
 
     const gzip = promisify(compress.gzip.bind(compress));
 
-    await Bluebird.map(
+    await pMap(
       gzipAssets,
       async asset => {
         // http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits

--- a/lib/transforms/gzip.js
+++ b/lib/transforms/gzip.js
@@ -10,23 +10,25 @@ module.exports = queryObj => {
 
     if (gzipAssets.length > 0) {
       try {
-        compress = promisify(require('node-zopfli'));
+        compress = require('node-zopfli');
       } catch (e) {
         assetGraph.info(
           new Error(
             'node-zopfli is not available, using less efficient zlib compression'
           )
         );
-        compress = promisify(require('zlib'));
+        compress = require('zlib');
       }
     }
+
+    const gzip = promisify(compress.gzip.bind(compress));
 
     await Bluebird.map(
       gzipAssets,
       async asset => {
         // http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits
         if (asset.type !== 'SourceMap' && asset.rawSrc.length > 860) {
-          const gzippedRawSrc = await compress.gzip(asset.rawSrc);
+          const gzippedRawSrc = await gzip(asset.rawSrc);
           if (gzippedRawSrc.length < asset.rawSrc.length) {
             assetGraph.addAsset({
               url: asset.url.replace(/(?=[?#]|$)/, '.gz'),

--- a/lib/transforms/loadAssets.js
+++ b/lib/transforms/loadAssets.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { promisify } = require('util');
-const Bluebird = require('bluebird');
+const pMap = require('p-map');
 const pathModule = require('path');
 const glob = promisify(require('glob'));
 const urlTools = require('urltools');
@@ -11,7 +11,7 @@ module.exports = function(...args) {
   const flattenedArguments = _.flatten(args);
   return async function loadAssets(assetGraph) {
     return _.flatten(
-      await Bluebird.map(
+      await pMap(
         _.flatten(flattenedArguments),
         async assetConfig => {
           let assets;

--- a/lib/transforms/loadAssets.js
+++ b/lib/transforms/loadAssets.js
@@ -1,7 +1,8 @@
 const _ = require('lodash');
-const Promise = require('bluebird');
+const { promisify } = require('util');
+const Bluebird = require('bluebird');
 const pathModule = require('path');
-const glob = require('glob');
+const glob = promisify(require('glob'));
 const urlTools = require('urltools');
 
 // Takes assetConfigs, urls or root-relative paths or arrays of these
@@ -10,7 +11,7 @@ module.exports = function(...args) {
   const flattenedArguments = _.flatten(args);
   return async function loadAssets(assetGraph) {
     return _.flatten(
-      await Promise.map(
+      await Bluebird.map(
         _.flatten(flattenedArguments),
         async assetConfig => {
           let assets;
@@ -25,15 +26,12 @@ module.exports = function(...args) {
                 assetConfig = urlTools.fileUrlToFsPath(assetConfig);
               }
               assets = _.flatten(
-                await Promise.fromNode(cb =>
-                  glob(
-                    pathModule.resolve(
-                      assetGraph.root
-                        ? urlTools.fileUrlToFsPath(assetGraph.root)
-                        : process.cwd(),
-                      assetConfig
-                    ),
-                    cb
+                await glob(
+                  pathModule.resolve(
+                    assetGraph.root
+                      ? urlTools.fileUrlToFsPath(assetGraph.root)
+                      : process.cwd(),
+                    assetConfig
                   )
                 )
               ).map(path => assetGraph.addAsset(encodeURI(`file://${path}`)));

--- a/lib/transforms/minifySvgAssetsWithSvgo.js
+++ b/lib/transforms/minifySvgAssetsWithSvgo.js
@@ -1,5 +1,3 @@
-const Promise = require('bluebird');
-
 module.exports = queryObj => {
   return async function minifySvgAssetsWithSvgo(assetGraph) {
     let Svgo;
@@ -18,53 +16,57 @@ module.exports = queryObj => {
         return;
       }
     }
-    await Promise.map(svgAssets, async svgAsset => {
-      // The removeUnknownsAndDefaults SVGO plugin strips top-level attributes of the <svg> element
-      // that could be important. Note down all the attributes so they can be re-attached after the optimization
-      // https://github.com/svg/svgo/issues/301
-      const originalTopLevelAttributes = {};
-      if (svgAsset.isInline) {
-        for (const attribute of Array.from(
-          svgAsset.parseTree.documentElement.attributes
-        )) {
-          originalTopLevelAttributes[attribute.name] = attribute.value;
-        }
-      }
-
-      let result;
-      try {
-        result = await new Svgo({
-          floatPrecision: 6, // The default of 2 is so low that it's visibly lossy in some cases
-          plugins: [{ removeViewBox: false }]
-        }).optimize(svgAsset.text);
-      } catch (err) {
-        assetGraph.warn(
-          new Error(
-            `SVG optimization error in ${svgAsset.urlOrDescription}\nOptimiztion skipped.\n${err}`
-          )
-        );
-      }
-
-      if (result) {
-        svgAsset.text = result.data;
+    await Promise.all(
+      svgAssets.map(async svgAsset => {
+        // The removeUnknownsAndDefaults SVGO plugin strips top-level attributes of the <svg> element
+        // that could be important. Note down all the attributes so they can be re-attached after the optimization
+        // https://github.com/svg/svgo/issues/301
+        const originalTopLevelAttributes = {};
         if (svgAsset.isInline) {
-          let dirty = false;
-          for (const attributeName of Object.keys(originalTopLevelAttributes)) {
-            if (
-              !svgAsset.parseTree.documentElement.hasAttribute(attributeName)
-            ) {
-              svgAsset.parseTree.documentElement.setAttribute(
-                attributeName,
-                originalTopLevelAttributes[attributeName]
-              );
-              dirty = true;
+          for (const attribute of Array.from(
+            svgAsset.parseTree.documentElement.attributes
+          )) {
+            originalTopLevelAttributes[attribute.name] = attribute.value;
+          }
+        }
+
+        let result;
+        try {
+          result = await new Svgo({
+            floatPrecision: 6, // The default of 2 is so low that it's visibly lossy in some cases
+            plugins: [{ removeViewBox: false }]
+          }).optimize(svgAsset.text);
+        } catch (err) {
+          assetGraph.warn(
+            new Error(
+              `SVG optimization error in ${svgAsset.urlOrDescription}\nOptimiztion skipped.\n${err}`
+            )
+          );
+        }
+
+        if (result) {
+          svgAsset.text = result.data;
+          if (svgAsset.isInline) {
+            let dirty = false;
+            for (const attributeName of Object.keys(
+              originalTopLevelAttributes
+            )) {
+              if (
+                !svgAsset.parseTree.documentElement.hasAttribute(attributeName)
+              ) {
+                svgAsset.parseTree.documentElement.setAttribute(
+                  attributeName,
+                  originalTopLevelAttributes[attributeName]
+                );
+                dirty = true;
+              }
+            }
+            if (dirty) {
+              svgAsset.markDirty();
             }
           }
-          if (dirty) {
-            svgAsset.markDirty();
-          }
         }
-      }
-    });
+      })
+    );
   };
 };

--- a/lib/transforms/startRepl.js
+++ b/lib/transforms/startRepl.js
@@ -1,5 +1,4 @@
 const Repl = require('repl');
-const Promise = require('bluebird');
 const open = require('open');
 
 function quoteRegExpMetaChars(str) {

--- a/lib/transforms/writeAssetsToDisc.js
+++ b/lib/transforms/writeAssetsToDisc.js
@@ -1,16 +1,17 @@
-const Promise = require('bluebird');
-const fs = Promise.promisifyAll(require('fs'));
+const { promisify } = require('util');
+const Bluebird = require('bluebird');
+const writeFile = promisify(require('fs').writeFile);
 const Path = require('path');
-const mkdirpAsync = Promise.promisify(require('mkdirp'));
+const mkdirpAsync = promisify(require('mkdirp'));
 const urlTools = require('urltools');
 
 async function mkpathAndWriteFileAsync(fileName, contents, encoding) {
   try {
-    await fs.writeFileAsync(fileName, contents, encoding);
+    await writeFile(fileName, contents, encoding);
   } catch (err) {
     if (err.code === 'ENOENT') {
       await mkdirpAsync(Path.dirname(fileName));
-      await fs.writeFileAsync(fileName, contents, encoding);
+      await writeFile(fileName, contents, encoding);
     } else {
       throw err;
     }
@@ -23,7 +24,7 @@ module.exports = (queryObj, outRoot, root) => {
   }
 
   return async function writeAssetsToDisc(assetGraph) {
-    await Promise.map(
+    await Bluebird.map(
       assetGraph.findAssets(
         Object.assign(
           {

--- a/lib/transforms/writeAssetsToDisc.js
+++ b/lib/transforms/writeAssetsToDisc.js
@@ -1,5 +1,5 @@
 const { promisify } = require('util');
-const Bluebird = require('bluebird');
+const pMap = require('p-map');
 const writeFile = promisify(require('fs').writeFile);
 const Path = require('path');
 const mkdirpAsync = promisify(require('mkdirp'));
@@ -24,7 +24,7 @@ module.exports = (queryObj, outRoot, root) => {
   }
 
   return async function writeAssetsToDisc(assetGraph) {
-    await Bluebird.map(
+    await pMap(
       assetGraph.findAssets(
         Object.assign(
           {

--- a/lib/util/determineFileType.js
+++ b/lib/util/determineFileType.js
@@ -1,5 +1,5 @@
 const childProcess = require('child_process');
-const Promise = require('bluebird');
+const Bluebird = require('bluebird');
 
 function limitConcurrency(concurrency, fn) {
   const queue = [];
@@ -31,7 +31,7 @@ function limitConcurrency(concurrency, fn) {
 
 module.exports = limitConcurrency(20, function determineFileType(rawSrc) {
   // Work the magic
-  return new Promise((resolve, reject) => {
+  return new Bluebird((resolve, reject) => {
     const fileProcess = childProcess.spawn('file', ['-b', '--mime-type', '-']);
     let fileOutput = '';
 

--- a/lib/util/determineFileType.js
+++ b/lib/util/determineFileType.js
@@ -1,37 +1,11 @@
 const childProcess = require('child_process');
-const Bluebird = require('bluebird');
+const pLimit = require('p-limit');
 
-function limitConcurrency(concurrency, fn) {
-  const queue = [];
-  let numInFlight = 0;
-  function proceed() {
-    while (numInFlight < concurrency && queue.length > 0) {
-      const job = queue.shift();
-      numInFlight += 1;
-      const returnValue = fn.apply(job.thisObject, job.args);
-      returnValue.then(job.resolve, job.reject).finally(() => {
-        numInFlight -= 1;
-        proceed();
-      });
-    }
-  }
-  return function(...args) {
-    const thisObject = this;
-    return new Promise((resolve, reject) => {
-      queue.push({
-        args,
-        thisObject,
-        resolve,
-        reject
-      });
-      proceed();
-    });
-  };
-}
+const limit = pLimit(4);
 
-module.exports = limitConcurrency(20, function determineFileType(rawSrc) {
+function determineFileType(rawSrc) {
   // Work the magic
-  return new Bluebird((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const fileProcess = childProcess.spawn('file', ['-b', '--mime-type', '-']);
     let fileOutput = '';
 
@@ -56,4 +30,6 @@ module.exports = limitConcurrency(20, function determineFileType(rawSrc) {
 
     fileProcess.stdin.end(rawSrc);
   });
-});
+}
+
+module.exports = rawSrc => limit(() => determineFileType(rawSrc));

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "acorn": "^7.0.0",
     "acorn-jsx": "^5.0.1",
-    "bluebird": "^3.5.1",
     "chalk": "^2.0.1",
     "common-path-prefix": "^2.0.0",
     "createerror": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "memoizesync": "1.1.1",
     "mkdirp": "^0.5.1",
     "normalizeurl": "^1.0.0",
+    "p-limit": "^2.2.1",
     "p-map": "^3.0.0",
     "perfectionist": "^2.4.0",
     "postcss": "^7.0.14",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "memoizesync": "1.1.1",
     "mkdirp": "^0.5.1",
     "normalizeurl": "^1.0.0",
+    "p-map": "^3.0.0",
     "perfectionist": "^2.4.0",
     "postcss": "^7.0.14",
     "read-pkg-up": "^6.0.0",

--- a/test/TransformQueue.js
+++ b/test/TransformQueue.js
@@ -1,6 +1,5 @@
 const expect = require('./unexpected-with-plugins');
 const AssetGraph = require('../lib/AssetGraph');
-const Promise = require('bluebird');
 
 AssetGraph.registerTransform(function pushItemToArraySync(item, array) {
   return function(assetGraph) {

--- a/test/util/determineFileType.js
+++ b/test/util/determineFileType.js
@@ -1,0 +1,29 @@
+const expect = require('../unexpected-with-plugins');
+const determineFileType = require('../../lib/util/determineFileType');
+
+describe('determineFileType', function() {
+  it('should detect that a buffer contains a PNG', async function() {
+    const fileType = await determineFileType(
+      Buffer.from([
+        0x89,
+        0x50,
+        0x4e,
+        0x47,
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a,
+        0x00,
+        0x00,
+        0x00,
+        0x0d,
+        0x49,
+        0x48,
+        0x44,
+        0x52
+      ])
+    );
+
+    expect(fileType, 'to equal', 'image/png');
+  });
+});


### PR DESCRIPTION
These days we shouldn't really need Bluebird anymore.

- [x] Replace bluebird with native promises where possible
- [x] Use `util.promisify` to promisify in stead of bluebird
- [x] Replace bluebird usage for concurrency. Maybe `p-] limit`?
- [x] Replace bluebird usage for `.finally` support in https://github.com/assetgraph/assetgraph/blob/master/lib/util/determineFileType.js#L12
- [x] Delete bluebird from package.json

I renamed the remaining uses of bluebird from `Promise` to `Bluebird` to make it easier to spot the leftover usages.

The `.finally` usage in https://github.com/assetgraph/assetgraph/blob/master/lib/util/determineFileType.js#L12 is a homegrown concurrency limiter. Could that whole thing also be replaced with `p-limit` or another out of the box concurrency control for native promises? 