### PR TITLE
Switch moveAssetsInOrder to emit a warning about cyclic dependencies instead of throwing

### DIFF
--- a/jsdoc-plugins/remove-imports.js
+++ b/jsdoc-plugins/remove-imports.js
@@ -1,0 +1,14 @@
+/**
+ * This jsdoc plugin removes all comments that import other files at part of a type definition
+ * Jsdoc doesn't support this syntax, but it is needed for typescript typings
+ */
+exports.handlers = {
+  jsdocCommentFound: function(e) {
+    if (
+      e.comment.includes('@typedef {import(') ||
+      e.comment.includes('@type {typeof import(')
+    ) {
+      e.comment = '';
+    }
+  }
+};

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -12,12 +12,10 @@
     "includePattern": ".js$"
   },
 
-  "plugins": [
-      "plugins/markdown"
-  ],
+  "plugins": ["plugins/markdown", "jsdoc-plugins/remove-imports"],
 
   "docdash": {
-      "static": true,
-      "sort": true
+    "static": true,
+    "sort": true
   }
 }

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -491,6 +491,53 @@ class Relation {
         : 'unattached'
     }]`;
   }
+
+  /**
+   * Get a location object
+   */
+  get location() {
+    const asset = this.from.nonInlineAncestor;
+
+    if (asset.isText) {
+      let line, column;
+      let details = '';
+
+      if (asset.type === 'Css') {
+        const source = this.node.source;
+
+        details = source.input.css.trim();
+
+        line = source.start.line;
+        column = source.start.column + details.indexOf(this.href);
+      } else {
+        const text = asset.rawSrc.toString();
+        const linesBefore = text.split(this.href)[0].split('\n');
+        const charsBefore = linesBefore[linesBefore.length - 1];
+
+        line = linesBefore.length;
+        column = charsBefore.length + 1;
+      }
+
+      const node = this.node;
+
+      if (this.from.isInline && asset.type !== this.from.type) {
+        details += `(inlined ${this.from.type}) `;
+      }
+
+      // DOM node
+      if (asset.type === 'Html') {
+        details += node.outerHTML.replace(node.innerHTML, '...');
+      }
+
+      if (asset.url.startsWith('file:')) {
+        return `${asset.urlOrDescription}:${line}:${column} ${details}`;
+      }
+
+      return `${asset.urlOrDescription} (${line}:${column}) ${details}`;
+    }
+
+    return asset.urlOrDescription;
+  }
 }
 
 Object.assign(Relation.prototype, {

--- a/lib/relations/Relation.js
+++ b/lib/relations/Relation.js
@@ -493,7 +493,11 @@ class Relation {
   }
 
   /**
-   * Get a location object
+   * The source location of the relation in the asset it is defined in.
+   * If the asset is a text asset this will yield the path:line:col for
+   * file URL's that make it easier to locate the relation in the source file.
+   *
+   * @returns {string} line and column annotated file path
    */
   get location() {
     const asset = this.from.nonInlineAncestor;

--- a/lib/transforms/logEvents.js
+++ b/lib/transforms/logEvents.js
@@ -72,6 +72,12 @@ module.exports = ({ afterTransform, repl, stopOnWarning } = {}) => {
               .join('\n    ')}\n`;
           }
         }
