### PR TITLE
Ensure _text is always available on JavaScript assets.

### DIFF
--- a/lib/assets/JavaScript.js
+++ b/lib/assets/JavaScript.js
@@ -12,6 +12,12 @@ class JavaScript extends Text {
   init(config) {
     super.init(config);
     this.serializationOptions = this.serializationOptions || {};
+    // attempt to make a textual representation of rawSrc available on instantiation
+    try {
+      this._text = this._getTextFromRawSrc();
+    } catch (e) {
+      // ignore
+    }
   }
 
   _getEscodegenOptions() {

--- a/test/assets/JavaScript.js
+++ b/test/assets/JavaScript.js
@@ -4,6 +4,29 @@ const AssetGraph = require('../../lib/AssetGraph');
 const sinon = require('sinon');
 
 describe('assets/JavaScript', function () {
+  it('should populate the _text property with the rawSrc on creation', async function () {
+    let firstWarning;
+    const assets = await new AssetGraph({
+      root: pathModule.resolve(__dirname, '../../testdata/assets/JavaScript/'),
+    })
+      .on('warn', (err) => (firstWarning = firstWarning || err))
+      .loadAssets('parseError.js');
+
+    expect(assets, 'to have length', 1);
+    const jsAsset = assets[0];
+    expect(
+      jsAsset._text,
+      'to equal',
+      `function blah () {
+    function quux () {
+    }
+}
+whatever();
+this.is(very wrong);
+`
+    );
+  });
+
   it('should handle a test case that has a parse error in an inline JavaScript asset', async function () {
     let firstWarning;
     await new AssetGraph({


### PR DESCRIPTION
As of assetgraph 7.1.0 assignment to the .text property keeps the
original source code available as _text. This is immensely useful
but has also opened up an unfortunate inconsistency because _text
is not populated from the rawSrc when such assets are instantiated.

In order to avoid adding special cases to callers try to make _text
uniformly available assetgraph is able to decode the raw buffer.