### PR TITLE
Add qs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "p-map": "^4.0.0",
     "perfectionist": "^2.4.0",
     "postcss": "^7.0.14",
+    "qs": "^6.9.4",
     "read-pkg-up": "^7.0.0",
     "repeat-string": "^1.5.4",
     "schemes": "^1.0.1",


### PR DESCRIPTION
`qs` is directly used in this repo but is not in the `package.json`. This causes error when using asset graph with yarn. 

```
> rg qs
lib/assets/Asset.js:const qs = require('qs');
lib/assets/Asset.js:    const queryString = qs.stringify(obj);
lib/assets/Asset.js:        qs.parse(new urlModule.URL(this.url).search.slice(1)),
lib/assets/Asset.js:      query = qs.parse(query.replace(/^\?/, ''));
```

Adding qs might solve the problem