+
+        if (messageOrError.relations) {
+          message += `\nCyclic relations:\n    ${messageOrError.relations
+            .map(incomingRelation => incomingRelation.location)
+            .join('\n    ')}\n`;
+        }
       } else {
         if (typeof messageOrError === 'string') {
           message = messageOrError;

--- a/lib/transforms/moveAssetsInOrder.js
+++ b/lib/transforms/moveAssetsInOrder.js
@@ -78,8 +78,8 @@ function* generateMoveOrder(assetGraph, queryObj) {
         'transforms.moveAssetsInOrder: Cyclic dependencies detected. All files could not be moved'
       );
 
-      const relevantRelations = [...outgoingRelationsByAsset.values()]
-        .flat()
+      const relevantRelations = []
+        .concat(...outgoingRelationsByAsset.values())
         .filter(relation => outgoingRelationsByAsset.has(relation.to))
         .sort((a, b) => a.from.id < b.from.id);
 

--- a/lib/transforms/moveAssetsInOrder.js
+++ b/lib/transforms/moveAssetsInOrder.js
@@ -1,14 +1,26 @@
 const compileQuery = require('../compileQuery');
 const createAssetMover = require('../util/assetMover');
 
+/** @typedef {import('../AssetGraph')} AssetGraph */
+/** @typedef {import('../assets/Asset')} Asset */
+/** @typedef {import('../relations/Relation')} Relation */
+
+/**
+ *
+ * @param {AssetGraph} assetGraph
+ * @param {object} queryObj
+ */
+
 // Helper function for determining the order in which the hashes can be computed and the assets
 // moved. The challenge lies in the fact that updating a relation to point at <hash>.<extension>
 // will change the hash of the asset that owns the relation.
 // Needless to say this will fail if the graph of assets to be moved has cycles, so be careful.
 function* generateMoveOrder(assetGraph, queryObj) {
+  /** @type {Map<Asset, Relation[]>} */
   const outgoingRelationsByAsset = new Map();
   const assetMatcher = compileQuery(queryObj);
 
+  // Create map of file-assets and their relations to other file-assets
   for (const asset of assetGraph.findAssets({ isInline: false })) {
     if (assetMatcher(asset)) {
       const relationFrom = assetGraph.collectAssetsPostOrder(asset, {
@@ -33,28 +45,51 @@ function* generateMoveOrder(assetGraph, queryObj) {
     if (outgoingRelationsByAsset.size === 0) {
       break;
     }
+
+    /** @type {Asset[]} */
     const currentBatch = [];
-    for (const asset of outgoingRelationsByAsset.keys()) {
+
+    // Find batches of assets that point to no other files in the map
+    for (const [
+      asset,
+      outgoingRelations
+    ] of outgoingRelationsByAsset.entries()) {
       if (
-        !outgoingRelationsByAsset
-          .get(asset)
-          .some(outgoingRelation =>
-            outgoingRelationsByAsset.has(outgoingRelation.to)
-          )
+        !outgoingRelations.some(outgoingRelation =>
+          outgoingRelationsByAsset.has(outgoingRelation.to)
+        )
       ) {
         currentBatch.push(asset);
       }
     }
 
+    // Remove assets in current batch from file-asset map
     for (const asset of currentBatch) {
       outgoingRelationsByAsset.delete(asset);
     }
 
+    // There are assets left in the map which have relations to other
+    // assets in the map.
+    // At this point that can only happen if there is one or more
+    // dependency circles in the graph represented by the remaining
+    // map of assets
     if (currentBatch.length === 0) {
-      throw new Error(
-        "transforms.moveAssetsInOrder: Couldn't find a suitable rename order due to cycles in the selection"
+      const warning = new Error(
+        'transforms.moveAssetsInOrder: Cyclic dependencies detected. All files could not be moved'
       );
+
+      const relevantRelations = [...outgoingRelationsByAsset.values()]
+        .flat()
+        .filter(relation => outgoingRelationsByAsset.has(relation.to))
+        .sort((a, b) => a.from.id < b.from.id);
+
+      warning.relations = relevantRelations;
+
+      assetGraph.emit('warn', warning);
+
+      break;
     }
+
     yield* currentBatch;
   }
 }

--- a/lib/transforms/moveAssetsInOrder.js
+++ b/lib/transforms/moveAssetsInOrder.js
@@ -80,8 +80,7 @@ function* generateMoveOrder(assetGraph, queryObj) {
 
       const relevantRelations = []
         .concat(...outgoingRelationsByAsset.values())
-        .filter(relation => outgoingRelationsByAsset.has(relation.to))
-        .sort((a, b) => a.from.id < b.from.id);
+        .filter(relation => outgoingRelationsByAsset.has(relation.to));
 
       warning.relations = relevantRelations;
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "file-loader": "^4.0.0",
     "httpception": "^3.0.0",
     "iconv-lite": "^0.5.0",
-    "jsdoc": "^3.5.5",
+    "jsdoc": "^3.6.4",
     "less": "^2.7.3",
     "magicpen-prism": "3.0.2",
     "mocha": "^6.0.0",

--- a/test/transforms/moveAssetsInOrder.js
+++ b/test/transforms/moveAssetsInOrder.js
@@ -1,4 +1,5 @@
 const expect = require('../unexpected-with-plugins');
+const sinon = require('sinon');
 const AssetGraph = require('../../lib/AssetGraph');
 
 describe('transforms/moveAssetsInOrder', function() {
@@ -29,18 +30,43 @@ describe('transforms/moveAssetsInOrder', function() {
     });
   });
 
-  it('should throw an error when encountering circular references', async function() {
+  it('should emit an error when encountering circular references', async function() {
+    const order = ['first.css', 'second.css', 'third.css', 'main.css'];
+    let idx = 0;
+
     const assetGraph = new AssetGraph({
       root: 'testdata/transforms/moveAssetsInOrder/'
     });
 
-    await assetGraph.loadAssets('circular.html');
-    await assetGraph.populate();
+    const spy = sinon.spy();
+    assetGraph.on('warn', spy);
 
-    await expect(
-      () => assetGraph.moveAssetsInOrder({ type: 'Css' }, '/css/'),
-      'to error',
-      /Couldn't find a suitable rename order due to cycles in the selection/
-    );
+    await assetGraph.loadAssets('partiallycircular.html');
+    await assetGraph.populate();
+    await assetGraph.moveAssetsInOrder({ type: 'Css' }, function(asset) {
+      expect(asset.fileName, 'to be', order[idx]);
+      idx += 1;
+    });
+
+    expect(spy, 'to have calls satisfying', () => {
+      spy({
+        message:
+          'transforms.moveAssetsInOrder: Cyclic dependencies detected. All files could not be moved',
+        relations: expect.it('to satisfy', [
+          {
+            from: {
+              fileName: 'circular-base.css'
+            },
+            href: 'circular-child.css'
+          },
+          {
+            from: {
+              fileName: 'circular-child.css'
+            },
+            href: 'circular-base.css'
+          }
+        ])
+      });
+    });
   });
 });

--- a/test/transforms/moveAssetsInOrder.js
+++ b/test/transforms/moveAssetsInOrder.js
@@ -52,7 +52,7 @@ describe('transforms/moveAssetsInOrder', function() {
       spy({
         message:
           'transforms.moveAssetsInOrder: Cyclic dependencies detected. All files could not be moved',
-        relations: expect.it('to satisfy', [
+        relations: expect.it('with set semantics', 'to satisfy', [
           {
             from: {
               fileName: 'circular-base.css'

--- a/testdata/transforms/moveAssetsInOrder/partiallycircular.html
+++ b/testdata/transforms/moveAssetsInOrder/partiallycircular.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="circular-base.css">
+<link rel="stylesheet" href="main.css">


### PR DESCRIPTION
Relates to https://github.com/Munter/netlify-plugin-hashfiles/issues/67

- `moveAssetsInOrder` now emits a `warn` event with an `Error` that has a `.relations` property of type `Relation[]`
- `logEvents` now handles an array of Relation on an Error and displays a list of them using a new addition to relation:
- `Relation.location` is a new getter that outputs the from asset and the location of the href for the relation, plus some context if available.

Example of `Relation.location`:

```
 ⚠ WARN: transforms.moveAssetsInOrder: Cyclic dependencies detected. All files could not be moved
         Cyclic relations:
             testdata/transforms/moveAssetsInOrder/circular-base.css:1:10 @import 'circular-child.css';
             testdata/transforms/moveAssetsInOrder/circular-child.css:1:10 @import 'circular-base.css';
```

The implementation is inspired by [`relationDebugDescription`](https://github.com/Munter/hyperlink/blob/master/lib/relationDebugDescription.js) from hyperlink