### PR TITLE
Update fetch expression to only match direct descendants.

### DIFF
--- a/lib/relations/JavaScript/JavaScriptFetch.js
+++ b/lib/relations/JavaScript/JavaScriptFetch.js
@@ -3,7 +3,7 @@ const Relation = require('../Relation');
 
 class JavaScriptFetch extends Relation {
   static get selector() {
-    return '!CallExpression[arguments.0.type=Literal][arguments.0.value=type(string)]:has(Identifier.callee[name=fetch], MemberExpression.callee[computed=false]:has(Identifier.object[name=window]) > Identifier.property[name=fetch])';
+    return 'CallExpression[arguments.0.type=Literal][arguments.0.value=type(string)]:matches([callee.name=fetch], [callee.type=MemberExpression][callee.property.type=Identifier][callee.property.name=fetch])';
   }
 
   static handler(node, [parentNode, parentParentNode], asset) {

--- a/test/relations/JavaScript/JavaScriptFetch.js
+++ b/test/relations/JavaScript/JavaScriptFetch.js
@@ -45,6 +45,20 @@ describe('relations/JavaScriptFetch', function () {
     expect(assetGraph, 'to contain assets', 'JavaScript', 2);
   });
 
+  it('should not populate this.addEventListener("fetch")', async function () {
+    const assetGraph = new AssetGraph({
+      root: pathModule.resolve(
+        __dirname,
+        '../../../testdata/relations/JavaScript/JavaScriptFetch'
+      ),
+    });
+    await assetGraph.loadAssets('serviceWorker.js');
+    await assetGraph.populate();
+
+    expect(assetGraph, 'to contain relations', 'JavaScriptFetch', 0);
+    expect(assetGraph, 'to contain assets', 'JavaScript', 1);
+  });
+
   it('should populate a sequence fetch', async function () {
     const assetGraph = new AssetGraph({
       root: pathModule.resolve(

--- a/testdata/relations/JavaScript/JavaScriptFetch/serviceWorker.js
+++ b/testdata/relations/JavaScript/JavaScriptFetch/serviceWorker.js
@@ -1,0 +1,3 @@
+this.addEventListener("fetch", e => {
+    return fetch(e.request);
+})


### PR DESCRIPTION
Previously it would match cases like `f("hi", fetch(url))` and consider the target `hi`.