### PR TITLE
Catch throws from decodeURI

### DIFF
--- a/lib/assets/Asset.js
+++ b/lib/assets/Asset.js
@@ -1477,10 +1477,16 @@ class Asset extends EventEmitter {
   get urlOrDescription() {
     function makeRelativeToCwdIfPossible(url) {
       if (/^file:\/\//.test(url)) {
-        return pathModule.relative(
-          process.cwd(),
-          urlTools.fileUrlToFsPath(url)
-        );
+        try {
+          return pathModule.relative(
+            process.cwd(),
+            urlTools.fileUrlToFsPath(url)
+          );
+        } catch (err) {
+          err.message = `Error while attempting to resolve working directory relative path for ${url}: ${err.message}`;
+          this.assetGraph.emit('warn', err);
+          return url;
+        }
       } else {
         return url;
       }


### PR DESCRIPTION
It seems that if a file path is invalid, we can get `decodeURI` to throw inside urltools while calling `fileUrlToFsPath`. Unfortunately this can happen when `logEvents` is attempting to write a useful error message because the path is exercised as part of the asset url pretty printing mechanism.

This change guards against this situation and makes sure that at least something is shown when getting an Assets `urlOrDescription`. 