### PR TITLE
Refresh CHANGELOG.md with preversion command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,158 @@
-### v6.0.0 (2019-08-17)
+### v7.5.0 (2022-03-20)
+
+- [#1228](https://github.com/assetgraph/assetgraph/pull/1228) Update more postcss-related packages ([Andreas Lind](mailto:andreas.lind@workday.com))
+
+### v7.4.0 (2022-03-19)
+
+#### Pull requests
+
+- [#1227](https://github.com/assetgraph/assetgraph/pull/1227) Replace perfectionist with perfectionist-papandreou \(postcss 8 compatible\) ([Andreas Lind](mailto:andreas.lind@workday.com))
+
+#### Commits to master
+
+- [Empty commit to trigger CI build](https://github.com/assetgraph/assetgraph/commit/e1b16113e7d829d563cb667f60296990f38ea559) ([Andreas Lind](mailto:andreas.lind@workday.com))
+
+### v7.3.1 (2021-10-21)
+
+- [Update postcss to ^8.3.10](https://github.com/assetgraph/assetgraph/commit/2aabe8ca196630f843e8b1db7ae352c29ed71c44) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Replace Travis with Github Actions](https://github.com/assetgraph/assetgraph/commit/80a76650f3423a7f3929abaf54d7881e798a86bb) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v7.3.0 (2021-10-21)
+
+- [Adapt to the new cssnano api](https://github.com/assetgraph/assetgraph/commit/412536bd2595f2ac660e3e7d74d485215a37a313) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Update cssnano to version 5.0.8](https://github.com/assetgraph/assetgraph/commit/073f804a739f4c5ffa65884666f884821d6b714d) ([depfu[bot]](mailto:23717796+depfu[bot]@users.noreply.github.com))
+
+### v7.2.0 (2021-08-13)
+
+- [Replace sw-precache with workbox-build](https://github.com/assetgraph/assetgraph/commit/b1a7afcb017681e6ed58ad97cf38412b41f46385) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [improve jsdoc typings](https://github.com/assetgraph/assetgraph/commit/f78e44367285dd621b2a073fa05c49984951f41d) ([Peter Müller](mailto:pingvin+github@gmail.com))
+- [Improve Jsdoc typings](https://github.com/assetgraph/assetgraph/commit/188e443fb0847868f686ffd7c4511cdae9b82ee1) ([Peter Müller](mailto:pingvin+github@gmail.com))
+
+### v7.1.0 (2021-07-15)
+
+- [prettier --write '\*\*\/\*.{js,json,md,css}'](https://github.com/assetgraph/assetgraph/commit/f48ac9c7e77541acf4b394e34342e5ff99c8af90) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Add CHANGELOG.md to .prettierignore](https://github.com/assetgraph/assetgraph/commit/efd540445638a381ead3b77f3d27dc7758120a8a) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Add \/.nyc\_output to .prettierignore](https://github.com/assetgraph/assetgraph/commit/19faeafe4c839c74a497af3c2ddf327b015a30e7) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Update prettier to ~2.3.2](https://github.com/assetgraph/assetgraph/commit/12e85d2a4d1cbb04e0c2adcd66d0855a47534af1) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Make sure that Text\#\_text is populated when text is reassigned, even for asset types with a parse tree](https://github.com/assetgraph/assetgraph/commit/85b65c15fcc46cad55b4c63e379e1adc896a6a86) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v7.0.1 (2021-05-12)
+
+- [Make jsdom a regular dependency, whoops](https://github.com/assetgraph/assetgraph/commit/e4b46148643c3456911eeec43e2c59d7092df64d) ([Andreas Lind](mailto:andreas.lind@workday.com))
+
+### v7.0.0 (2021-05-12)
+
+- [prettier --write test\/transforms\/compressJavaScript.js](https://github.com/assetgraph/assetgraph/commit/eca5672ef336b0281f41ca8d6fb13bce46c80822) ([Andreas Lind](mailto:andreas.lind@workday.com))
+- [Fix compressJavaScript test now that uglify-js got even smarter](https://github.com/assetgraph/assetgraph/commit/221305242f5993b03256e14f1b2d274747492fcd) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+- [Update jsdom to ^16.5.3](https://github.com/assetgraph/assetgraph/commit/8bdff3260c692d0d67502f1508a178ca2343368f) ([Andreas Lind](mailto:andreas.lind@workday.com))
+- [Don't bother installing fonttools on CI, no longer needed](https://github.com/assetgraph/assetgraph/commit/7b3b3d4cfdfa78039626758d31a23b48066759c2) ([Andreas Lind](mailto:andreas.lind@workday.com))
+- [Drop node.js 8 support, add 12, 14, 16 \(semver-major\)](https://github.com/assetgraph/assetgraph/commit/b0bc7cb97de5a5c0100dadb6fc6f12a638f745f5) ([Andreas Lind](mailto:andreas.lind@workday.com))
+
+### v6.6.0 (2021-02-06)
+
+- [Backport fix for \#1123 from master \(cd99a60..00dae9f\)](https://github.com/assetgraph/assetgraph/commit/220f93da4210b62686dae261a1362e3bcd1431ca) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+
+### v6.5.0 (2021-01-24)
+
+- [Add AssetGraph\#buildHref that supports any hrefType](https://github.com/assetgraph/assetgraph/commit/ca85ec219efac3693a4062b061664324aebdee47) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Fix typo in test description](https://github.com/assetgraph/assetgraph/commit/d27894fae19ae26e56c3ef2693384276ed9f7ebe) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.4.5 (2021-01-21)
+
+- [Run prettier on the files cherry-picked in the previous commit](https://github.com/assetgraph/assetgraph/commit/fdb22c2b15399c56035c3b8fff5d9e24124e4410) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+- [Sidestep teepee's buggy expansion of {...} in urls](https://github.com/assetgraph/assetgraph/commit/cfdf85ea66ea4a94a93bf38cf5e51daeb42de54f) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+
+### v6.4.4 (2021-01-18)
+
+- [Pass ecmaVersion:2021 to acorn](https://github.com/assetgraph/assetgraph/commit/c75b57b15da1079273cd98b415f3b51438e02a21) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+
+### v6.4.3 (2021-01-18)
+
+- [Also handle HTTP status codes of 307 and 308 as redirects](https://github.com/assetgraph/assetgraph/commit/3121ed170b11b0f0bdd605dc2717bc442a994618) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [prettier](https://github.com/assetgraph/assetgraph/commit/f6a5bf6155fb6047c91baa009a33ab4ea511b2ba) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+
+### v6.4.2 (2021-01-17)
+
+- [Tolerate unspecified "as" attribute values for resource hints](https://github.com/assetgraph/assetgraph/commit/90988c61f102e7f1890369731ee55e531d3f00b5) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+
+### v6.4.1 (2021-01-17)
+
+- [Call decodeURIComponent on javascript: urls before parsing them](https://github.com/assetgraph/assetgraph/commit/0febc9f1649e38279bdfc4e890c717ef66ebf5cd) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+
+### v6.4.0 (2020-12-22)
+
+- [populate: Support startAssets being passed as an asset instance or an array of asset instances](https://github.com/assetgraph/assetgraph/commit/3e49eebf215c280b88220c1ab6424c4a46d85712) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [prettier --write lib\/assets\/JavaScript.js](https://github.com/assetgraph/assetgraph/commit/01aca3e8437c42c706173ff6d8655956af0b3b4c) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.3.0 (2020-11-12)
+
+- [Update test now that uglify-js supports template strings](https://github.com/assetgraph/assetgraph/commit/61e28482192d0c3d2750ee67e2569e3c9e9e9ad5) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Update escodegen to ^2.0.0](https://github.com/assetgraph/assetgraph/commit/c4517c40cfde56dd277b1a309d4a46b8dabb7345) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Update estraverse to ^5.2.0](https://github.com/assetgraph/assetgraph/commit/1445952993287f67bcddeb16dbb0db21121fec3e) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Add test for optional chaining syntax](https://github.com/assetgraph/assetgraph/commit/196d814016ea8cb26864a14532c1ff1528f37c87) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Update acorn to ^8.0.4](https://github.com/assetgraph/assetgraph/commit/10f6eaf02bd2161bc86120bdaf3e281f3147c4d5) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [+1 more](https://github.com/assetgraph/assetgraph/compare/v6.2.2...v6.3.0)
+
+### v6.2.2 (2020-11-05)
+
+- [Guard against a bug in source-map](https://github.com/assetgraph/assetgraph/commit/503a695760d7195a87dd9f3f5de40770781cd430) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.2.1 (2020-10-05)
+
+- [Update lodash to ^4.17.20](https://github.com/assetgraph/assetgraph/commit/6a2fcfe0175d05f26f8810a4756b473a36461411) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+
+### v6.2.0 (2020-08-08)
+
+- [logEvents: Support a custom console implementation](https://github.com/assetgraph/assetgraph/commit/24c65f85013d992f60ce41e886fad0ea648dae6f) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.1.3 (2020-08-03)
+
+- [Improve Relation.location output for CSS](https://github.com/assetgraph/assetgraph/commit/6c839be9a3d8d42ad69924eb227696c25c5f8eca) ([Peter Müller](mailto:munter@fumle.dk))
+
+### v6.1.2 (2020-08-02)
+
+- [#1097](https://github.com/assetgraph/assetgraph/pull/1097) Switch moveAssetsInOrder to emit a warning about cyclic dependencies instead of throwing ([Peter Müller](mailto:munter@fumle.dk))
+
+### v6.1.1 (2020-07-09)
+
+- [Also null out .consumer when initializing in case the asset is a source map](https://github.com/assetgraph/assetgraph/commit/a49b4979bfeb888bfa2061c7c87159c3a0e6f0de) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.1.0 (2020-07-09)
+
+- [serializeSourceMaps: Take a query object](https://github.com/assetgraph/assetgraph/commit/3e3ceed25a9debf51fee0c10deb27193cfa60921) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Asset\#init: Flush the cached states when text, rawSrc, or parseTree is given without the others](https://github.com/assetgraph/assetgraph/commit/c0aa8f101142a666db6d334acb5556bca44779fb) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [Relax the qs version range a bit so it can be deduped with the copy pulled in by request and u-messy](https://github.com/assetgraph/assetgraph/commit/ecd2d4931cbfbf11ffe91e23d9bfc34e817be2a0) ([Andreas Lind](mailto:andreas.lind@peakon.com))
+- [Add qs dependency](https://github.com/assetgraph/assetgraph/commit/fdd03265b5d4ba53e1baf61395a33ea46a40eae5) ([Jang Whemoon](mailto:palindrom615@gmail.com))
+
+### v6.0.7 (2020-05-24)
+
+- [#1092](https://github.com/assetgraph/assetgraph/pull/1092) Catch throws from decodeURI ([Peter Müller](mailto:munter@fumle.dk))
+
+### v6.0.6 (2020-05-18)
+
+- [Avoid directories in glob results in loadAssets and addAssets. Fixes \#1081](https://github.com/assetgraph/assetgraph/commit/4b0c40d29411f088c1297d110279880fa6f70054) ([Peter Müller](mailto:munter@fumle.dk))
+
+### v6.0.5 (2020-01-02)
+
+- [reviewCSP: Avoid getAttribute of undefined error on relations that don't have a node](https://github.com/assetgraph/assetgraph/commit/08c7e366b9d4d9612fe01a459e44f87640d120d7) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.0.4 (2019-12-11)
+
+- [#1066](https://github.com/assetgraph/assetgraph/pull/1066) Tech\/backport base href to v6 ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.0.3 (2019-11-28)
+
+- [Avoid serializing the target asset twice when inlining an HtmlRelation with a custom inline\(\) impl](https://github.com/assetgraph/assetgraph/commit/e638de2ee6a2994a234664a3f9d75158e6c79a7c) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.0.2 (2019-11-25)
+
+- [#1064](https://github.com/assetgraph/assetgraph/pull/1064) Backport\/recover from missing xmlns ([Peter Müller](mailto:munter@fumle.dk))
+
+### v6.0.1 (2019-11-05)
+
+- [http: Don't set isRedirect unless the status code is 301...303](https://github.com/assetgraph/assetgraph/commit/8d86e407329d5d99412a87d3558de956effea375) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+
+### v6.0.0 (2019-08-18)
 
 - [#1035](https://github.com/assetgraph/assetgraph/pull/1035) Use jsdom instead of xmldom for XML assets ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#1041](https://github.com/assetgraph/assetgraph/pull/1041) Remove subsetFonts ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
@@ -21,10 +175,11 @@
 
 #### Pull requests
 
+- [#1042](https://github.com/assetgraph/assetgraph/pull/1042) Resolve canonical URL's with no trailing slash as the assetgrap… ([Peter Müller](mailto:munter@fumle.dk))
 - [#988](https://github.com/assetgraph/assetgraph/pull/988) subsetFonts: Allow passing in per-page font traces ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#1002](https://github.com/assetgraph/assetgraph/pull/1002) Avoid preloading the unused variants ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#998](https://github.com/assetgraph/assetgraph/pull/998) subsetFonts: Implement omitFallbacks:true mode ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
-- [#1000](https://github.com/assetgraph/assetgraph/pull/1000)  subsetFonts: Consistently issue root-relative urls instead of relative ones ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [#1000](https://github.com/assetgraph/assetgraph/pull/1000) subsetFonts: Consistently issue root-relative urls instead of relative ones ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#999](https://github.com/assetgraph/assetgraph/pull/999) subsetFonts: Async load the original @font-face declarations for self-hosted fonts ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#1039](https://github.com/assetgraph/assetgraph/pull/1039) Upgrade lodash to version 4.17.15 ([depfu[bot]](mailto:23717796+depfu[bot]@users.noreply.github.com))
 - [#1038](https://github.com/assetgraph/assetgraph/pull/1038) Upgrade eslint-plugin-mocha to version 6.0.0 ([depfu[bot]](mailto:23717796+depfu[bot]@users.noreply.github.com))
@@ -62,6 +217,7 @@
 
 #### Pull requests
 
+- [#1021](https://github.com/assetgraph/assetgraph/pull/1021) Add JavaScriptWorklet relation ([Peter Müller](mailto:munter@fumle.dk))
 - [#1020](https://github.com/assetgraph/assetgraph/pull/1020) Upgrade prettier to version 1.18.2 ([Andreas Lind](mailto:andreaslindpetersen@gmail.com), [depfu[bot]](mailto:depfu[bot]@users.noreply.github.com))
 - [#1019](https://github.com/assetgraph/assetgraph/pull/1019) Upgrade file-loader to version 4.0.0 ([depfu[bot]](mailto:depfu[bot]@users.noreply.github.com))
 - [#1017](https://github.com/assetgraph/assetgraph/pull/1017) Upgrade terser to version 4.0.0 ([depfu[bot]](mailto:depfu[bot]@users.noreply.github.com))
@@ -674,7 +830,7 @@
 - [#762](https://github.com/assetgraph/assetgraph/pull/762) Switch AssetGraph\#\_assets over to a Set instance ([Andreas Lind](mailto:andreas@one.com))
 - [#794](https://github.com/assetgraph/assetgraph/pull/794) Stop using type:'Asset' to mean unknown type in the public API, use undefined instead ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#795](https://github.com/assetgraph/assetgraph/pull/795) Update dependencies ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
-- [#793](https://github.com/assetgraph/assetgraph/pull/793)  Make Asset\#type a getter that offers a guess based on Content-Type, incoming relations, file extension etc. ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
+- [#793](https://github.com/assetgraph/assetgraph/pull/793) Make Asset\#type a getter that offers a guess based on Content-Type, incoming relations, file extension etc. ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#787](https://github.com/assetgraph/assetgraph/pull/787) Model &lt;noscript&gt;...&lt;\/noscript&gt; as an inline Html asset ([Andreas Lind](mailto:andreas.lind@peakon.com))
 - [#785](https://github.com/assetgraph/assetgraph/pull/785) Propagate the fulfillment\/return value of the transform to the returned promise \(or the callback\) ([Andreas Lind](mailto:andreaslindpetersen@gmail.com))
 - [#768](https://github.com/assetgraph/assetgraph/pull/768) Turn Relation\#to into a setter and try to DTRT when it's updated ([Andreas Lind](mailto:andreas@one.com))
@@ -684,7 +840,6 @@
 - [#750](https://github.com/assetgraph/assetgraph/pull/750) es6\/2017-ify transforms ([Andreas Lind](mailto:andreas@one.com))
 - [#751](https://github.com/assetgraph/assetgraph/pull/751) Upgrade webpack to ^3.0.0 and also update the related dev deps ([Andreas Lind](mailto:andreas@one.com))
 - [#741](https://github.com/assetgraph/assetgraph/pull/741) Add transform that uses sw-precache to generate a service worker ([Andreas Lind](mailto:andreas@one.com))
-- [#749](https://github.com/assetgraph/assetgraph/pull/749) Update style-loader to version 0.18.1 🚀 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
 
 #### Commits to master
 
@@ -1016,13 +1171,6 @@
 - [#573](https://github.com/assetgraph/assetgraph/pull/573) Update postcss to version 5.1.0 🚀 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
 - [#568](https://github.com/assetgraph/assetgraph/pull/568) Update eslint to version 3.0.1 🚀 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
 - [#565](https://github.com/assetgraph/assetgraph/pull/565) Remove support for transpiling ([Andreas Lind](mailto:andreas@one.com))
-- [#564](https://github.com/assetgraph/assetgraph/pull/564) Simplify base asset resolution and housekeeping ([Andreas Lind](mailto:andreas@one.com))
-- [#562](https://github.com/assetgraph/assetgraph/pull/562) Web worker support ([Andreas Lind](mailto:andreas@one.com))
-- [#567](https://github.com/assetgraph/assetgraph/pull/567) Update uglify-js to version 2.7.0 🚀 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
-- [#566](https://github.com/assetgraph/assetgraph/pull/566) relations\/JavaScriptFetch implementation ([Peter Müller](mailto:munter@fumle.dk))
-- [#561](https://github.com/assetgraph/assetgraph/pull/561) Update eslint to version 3.0.0 🚀 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
-- [#560](https://github.com/assetgraph/assetgraph/pull/560) teepee@2.23.0 breaks build 🚨 ([greenkeeperio-bot](mailto:support@greenkeeper.io))
-- [#547](https://github.com/assetgraph/assetgraph/pull/547) Rework require.js bundling support ([Andreas Lind](mailto:andreas@one.com))
 
 #### Commits to master
 
@@ -1498,6 +1646,7 @@
 - [+5 more](https://github.com/assetgraph/assetgraph/compare/v1.22.0...v1.23.0)
 
 ### v1.22.0
+
 - [Avoid adding index.html to an href pointing at file:\/\/...\/index.html if it's not already there.](https://github.com/assetgraph/assetgraph/commit/9d7c4fcc9a1e6923f46f0a191edc8b227eda5079) ([Andreas Lind](mailto:andreas@one.com))
 - [Reorganized the populate tests.](https://github.com/assetgraph/assetgraph/commit/984e9ad80e89c18339fb8c7d326b24e1ea810a4c) ([Andreas Lind](mailto:andreas@one.com))
 - [Update .codeclimate.yml](https://github.com/assetgraph/assetgraph/commit/039b7e13ff8979bc989278e405ff47f7fb33a6df) ([Peter Müller](mailto:munter@fumle.dk))
@@ -1568,7 +1717,7 @@
 #### Pull requests
 
 - [#238](https://github.com/assetgraph/assetgraph/pull/238) transforms\/registerRequireJsConfig: Run config detection on already load... ([Peter Müller](mailto:munter@fumle.dk))
-- [#237](https://github.com/assetgraph/assetgraph/pull/237) Support all types of global requirejs configuration  ([Peter Müller](mailto:munter@fumle.dk))
+- [#237](https://github.com/assetgraph/assetgraph/pull/237) Support all types of global requirejs configuration ([Peter Müller](mailto:munter@fumle.dk))
 
 #### Commits to master
 
@@ -1594,6 +1743,7 @@
 - [populate: Don't swallow errors encountered when resolving relations.](https://github.com/assetgraph/assetgraph/commit/2d3a2a367644def7302a633fbaf37787bf57aa8e) ([Peter Müller](mailto:munter@fumle.dk))
 
 ### v1.15.4
+
 - [removeDeadIfsInJavaScript: Try to avoid a hard-to-reproduce issue when the parent of an 'if' AST node has a body that's not an array.](https://github.com/assetgraph/assetgraph/commit/6cb7f59ab59c61ca0672f26389bf24d15cd401a7) ([Andreas Lind](mailto:andreas@one.com))
 - [Remove outdated comment.](https://github.com/assetgraph/assetgraph/commit/8ae07f05388537b86f42b4dc21f875703327dd0b) ([Andreas Lind](mailto:andreas@one.com))
 
@@ -2032,6 +2182,7 @@
 - [Human readable file name output from splitCss transform](https://github.com/assetgraph/assetgraph/commit/c0979a4eecdbd9021f7def3a2f483c51161009a1) ([Peter Müller](mailto:munter@fumle.dk))
 
 ### v1.6.13
+
 - [Release 1.6.13.](https://github.com/assetgraph/assetgraph/commit/081240541e4edbca44377538225b1fa16a396b50) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations: Don't rely on node.matchesSelector, which does not work for documents that don't have an &lt;html&gt; element.](https://github.com/assetgraph/assetgraph/commit/8451327d32a206c67b5326d4eada2e4e4daccbfb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Modified flattenRequireJs test so the Travis output has a better chance of telling me why it fails.](https://github.com/assetgraph/assetgraph/commit/a660a2a82752f386b1f57a54fd38939888917a46) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2040,6 +2191,7 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v1.6.12...v1.6.13)
 
 ### v1.6.12
+
 #### Pull requests
 
 - [#173](https://github.com/assetgraph/assetgraph/pull/173) Bundle discriminator strict ([Peter Müller](mailto:munter@fumle.dk))
@@ -2193,58 +2345,70 @@
 - [Use setImmediate instead of process.nextTick if available. \(cherry-picked from commit 3a92a64094dfb83250b424528edc88f730015136\)](https://github.com/assetgraph/assetgraph/commit/5891959d95c19d823ba723353a1b8e70e91d7b38) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.11
+
 - [Release 1.5.11.](https://github.com/assetgraph/assetgraph/commit/fc1b56228c70b718953300799a3e9c449b232ee0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScript.isEmpty: Don't break if the asset could not be parsed.](https://github.com/assetgraph/assetgraph/commit/25136b15e0a4ecec0dea4163b43141f61df95951) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.10
+
 - [Release 1.5.10.](https://github.com/assetgraph/assetgraph/commit/0098732bb4fe6134425ffbadbb43063774722cd1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [flattenStaticIncludes: Also add &lt;link rel="stylesheet" href=...&gt; tags pointing at .less files to the HTML.](https://github.com/assetgraph/assetgraph/commit/457748b9ba371cb18d5f63d62596cd92186ee775) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Added "tag":"v1.5" so npm publish won't overwrite the "latest" tag.](https://github.com/assetgraph/assetgraph/commit/4fce765606599f20f8d58ac0708fd4b88b68fd38) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.9
+
 - [Release 1.5.9.](https://github.com/assetgraph/assetgraph/commit/8ea9ae7bb3abafa0b56e50e624fced3b0131f6f1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed resolution of root-relative AMD require\/define relations.](https://github.com/assetgraph/assetgraph/commit/96d308a10b7c249a0d4218bc8338c0496457f4bc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Moved the code that resolves a url while taking the root of the assetgraph into account into a helper method.](https://github.com/assetgraph/assetgraph/commit/53d3d6c1b6dcf9528b4f3c6abb4720be0c9dd84c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.8
+
 - [Release 1.5.8.](https://github.com/assetgraph/assetgraph/commit/2c1f89c7ab8f86463ff2f4c9b0e7189cfc8963d6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [inlineKnockoutJsTemplates: Only inline relations pointing at Html with a .ko ending.](https://github.com/assetgraph/assetgraph/commit/1ab7ebea067492b4570f4075987b915042ffa89a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [inline\(Knockout|Angular\)JsTemplates: Don't attempt to inline relations pointing at unloaded Html assets.](https://github.com/assetgraph/assetgraph/commit/f2a44766fc30bfcf69cb13afea1ac0c91abd3fa8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.7
+
 - [Release 1.5.7.](https://github.com/assetgraph/assetgraph/commit/115b03a7819397c7d9361d34d57228252b4313a2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Avoid calling require\('url'\).resolve\(undefined, ...\). It breaks in node.js &gt;= 0.10.](https://github.com/assetgraph/assetgraph/commit/35622a1edf313fe65ebe8791ff7449ddf1754ba1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.6
+
 - [Release 1.5.6.](https://github.com/assetgraph/assetgraph/commit/a7283b6c028e349903c0d7c3ddb08b7de09d2615) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [convertHtmlStylesToInlineCssImports: Preserve the hrefType of the original relation.](https://github.com/assetgraph/assetgraph/commit/b11ac0dcce12c309c6d4f5c96d02d6f691bd38ef) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [convertCssImportsToHtmlStyles: Preserve the hrefType of the original relations.](https://github.com/assetgraph/assetgraph/commit/bac64f3d193fd8c3c72eed44f030f2961f58d59d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [inlineCssImagesWithLegacyFallback: Poiint at the IE-specific stylesheet with the same hrefType as the original relation.](https://github.com/assetgraph/assetgraph/commit/c79cf8ae2e4f2f2c0b6ad26c267242b25b0214a4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.5
+
 - [Release 1.5.5.](https://github.com/assetgraph/assetgraph/commit/ab9f65228f761d16dc35044c7dbbae85e7db8b38) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations: Point at the bundled asset with a root-relative href if at least one of the bundled relations have a non-relative hrefType.](https://github.com/assetgraph/assetgraph/commit/3d0b15da7082d0a856305f748f8e1a682d90f886) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model inline event handlers as relations.](https://github.com/assetgraph/assetgraph/commit/91484256f15220e8acb72068805b14c31ec3a7da) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.4
+
 - [Release 1.5.4.](https://github.com/assetgraph/assetgraph/commit/696d08fe9598a5177961fc21cad455459b5d6894) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [registerRequireJsConfig: Fixed some glitches in the url resolution code.](https://github.com/assetgraph/assetgraph/commit/cc41591cff4f049e737b8887720a0c86bb951daa) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.3
+
 - [Release 1.5.3.](https://github.com/assetgraph/assetgraph/commit/a5546fdf1f0542fd265782ad58e3a711b8f155b3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [registerRequireJsConfig: Added support for an option that sets the 'keepUnpopulated' property on all JavaScript assets if the require.js config hasn't been found yet. Hack, hack.](https://github.com/assetgraph/assetgraph/commit/aa6c861d8235b2e8c60e22330c5f537e27eee8b0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [populate transform: Honor the 'keepUnpopulated' property when looking for outgoing relations.](https://github.com/assetgraph/assetgraph/commit/11a599bcda5c9638c00e44930fda462e3f0579dc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.2
+
 - [Release 1.5.2.](https://github.com/assetgraph/assetgraph/commit/17aafc0df0f63f0d5f107f99af070618e4df9e01) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [StaticUrlMap: Don't break if there are wild card values, but the wildcards only match a single file.](https://github.com/assetgraph/assetgraph/commit/c9cdc686d6736fca18fb06c025455e8796307f8a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [StaticUrlMap.findOutgoingRelationsInParseTree: Support GETSTATICURL\({...}.Foo\) as well as GETSTATICURL\({...}\['Foo'\]\).](https://github.com/assetgraph/assetgraph/commit/029e7ff6cfcf77a7decb8e9ca63a98342f40e350) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.1
+
 - [Release 1.5.1.](https://github.com/assetgraph/assetgraph/commit/d9dc33971ab748babe7a97f9b3f9b9599804fb5d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [populate transform: Replace one usage of the seq library with async to prevent process.nextTick overflow in node.js 0.10.](https://github.com/assetgraph/assetgraph/commit/4896397e28dfab6abb4daf30a1a5e32721ddf7dc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.5.0
+
 - [Release 1.5.0.](https://github.com/assetgraph/assetgraph/commit/206e1e2e848c22fa21e2d2a3803129831b6db580) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [urlTools.makeFileUrlMatcher: Don't break when called with non-string arguments.](https://github.com/assetgraph/assetgraph/commit/3d2c1081b67d12fd12a2049de29ce2c5eab0a2be) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update iconv to 2.0.3.](https://github.com/assetgraph/assetgraph/commit/2b4bbec751e9d55fb6db34922870c5149f1ca6e9) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2253,6 +2417,7 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v1.4.2...v1.5.0)
 
 ### v1.4.2
+
 - [Release 1.4.2.](https://github.com/assetgraph/assetgraph/commit/e7d71c399d5a7e61663892ba8ca0ad20784bca30) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Unbreak JavaScriptAmd\(Require|Define\) for hrefs with extensions.](https://github.com/assetgraph/assetgraph/commit/bc264ecb0c69c3e8a6f3cdd0ef9361bbabb79fa6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [registerRequireJsConfig: Fixed resolution of paths with more than one fragment.](https://github.com/assetgraph/assetgraph/commit/c7fadcd7014ec80c25bc7df312e5f173d0282403) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2261,10 +2426,12 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v1.4.1...v1.4.2)
 
 ### v1.4.1
+
 - [Release 1.4.1.](https://github.com/assetgraph/assetgraph/commit/7e168901fb715c8688e3d61a4bf763b49262be02) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRequireJs transform: Don't throw away the dependencies when detecting an UMD stub.](https://github.com/assetgraph/assetgraph/commit/136d4cb99a2089c39bf8875a9eaeba1ae7fe31e5) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.4.0
+
 - [Release 1.4.0.](https://github.com/assetgraph/assetgraph/commit/b734378a0f718ac7a38acd9d7bc34f0d6481f38a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRequireJs transform: Skip assets that haven't been loaded.](https://github.com/assetgraph/assetgraph/commit/356ca6838ce8b12af3f2c156a5bee54a4ce1dae1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update jsdom-papandreou to 0.5.1-patch1.](https://github.com/assetgraph/assetgraph/commit/6aa095409a9bdecfb525efd5def08d51a7b0d513) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2272,6 +2439,7 @@
 - [Model cursor: url\(...\) as a CssImage relation. Fixes \#96.](https://github.com/assetgraph/assetgraph/commit/391e345d9363eb98b96ca292c043d5dbcbfc40ed) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.12
+
 #### Pull requests
 
 - [#100](https://github.com/assetgraph/assetgraph/pull/100) Relation.resolve for unknown protocols ([Peter Müller](mailto:munter@fumle.dk))
@@ -2281,10 +2449,12 @@
 - [Release 1.3.12.](https://github.com/assetgraph/assetgraph/commit/dcefb66965720188b925ad7f816cbe7ebac775b9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.11
+
 - [Release 1.3.11.](https://github.com/assetgraph/assetgraph/commit/a005270107838909a41722370edea0ff74a8c304) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations: Make sure that all @import rules go at the top of the bundled asset.](https://github.com/assetgraph/assetgraph/commit/41a016f710f7a35dbbfdca6012eb01720e658307) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.10
+
 #### Pull requests
 
 - [#98](https://github.com/assetgraph/assetgraph/pull/98) data-main-attribute now accepts '.js' file endings. Relates to \#97 ([Peter Müller](mailto:munter@fumle.dk))
@@ -2298,39 +2468,47 @@
 - [http resolver: Wait a configurable amount of time before retrying a request that failed due to a socket hangup or timeout \(defaults to 250 ms\).](https://github.com/assetgraph/assetgraph/commit/e5afe20dacb006083e26740cd4e1f1418f1e811e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.9
+
 - [Release 1.3.9.](https://github.com/assetgraph/assetgraph/commit/72b446882455ff31787471a7b8167b10e7c0384f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScript, text getter: Always add a semicolon at the end like the UglifyJS binary does.](https://github.com/assetgraph/assetgraph/commit/e73a3b644f10e38d1793b01ab4dc56f39e648fb5) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.8
+
 - [Release 1.3.8.](https://github.com/assetgraph/assetgraph/commit/7e51e07cb11f59514a17df0f678c2bf94d4a9c0b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [compressJavaScript: Compress assets bigger than ~2KB in an external process and run one concurrent job per CPU.](https://github.com/assetgraph/assetgraph/commit/539f6d28a7556235b600841d27aee3774714a467) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Name the convertHtmlRequireJsMainToHtmlScript transform.](https://github.com/assetgraph/assetgraph/commit/d72ee2445881938c03b5615c3b3fa757e742c418) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.7
+
 - [Release 1.3.7.](https://github.com/assetgraph/assetgraph/commit/e2b2e2e04942f83ce93bd3fb144b81070570cfa3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Implemented I18n.prettyPrint \(canonicalizes the first two levels\).](https://github.com/assetgraph/assetgraph/commit/bdb55ae83d1f0d882001a51f957ce2e983cc7a0b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.6
+
 - [Release 1.3.6.](https://github.com/assetgraph/assetgraph/commit/fde60e074537a4cc67e0a47584bd15361e331348) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added transform that converts &lt;script data-main=...&gt; to &lt;script src=...&gt; to avoid depending on require.js in production.](https://github.com/assetgraph/assetgraph/commit/8939f1a2086fa626553ac25ef92c19c64c4d9f64) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model &lt;!--esi ... --&gt; as an inline HTML asset. Fixes \#93.](https://github.com/assetgraph/assetgraph/commit/c336978aec9cba941f83139ece739c866556d1e2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.5
+
 - [Release 1.3.5.](https://github.com/assetgraph/assetgraph/commit/d4c579677e86321d3412c72f20b44e2c36e5d17e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [compressJavaScript transform: Preserve the copyright notice comments of the original asset.](https://github.com/assetgraph/assetgraph/commit/49a83cdb5adfdef1f88eb01c87b065b54710d43b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Updated the GETSTATICURL implementation in a test to support {...} wildcards.](https://github.com/assetgraph/assetgraph/commit/bc24d49fc427e329cf45fc575ff276391a53f48c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.4
+
 - [Release 1.3.4.](https://github.com/assetgraph/assetgraph/commit/e6fc492e2b9c66b6bd496843f1c23b8802692e43) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph.recomputeBaseAssets: Don't throw an error if a base asset cannot be recomputed \(see d96e21e3\).](https://github.com/assetgraph/assetgraph/commit/4df6fc083e02042959997646ffefea02b71a6644) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations, sharedBundles strategy: Fixed error with duplicate HtmlScript\/HtmlStyle references.](https://github.com/assetgraph/assetgraph/commit/42bc2b60ea0ba8007c0e5cab8c7133d0dd109704) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.3
+
 - [Release 1.3.3.](https://github.com/assetgraph/assetgraph/commit/f62881e8d1258c0a9f11780389a925b4b5e90ff1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRequireJs: Added ugly hack to make sure that the parentNode property of top-level INCLUDEs end up pointing at the bundle asset's top level statements array.](https://github.com/assetgraph/assetgraph/commit/ba7cd24c68f293c1cdca3d0d626d5322806e8d81) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations, sharedBundles: Fixed off-by-one error.](https://github.com/assetgraph/assetgraph/commit/3487b9a88ecb237517ae7cf7b06dd35a32a2c47c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.2
+
 - [Release 1.3.2.](https://github.com/assetgraph/assetgraph/commit/9727fff971f53b92629234764346962b34c5563f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update uglifyast to 0.1.0.](https://github.com/assetgraph/assetgraph/commit/03cfe0b75d1c389f9a140623aafe7c5ec577ba3b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [ImageSrcSet: Removed redundant requires.](https://github.com/assetgraph/assetgraph/commit/6e4af952fb7a9ae587d44ad4bbf4805433de94fd) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2338,6 +2516,7 @@
 - [Revert "Html.findOutgoingRelationsInParseTree: Also recognize &lt;script type='text\/template'&gt; as an HtmlInlineScriptTemplate relation. See assetgraph-builder\#44."](https://github.com/assetgraph/assetgraph/commit/fa2e70d4e7358ee6faa665e364013178d65d9cd8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.3.1
+
 - [Release 1.3.1.](https://github.com/assetgraph/assetgraph/commit/eb021e1b27d4ac0daef524505f82ba5e5aac3f70) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations, sharedBundles: Don't process relations that have been detached.](https://github.com/assetgraph/assetgraph/commit/b3c29e4be30c97f282d686978904ad809f302f75) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations: Share the code for generating the discriminator between the two strategies.](https://github.com/assetgraph/assetgraph/commit/773d2e59eb5110b88d3747d682b19299411c0ada) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2346,6 +2525,7 @@
 - [+8 more](https://github.com/assetgraph/assetgraph/compare/v1.3.0...v1.3.1)
 
 ### v1.3.0
+
 - [Release 1.3.0.](https://github.com/assetgraph/assetgraph/commit/6699c4afb2ebdd165f700d6e85a189f2b2eacaa8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [HtmlInlineScriptTemplate: Set this.node.textContent when inlining, but retrieve innerHTML when populating the relation. Seems to work, although I'm not completely happy.](https://github.com/assetgraph/assetgraph/commit/c188352922e2b0b64d6762414a17b8611bdd5c27) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed the inlineKnockoutJsTemplates test.](https://github.com/assetgraph/assetgraph/commit/cc143615abec4a27e4971d8766709834f8cef51d) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2354,6 +2534,7 @@
 - [+8 more](https://github.com/assetgraph/assetgraph/compare/v1.2.5...v1.3.0)
 
 ### v1.2.5
+
 - [Release 1.2.5.](https://github.com/assetgraph/assetgraph/commit/2135da6591859161870e2126c6f0a0b398cb29e6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Experimental implementation of a transform that inlines Knockout.js templates.](https://github.com/assetgraph/assetgraph/commit/83df0c3d61a52d00da2c718fbcbdc9bd47552e4d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Css: Model url\(...\) tokens in mask image properties as relations.](https://github.com/assetgraph/assetgraph/commit/be6f7023b5eeea7c4bb38b5d8ddacfaf3ef1e05e) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2362,23 +2543,27 @@
 - [+3 more](https://github.com/assetgraph/assetgraph/compare/v1.2.4...v1.2.5)
 
 ### v1.2.4
+
 - [Release 1.2.4.](https://github.com/assetgraph/assetgraph/commit/16aac2ad6278cdf578efda766c6a9e2f77a98185) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Html.minify: Preserve whitespace after comment nodes that are preserved.](https://github.com/assetgraph/assetgraph/commit/605c372fb6541491ce654df0fc678472f241093b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Remove lib\/util\/memoizeAsyncAccessor.js \(not used and superseeded by node-memoizeasync\).](https://github.com/assetgraph/assetgraph/commit/459aca590b4f6f11e5fbc30e1dc3a467465e2a91) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.2.3
+
 - [Release 1.2.3.](https://github.com/assetgraph/assetgraph/commit/56d91b2abe452775241edbc31828803271d5814b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Revert "Added 'removeAngularJsTemplatesThatHaveBeenInlined' transform. Hopefully it's temporary."](https://github.com/assetgraph/assetgraph/commit/9e6ef35b1a948557a4bdf292daac4e9b56d6b6f7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [inlineAngularJsTemplate: Remove the existing JavaScriptAngularJsTemplate relations. Prevents the templates from getting cloned.](https://github.com/assetgraph/assetgraph/commit/a658b0c5d635cf272980c8fc1f1f3b53a15ff934) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Implemented JavaScriptAngularJsTemplateCacheAssignment.inline.](https://github.com/assetgraph/assetgraph/commit/b36a140c881efc4b3a8925271129b880ced6bb25) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.2.2
+
 - [Release 1.2.2.](https://github.com/assetgraph/assetgraph/commit/07a70fae3dec393e0d7ea7039bdaa89167fcc61f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.populate, when an asset cannot be loaded: Degrade from an error to a warning.](https://github.com/assetgraph/assetgraph/commit/95a78099d2402f728c2ee389a7ec1a0de821dfd3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added 'removeAngularJsTemplatesThatHaveBeenInlined' transform. Hopefully it's temporary.](https://github.com/assetgraph/assetgraph/commit/71cdf9a2acb7162870c5e27626cc67e2fc679b3d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.writeStatsToStderr: Only attempt to gather stats for loaded assets.](https://github.com/assetgraph/assetgraph/commit/5a1dc1eaf695b1a2a6fa01c7f3f61841c3e30e14) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.2.1
+
 - [Release 1.2.1.](https://github.com/assetgraph/assetgraph/commit/d4a9ed414d0fa4ddb5bd0125c0a12d846eb9520d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed JavaScriptAngularJsTemplateCacheAssignment.detach.](https://github.com/assetgraph/assetgraph/commit/f2b79c3d5f3c86d740c0dfaac2b4ed9c917a77e1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Implemented JavaScriptAngularJsTemplate.inline.](https://github.com/assetgraph/assetgraph/commit/1db57cbf3873113f365a817771bb3d8c4a41631f) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2386,47 +2571,57 @@
 - [Major API cleanup.](https://github.com/assetgraph/assetgraph/commit/6c23f7509f2f32d8e147b0c540bbc0a552f828a4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.2.0
+
 - [Release 1.2.0.](https://github.com/assetgraph/assetgraph/commit/22de0302a38166ca12fa7934d92fc626a6b714b7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [inlineCssImagesWithLegacyFallback: Support ?inline=false](https://github.com/assetgraph/assetgraph/commit/38781f8a0ec4a55718ca60a444d9dc9ee7532764) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.inlineCssImagesWithLegacyFallback: Replaced -ag-inline-image with a GET parameter called 'inline'.](https://github.com/assetgraph/assetgraph/commit/3b768067d9cba71b209801ee617499fb75f8777c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Converted README to markdown.](https://github.com/assetgraph/assetgraph/commit/86e5e4e9db7b31b784e03d572581fc5b96cbce76) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.7
+
 - [Release 1.1.7.](https://github.com/assetgraph/assetgraph/commit/47ae0fa6bc5515037f1d62096efa5edc1c846841) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [http resolver: Wait a configurable amount of time before retrying a request that failed due to a socket hangup or timeout \(defaults to 250 ms\).](https://github.com/assetgraph/assetgraph/commit/bac88576487c4a392c024758f47ed3fdeb452f9d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.6
+
 - [Release 1.1.6.](https://github.com/assetgraph/assetgraph/commit/cfa376e9056767e26ff1b39f232b6e02d54bfbfb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations, sharedBundles strategy: Fixed error with duplicate HtmlScript\/HtmlStyle references.](https://github.com/assetgraph/assetgraph/commit/20f001d606e9e54d0909c25d66b42deef6cce6a4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRequireJs: Added ugly hack to make sure that the parentNode property of top-level INCLUDEs end up pointing at the bundle asset's top level statements array.](https://github.com/assetgraph/assetgraph/commit/1af612d27e1ad396f68e83465030cc41ba933276) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.5
+
 - [Release 1.1.5.](https://github.com/assetgraph/assetgraph/commit/19d40b3db45ab72ba489b273b41c8ebc6947b293) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations, sharedBundles: Fixed off-by-one error.](https://github.com/assetgraph/assetgraph/commit/9d7400ee8ad8d1c50db913f962e418be09f084a6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.4
+
 - [Release 1.1.4.](https://github.com/assetgraph/assetgraph/commit/f16f09a16999516d2d59d092a598eee3c3a9d79f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relation.refreshHref: Don't break for root-relative urls when the relation isn't part of an AssetGraph instance.](https://github.com/assetgraph/assetgraph/commit/9fac875814681fe258a024634e3420b342bcace8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Specify "tag": "v1.1" so new versions published from the v1.1 branch don't get the 'latest' tag.](https://github.com/assetgraph/assetgraph/commit/40e2e786a78077604243484e63a9a119402e4aa0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.3
+
 - [Release 1.1.3.](https://github.com/assetgraph/assetgraph/commit/7e9cc0cc37e8e4860327d3063b4daa83e0eb21a2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations, sharedBundles: Don't process relations that have been detached.](https://github.com/assetgraph/assetgraph/commit/80593c06b0126ec9204b3414d50819cd34243810) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bundleRelations: Share the code for generating the discriminator between the two strategies.](https://github.com/assetgraph/assetgraph/commit/c2a082837b611f182dc87b402be45a2f9f42cdb6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.2
+
 - [Release 1.1.2.](https://github.com/assetgraph/assetgraph/commit/1d5836c158a8eeb79f47309d75e19ddb7d847afc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fully implemented CssUrlTokenRelation.detach\(\).](https://github.com/assetgraph/assetgraph/commit/1b9ce3485810023049c00b166200a1692b4c0611) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.1
+
 - [Release 1.1.1.](https://github.com/assetgraph/assetgraph/commit/e0b193d51173f3e4fd068732aaa3e79032916a6f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.StaticUrlMapEntry: Also escape ? when building a regexp out of the url.](https://github.com/assetgraph/assetgraph/commit/fc9304833d3c705e802622f7d57f75c35d89a844) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [file resolver: Don't remove the query string and fragment identifier when expanding wildcards.](https://github.com/assetgraph/assetgraph/commit/979363796be2f6f3bac62ffe4b4bd474a4e1ab2f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.1.0
+
 - [Release 1.1.0.](https://github.com/assetgraph/assetgraph/commit/a5bb1517de965020e1673b659932341eb138ab1b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.28
+
 - [Release 1.0.28.](https://github.com/assetgraph/assetgraph/commit/6dd5536434b64f84ab66ee4fd1659e5d243ca87a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update iconv to 2.0.6.](https://github.com/assetgraph/assetgraph/commit/b1b3208273ece517eba00f6a2af76b79a4b7442c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update vows to 0.7.0.](https://github.com/assetgraph/assetgraph/commit/c8d975d0a6e4541c0f08e85c24ce9aa2eb6250e5) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2435,14 +2630,17 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v1.0.27...v1.0.28)
 
 ### v1.0.27
+
 - [Release 1.0.27.](https://github.com/assetgraph/assetgraph/commit/c0d41deb90873e54a09ab6e9224881285d87b1a4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [flattenStaticIncludes: If there's an existing include of an asset, only preserve it if it comes before the insertion point.](https://github.com/assetgraph/assetgraph/commit/a2a8a38dc8f7d24c13e4cdb30c958cf5da1cacec) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.26
+
 - [Release 1.0.26.](https://github.com/assetgraph/assetgraph/commit/d0390e917d64e01413f48a9c13b5276cb2c19c53) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.flattenStaticIncludes: Don't add duplicate HtmlScript\/HtmlStyle relations.](https://github.com/assetgraph/assetgraph/commit/0381bf50f54a6f203deddc687a507e57a7f4c8fe) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.25
+
 - [Release 1.0.25.](https://github.com/assetgraph/assetgraph/commit/c79a08cabfdaba10f4605a9c4a9e1c21e40125bf) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [inlineCssImagesWithLegacyFallback: Fixed bug with multiple Html assets pointing at the same stylesheet \(introduced in d7bb02b\).](https://github.com/assetgraph/assetgraph/commit/0a2a35e240fdb319604051de9139976827ef30ad) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [file resolver: Don't throw an error if a wildcard expands to nothing. It's inconvenient in loadAssets and doesn't really help in any situation.](https://github.com/assetgraph/assetgraph/commit/51dcb150034fe4d890abe8898b40cf9ad6d7d916) ([Peter Müller](mailto:munter@fumle.dk))
@@ -2451,6 +2649,7 @@
 - [+3 more](https://github.com/assetgraph/assetgraph/compare/v1.0.24...v1.0.25)
 
 ### v1.0.24
+
 - [Release 1.0.24.](https://github.com/assetgraph/assetgraph/commit/e5c027215c90bc1d2b22b5c5d411cb4b5deaaed6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Html: Added support for data-bind="{...}". Fixes \#85.](https://github.com/assetgraph/assetgraph/commit/9ccfb94866eec7ba300d5bbf639e2bac394f8b4a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Remove accidentally committed debug code.](https://github.com/assetgraph/assetgraph/commit/cb1fddd48f04d8dcaaa2ade265c0b124eb629aa4) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2459,36 +2658,43 @@
 - [+5 more](https://github.com/assetgraph/assetgraph/compare/v1.0.23...v1.0.24)
 
 ### v1.0.23
+
 - [Release 1.0.23.](https://github.com/assetgraph/assetgraph/commit/ddc48b769a2a12a5fce469e7770207cd98d76bf9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScript.findOutgoingRelationsInParseTree: Prevent bogus warnings when skipping already defined modules.](https://github.com/assetgraph/assetgraph/commit/4f735a707e988f8e4c9e1659cf91028160dbc369) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset.populate: Instantiate the assets pointed to by data: urls.](https://github.com/assetgraph/assetgraph/commit/9447dc24936388f8e225607aea42741b30302de8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Moved the data url parsing code into its own module.](https://github.com/assetgraph/assetgraph/commit/5465e555c40c637aea62958347686bbacfe4db2a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.22
+
 - [Release 1.0.22.](https://github.com/assetgraph/assetgraph/commit/2ca1f49ab59a80929c1b56db41346102221b28e7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.JavaScriptTrHtml: Added missing baseAssetQuery.](https://github.com/assetgraph/assetgraph/commit/5b715f8ef7fdb3f26a427e5544141c06887a6ca7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.21
+
 - [Release 1.0.21.](https://github.com/assetgraph/assetgraph/commit/ab111623b05a1df5af2fb257dc6da1fb297c9aa9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScript.findOutgoingRelationsInParseTree: Skip define\/requires referring to named defines occurring in the same file.](https://github.com/assetgraph/assetgraph/commit/6293f4fbd6157a8e0bae58ec6df3c0c98260bacc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Css: Also recognize border-image-source as a relation.](https://github.com/assetgraph/assetgraph/commit/589833a603328c7eed3695ba81c09d760905cf53) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.20
+
 - [Release 1.0.20.](https://github.com/assetgraph/assetgraph/commit/a61f36c4de66a3e84c5eed054a9c46a6051cd9ab) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [http resolver: Also retry when the server sends back a 5xx error.](https://github.com/assetgraph/assetgraph/commit/2116ba210df6d23b468603bc9b38e881a680befb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.19
+
 - [Release 1.0.19.](https://github.com/assetgraph/assetgraph/commit/93f55a53605c14a8f277a97a8f2370fd0609a100) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model &lt;img srcset=...&gt; as relations and assets. Fixes \#83.](https://github.com/assetgraph/assetgraph/commit/08fa49b2c86f105c7cd36415bf6638fefb0e55c6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Relation.baseAsset: Fixed error message.](https://github.com/assetgraph/assetgraph/commit/7a7632233262859c8af23730860ce3202faf99bc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.HtmlIFrameSrcDoc: Fixed typos in error messages.](https://github.com/assetgraph/assetgraph/commit/9c48507b569576be1eebe9788d58b21990973a45) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.18
+
 - [Release 1.0.18.](https://github.com/assetgraph/assetgraph/commit/22536fd53476cb75b7ab437546d89e2d3afcfa86) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Html.minify: Preserve whitespace after an empty tag in non-block level context.](https://github.com/assetgraph/assetgraph/commit/c220561d29d98afee07a87a94994adde6a9deea4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Remove un-used Travis-CI-image in the README.](https://github.com/assetgraph/assetgraph/commit/47cfa4a33096aa28907fd348c7c03515da3cc120) ([Morten Siebuhr](mailto:msi@one.com))
 
 ### v1.0.17
+
 #### Pull requests
 
 - [#80](https://github.com/assetgraph/assetgraph/pull/80) Warn instead of error on unknown url scheme ([Peter Müller](mailto:munter@fumle.dk))
@@ -2503,21 +2709,25 @@
 - [+5 more](https://github.com/assetgraph/assetgraph/compare/v1.0.16...v1.0.17)
 
 ### v1.0.16
+
 - [Release 1.0.16.](https://github.com/assetgraph/assetgraph/commit/fad656163b83240ed4c7aa59addac73618ea388c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [resolvers.http: Fixed parsing of charset=... in the Content-Type header.](https://github.com/assetgraph/assetgraph/commit/0f47d8048c0f2b3d9e4055ba0a7c81dded8cd37d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.15
+
 - [Release 1.0.15.](https://github.com/assetgraph/assetgraph/commit/296ddbd87f5bef1a418585f74805e87c62818627) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScriptTrHtml: Support TRHTML\(GETTEXT\(...\)\), support the 'omitFunctionCall' property, allow externalization, added test.](https://github.com/assetgraph/assetgraph/commit/a89e959671df27884d91219246247b54b28e67a3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScriptGetText: Fixed href getter\/setter when target asset is inline, added test.](https://github.com/assetgraph/assetgraph/commit/8991f41857051d6bbc6e4241b542ff68b476db4f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.JavaScript: Don't require TRHTML to be called with a string as its first argument. Opens the door to TRHTML\(GETTEXT\(&lt;fileName&gt;\)\) as long as the GETTEXT is inlined before the TRHTML is processed.](https://github.com/assetgraph/assetgraph/commit/3e9489a8c462b4428386fdd46782036279458bfa) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.14
+
 - [Release 1.0.14.](https://github.com/assetgraph/assetgraph/commit/fc6f25bd18d2e0126b2782dabe0605a04d8fd67b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model TRHTML\("..."\) as a relation.](https://github.com/assetgraph/assetgraph/commit/b59d368bab06d6804574f056914c4e2756191eac) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleRequireJs: Removed no longer required 2nd parameter to the getModuleName function.](https://github.com/assetgraph/assetgraph/commit/7cef3dd65447c4abe9e76b60715cc43337a83b2f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.13
+
 #### Pull requests
 
 - [#72](https://github.com/assetgraph/assetgraph/pull/72) The repo your repo could be like! ([travis4all](mailto:travis4all@diamon.dz))
@@ -2531,21 +2741,25 @@
 - [Updated the recommended less version.](https://github.com/assetgraph/assetgraph/commit/4bd7c8fb9158d33a506825220b19d2b93d14a523) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.12
+
 - [Release 1.0.12.](https://github.com/assetgraph/assetgraph/commit/cafe0a5477faba1333f3c94ad033acbd4d5ec985) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Update less to 1.3.0.](https://github.com/assetgraph/assetgraph/commit/1f030e02f71fcf0b235272a22f676a9543e9a6d6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleRequireJs: Detach JavaScriptAmd\(Define|Require\) relations to non-AMD modules, as determined by whether the module contains a plausible define statement. This removes the module from the require\/define array so require.js won't try to load it at runtime. Fixes \#77.](https://github.com/assetgraph/assetgraph/commit/d12365535030c28f855109523486868f3d02a787) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.11
+
 - [Release 1.0.11.](https://github.com/assetgraph/assetgraph/commit/58863f938ff7657185d4cce4cc2cdade406bc568) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Html.\_reformatParseTree: Don't remove whitespace right before and after &lt;span data-i18n='...'&gt; and preserve one leading\/trailing space in text nodes below a tag with a data-i18n attribute.](https://github.com/assetgraph/assetgraph/commit/0061013268d1ae347a329947c42b0bf477fcef0a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.10
+
 - [Release 1.0.10.](https://github.com/assetgraph/assetgraph/commit/3f64902dae37fe6ba5fe8832ad46b6254c8bfc9b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [CacheManifestEntry: Fixed href setter with freshly attached entries.](https://github.com/assetgraph/assetgraph/commit/905d128923d163a42ac3da2d6cd610c6af4e15f4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.addCacheManifest: Strip the query string, fragment identifier, and the .html extension when generating the url of the cache manifest from the html url.](https://github.com/assetgraph/assetgraph/commit/30bfffa2febf1e25ac3cabab870421218a10d4b3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.addCacheManifest: Renamed the returned function to 'addCacheManifest'.](https://github.com/assetgraph/assetgraph/commit/457c52b1715ee985b59145539569e3dc17ca8cab) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.9
+
 - [Release 1.0.9.](https://github.com/assetgraph/assetgraph/commit/7f346f61270433c7e9aacc5e6a48a24d2ccf28e0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added urlTools.findCommonUrlPrefix.](https://github.com/assetgraph/assetgraph/commit/2b015bba0d7678b465beef98b06fc65060e5bdb8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.resolveConfig: Don't call encodeURI if assetConfig is a string that includes a protocol.](https://github.com/assetgraph/assetgraph/commit/cdb23a7749d75c1bf5b453ab9f51908855ad2799) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2554,10 +2768,12 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v1.0.8...v1.0.9)
 
 ### v1.0.8
+
 - [Release 1.0.8.](https://github.com/assetgraph/assetgraph/commit/f38525790e8e1bc4a8dff8fe0f9262fd08894379) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Html.minify: Don't touch non-breaking space.](https://github.com/assetgraph/assetgraph/commit/e01ad8565f349d26f491b3303b70a5a15d427cbb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.7
+
 - [Release 1.0.7.](https://github.com/assetgraph/assetgraph/commit/3d9eeb763bf8fc096e4a65cac0c2628248c5c424) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Html.minify: More aggressive removal of whitespace.](https://github.com/assetgraph/assetgraph/commit/fb4c72d440ad04ec1fb0d0a889fcfcbc5f6731da) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added cloneAsset\/require.js test.](https://github.com/assetgraph/assetgraph/commit/3f5a232fa36d8eae826639a611383fc778cfb6be) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2566,6 +2782,7 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v1.0.6...v1.0.7)
 
 ### v1.0.6
+
 - [Release 1.0.6.](https://github.com/assetgraph/assetgraph/commit/b08a6198449ebd4b00434999d0495708f957661c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleRequireJs: Don't break in certain scenarios where multiple Html assets depend on the same module chains.](https://github.com/assetgraph/assetgraph/commit/f59114a3ac1192b92334552c3a824116632a0515) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset.clone: Added hack to make sure that the relations resolve correctly, even without attaching an incoming relation.](https://github.com/assetgraph/assetgraph/commit/1adf5963880bb453d7cb6666fd3ae5ad71e77402) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2573,30 +2790,36 @@
 - [Added failing transforms.bundleRequireJs test.](https://github.com/assetgraph/assetgraph/commit/051c222cff57f4953356bae9fca148008a8f9ac8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.5
+
 - [Release 1.0.5.](https://github.com/assetgraph/assetgraph/commit/d31f4df3429fb159f0fd91392339be46abc774a9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScript.clone & transforms.compressJavaScript: Preserve 'quoteChar' and 'initialComments' attributes.](https://github.com/assetgraph/assetgraph/commit/a114bc478698f86977d9b727ec7187431d04aab1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.4
+
 - [Release 1.0.4.](https://github.com/assetgraph/assetgraph/commit/8f6265b0d97d2a5b219b7d90278d0240006b3bf1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model &lt;script type='text\/html'&gt; templates as relations and assets.](https://github.com/assetgraph/assetgraph/commit/db7612553a3d8c69f8eb74418006f7dbd835c79e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update jsdom-papandreou to 0.2.14-patch3.](https://github.com/assetgraph/assetgraph/commit/a7a979a6557c76a3690d7f02561dcb4fff0c0cf0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.3
+
 - [Release 1.0.3.](https://github.com/assetgraph/assetgraph/commit/c707b9b88f5b244648a31f76a18a54939ab1c8f3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Treat extensions as case insensitive when looking them up in assets.typeByExtension.](https://github.com/assetgraph/assetgraph/commit/76a659f43b197df98f1874011c4e7d118ec2f627) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.\*: Made asset.defaultExtension a getter and replaced alternativeExtensions with supportedExtensions \(an array where the default extension is the first element\).](https://github.com/assetgraph/assetgraph/commit/d03104713b7e971daeb375e67ceea275f62cee5c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.2
+
 - [Release 1.0.2.](https://github.com/assetgraph/assetgraph/commit/3a12fb2a6222d46e546d6003c609331f2c986dac) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Simplified transforms.moveAssets and transforms.moveAssetsInOrder and made the behavior more sane when the target url is relative\/root-relative or protocol-relative.](https://github.com/assetgraph/assetgraph/commit/a1029e255164fbcacfb4cc3ed695a4749d5577dd) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset.url setter: DTRT if set to a protocol-relative, root-relative, or relative url. Fixes \#75.](https://github.com/assetgraph/assetgraph/commit/7ebb4883bd94f64571804f974ddd11775ed0a90d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Relation.baseAsset getter: More friendly error message if the base asset cannot be found.](https://github.com/assetgraph/assetgraph/commit/8c26797775dd0517d620035ff290a8f85a44496f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.1
+
 - [Release 1.0.1.](https://github.com/assetgraph/assetgraph/commit/c5f19cc1d3b504f7a9cf9de4acbf3287725b6230) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html & assets.JavaScript: Emit 'warn' on the assetGraph instance instead of logging to the console. Added asset.urlOrDescription getter for convenience.](https://github.com/assetgraph/assetgraph/commit/60210ce0e5e823e6a45dd8f948c145ef430817ce) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v1.0.0
+
 - [Release 1.0.0. Yup!](https://github.com/assetgraph/assetgraph/commit/71d312d4b7008b865513d2dc52b0bc4019a7591f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added support for &lt;meta charset='...'&gt; when determining and updating the encoding of Html assets, and prefer it to the &lt;meta http-equiv='Content-Type' content='text\/html; ...'&gt; syntax.](https://github.com/assetgraph/assetgraph/commit/a5fb9c15a324a7bd76cc7b0d003ae98861e08904) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model Flash as an asset. Fixes \#76.](https://github.com/assetgraph/assetgraph/commit/64c05370520402fa796d02fa37bec81629313788) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2605,10 +2828,12 @@
 - [+70 more](https://github.com/assetgraph/assetgraph/compare/v0.4.59...v1.0.0)
 
 ### v0.4.59
+
 - [Release 0.4.59.](https://github.com/assetgraph/assetgraph/commit/b76bd8c0b56dc5434b61b7945f600a5c59244e7a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.flattenStaticIncludes: Don't remove non-one.include relations from the graph. Fixes a problem with missing base assets.](https://github.com/assetgraph/assetgraph/commit/d77d7ec86f2e59ebc6a362fd49d4bf03ce398f56) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.58
+
 - [Release 0.4.58.](https://github.com/assetgraph/assetgraph/commit/5da769e3a5a2bfccb517f01824c224a728b746cc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [HtmlDataBindAttribute, HtmlKnockoutContainerless: Strip leading and trailing newlines when inlining \(only relevant when the asset is pretty-printed\).](https://github.com/assetgraph/assetgraph/commit/61c29314a64272eaf5833532265c5b4a4554955f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html.reformatParseTree: Don't remove Knockout.js containerless binding comments, even when removeComments is true.](https://github.com/assetgraph/assetgraph/commit/550e5d1cbffe8e6522c11e106b189473ae817119) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2616,67 +2841,81 @@
 - [assets.Html: Removed '.php' from alternativeExtensions. Doesn't really make sense.](https://github.com/assetgraph/assetgraph/commit/d98a072c404015f835439d0d85e70095eef42ace) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.57
+
 - [Release 0.4.57.](https://github.com/assetgraph/assetgraph/commit/8b9af8e1d5758b494e3cbb7abc94e67a03b75b55) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added asset.isExternalizable attribute and changed transforms.externalizeRelations and transforms.mergeIdenticalAssets to the assets that have it set.](https://github.com/assetgraph/assetgraph/commit/daee09e060cae01f064cd24d3a6d70881a85e375) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.56
+
 - [Release 0.4.56.](https://github.com/assetgraph/assetgraph/commit/9e98cb56fcbead545d1797619e7622e1543618d9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Saner handling of protocol-relative urls.](https://github.com/assetgraph/assetgraph/commit/45d185c8509dddcce627ce4dccba74c519bb1b02) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.ensureAssetConfigHasType: Don't crash if the stdin of the 'file' command is closed before we've completed piping into it.](https://github.com/assetgraph/assetgraph/commit/3db539c9a19d3067d2c06f44a3626e9cd2e494fb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [TransformQueue: Implemented .else\(\)](https://github.com/assetgraph/assetgraph/commit/70a23efaf09400e7196669755f7034601ff644d6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.55
+
 - [Release 0.4.55.](https://github.com/assetgraph/assetgraph/commit/176d2af30046b3e50db91f33e00b9e260d39c08b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleRelations: Preserve the copyright notices from each bundled asset.](https://github.com/assetgraph/assetgraph/commit/27be3c368cf2f51864bd5ae23e88bc3cf8f0d477) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScript: Only preserve leading Copyright comments with \/\*! ... \*\/ à la YUICompressor.](https://github.com/assetgraph/assetgraph/commit/414d2d5b0c0f6b38e6e514caa03b20ffab9e4b44) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.54
+
 - [Release 0.4.54.](https://github.com/assetgraph/assetgraph/commit/8ec3621e6bdb34c9181ef65135fda481275a6548) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [CssImage.href setter: Don't lose the !important suffix.](https://github.com/assetgraph/assetgraph/commit/35e2be3e443f6eff2fe1be1be4f4c35d89addb69) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added support for the Knockout.js containerless flow syntax: &lt;!-- ko foreach: ... --&gt;](https://github.com/assetgraph/assetgraph/commit/2ed358ac6e4da75a3835bc7ec0d7430bedbcce8b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Slightly improve docs for relation.hrefType.](https://github.com/assetgraph/assetgraph/commit/4f708d21780b0d174a2c7e7372cf0a7b7bceb6ad) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.53
+
 - [Release 0.4.53.](https://github.com/assetgraph/assetgraph/commit/e3ead000c609bbdda9b3c3089c38f4ef797c137f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset.populate: Resolve root-relative urls correctly when both assetGraph.root and the base asset url are file:](https://github.com/assetgraph/assetgraph/commit/b381f7b83d67d5fc3f4a1704f6b417226c20fd67) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.52
+
 - [Release 0.4.52.](https://github.com/assetgraph/assetgraph/commit/c4ea7b34bedf81df8667cf0284d39a2baf3d308f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update to uglify-js-papandreou 1.3.3-patch2 and update all require\('uglify-js'\) statements to require\('uglify-js-papandreou'\) -- whoops.](https://github.com/assetgraph/assetgraph/commit/370e2c3adc770a8dfa5c49f5634fe63f982ae4d8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.51
+
 - [Release 0.4.51.](https://github.com/assetgraph/assetgraph/commit/095f1dd4541805a3bab2b954bf057e90cef5c6ad) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Minor fixes to make the test suite pass again after the previous commit.](https://github.com/assetgraph/assetgraph/commit/81923d913af1803eb21432befd32de9f0632ca04) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Relation \(experimental\): Added support for hrefType='rootRelative' and hrefType='protocolRelative'.](https://github.com/assetgraph/assetgraph/commit/597083e8a1944b4a30573acace2f9635ac8fb94b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.50
+
 - [Release 0.4.50.](https://github.com/assetgraph/assetgraph/commit/d2aee245af50da9fa09954aa07873f498b737b95) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update to uglify-js-papandreou 1.3.3-patch1 and prefer singlequotes when serializing data-bind attributes.](https://github.com/assetgraph/assetgraph/commit/94b55cb3d01a5c577f91f60c32b3f6ea9c8cb421) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model javascript: urls as inline assets. Fixes \#53.](https://github.com/assetgraph/assetgraph/commit/1e41256c438ee78d12d1fd11c4fe2a98c5f7b58d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.49
+
 - [Release 0.4.49.](https://github.com/assetgraph/assetgraph/commit/a28b5a9dcfa55575173f0151ac8b48d4a77e7b02) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Model data-bind \(Knockout.js\) attributes as relations to inline JavaScript assets.](https://github.com/assetgraph/assetgraph/commit/d3b14a24784c080f60db718f99e436eba0c600b5) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.48
+
 - [Release 0.4.48.](https://github.com/assetgraph/assetgraph/commit/747e2a0d92be5f24f08841cb2e190967aea0ba57) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Gaah...](https://github.com/assetgraph/assetgraph/commit/8fb37eb434c30870852799125cfe48280b94705e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.47
+
 - [Release 0.4.47.](https://github.com/assetgraph/assetgraph/commit/366200dcaf34935e79df105e2a4033fb3febd5cf) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [fsTools: Fixed typo, grrr.](https://github.com/assetgraph/assetgraph/commit/bada0fd5a329edd512ff31199f86e2bb0de68924) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.46
+
 - [Release 0.4.46.](https://github.com/assetgraph/assetgraph/commit/886071b9160c00ee302ba9e8ca8d48dcb1df1adf) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Use fs.stat instead of path.exists.](https://github.com/assetgraph/assetgraph/commit/e9c2634d9aeda36ff799f13232329556ea249e5c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Minor cleanup of an unused regexp and a comment.](https://github.com/assetgraph/assetgraph/commit/3ac7fa56a0886e703629e74d820a205c5e18458e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.45
+
 - [Release 0.4.45.](https://github.com/assetgraph/assetgraph/commit/e37e06e9f12cebce59fa609d77a645d16742eb6f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Relation.resolve: Don't detach relations that cannot be resolved \(if they point at an unsupported scheme, for instance\) -- just remove them from the graph. Backported from master, where it's part of 05546df.](https://github.com/assetgraph/assetgraph/commit/58859ec7e59df01483a8cf6ff591add16e306b9d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added test demonstrating that relations to unsupported schemes are detached.](https://github.com/assetgraph/assetgraph/commit/d14c951753fe17c106bfab75643a7d12d4835a46) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.44
+
 #### Pull requests
 
 - [#70](https://github.com/assetgraph/assetgraph/pull/70) V0.4 ([Peter Müller](mailto:munter@fumle.dk))
@@ -2687,52 +2926,63 @@
 - [Don't break when a relation points at an unsupported scheme, just skip it. Really. Fixes \#54.](https://github.com/assetgraph/assetgraph/commit/e14773389ee8fe6cee741d94814df017b62df765) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.43
+
 - [Release 0.4.43.](https://github.com/assetgraph/assetgraph/commit/2cba84c7d58c5fb89598edab8d6222158a77139a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added test that ensures that unsupported protocols are left alone.](https://github.com/assetgraph/assetgraph/commit/27f51dc791a3f32c53df167bfef91644eec33c66) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Preserve the first comment in JavaScript assets like the UglifyJS binary does \(assuming it's a copyright notice\).](https://github.com/assetgraph/assetgraph/commit/913f230f7242e5c7704ae0fac644e5e46d514315) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.42
+
 - [Release 0.4.42.](https://github.com/assetgraph/assetgraph/commit/ca1d12ce1d8fef63673d2419095c51c7c741b535) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relation.refreshHref: Don't rewrite root-relative urls to relative ones.](https://github.com/assetgraph/assetgraph/commit/a4a9bbd6ba2b8a110a0a061d460bb3beb519a4a6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.41
+
 - [Release 0.4.41.](https://github.com/assetgraph/assetgraph/commit/d7a9a7cf067bc785b491fc487f42540e775bb79e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleRelations: Fixed bundling in the presence of same-type relations that aren't to be included in the bundle.](https://github.com/assetgraph/assetgraph/commit/41db4610ee3df89f5fb4f3e639fd06d1ea862757) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.JavaScript: Don't warn about 'non-string' items when skipping require|define\(\['exports'\], ...\).](https://github.com/assetgraph/assetgraph/commit/16097ecc2f41addad252e8335d76bce31da567dc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.40
+
 - [Release 0.4.40.](https://github.com/assetgraph/assetgraph/commit/ea42c2df786c71e0db94412f3014425f1ffb2084) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html: Don't model define\(\['exports'\], ...\) and require\(\['exports'\], ...\) as relations. Closes \#67.](https://github.com/assetgraph/assetgraph/commit/023ff7a16ea6efe459314718e5115a7aca694445) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [The 'uglifyAst' module was moved to its own package \(uglifyast\), get it from there.](https://github.com/assetgraph/assetgraph/commit/24446d04be0cf2fb7dce0e1c3699755ee0f53ac2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.39
+
 - [Release 0.4.39.](https://github.com/assetgraph/assetgraph/commit/b80a4468ce8dae465934e05f58f8c9695b601685) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.loadAssets: Limit the concurrency to 10 when loading the assets.](https://github.com/assetgraph/assetgraph/commit/16f653c6494308594f08584b47eb1693d2c8eccc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.38
+
 - [Release 0.4.38.](https://github.com/assetgraph/assetgraph/commit/5708f8696467629fd24fffc4ad7fa49d8bde1e53) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Experimental: Added support for asset.keepUnpopulated.](https://github.com/assetgraph/assetgraph/commit/7904c1d86e457139ee5618abe4dff36d4f0a49ca) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset.prototype.load: If metadata object from the proxy specifies an encoding, just update the \_encoding property instead of using the setter, which has a bunch of unwanted side effects in this case.](https://github.com/assetgraph/assetgraph/commit/a9e442ffd35d2091e22295e0eb381ec36bc3c4b4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.37
+
 - [Release 0.4.37.](https://github.com/assetgraph/assetgraph/commit/1e9ae452982f4fe5d1eb085fe94850f20c9f4f72) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset.prototype.unload: Get the outgoing relations via the getter instead of accessing \_outgoingRelations directly. Fixes unloading of assets that have had outgoing relations removed since they were initially populated.](https://github.com/assetgraph/assetgraph/commit/de79947d139ac1c70d524817785ba38158725236) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.{Css,JavaScript,Html,Xml,CacheManifest,Json}, parseTree setter: Clean up the relations properly.](https://github.com/assetgraph/assetgraph/commit/aabecb1dff7958200d622b3a44bf557769e9ab1f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Implemented Asset.prototype.unload and got rid of the \_clearOutgoingRelations method.](https://github.com/assetgraph/assetgraph/commit/b3b978c961159239bf93a6c7d1d1217be05de903) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.36
+
 - [Release 0.4.36.](https://github.com/assetgraph/assetgraph/commit/48217e3a4dd9f0a94a7077d3db6f27a1772251fc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph constructor: Don't break if config.root is undefined.](https://github.com/assetgraph/assetgraph/commit/24f0f8c4952a39753eed978a21c4372fb015202d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.35
+
 - [Release 0.4.35.](https://github.com/assetgraph/assetgraph/commit/d0dcc69a81f4ed6ced453a5fd5d73172fcef7497) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.resolveConfig: Only call encodeURI when resolving a string \(bug introduced in 641a8bc\).](https://github.com/assetgraph/assetgraph/commit/7a9c56271534fdf296bc0ec80cf04e70f6c649b6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.34
+
 - [Release 0.4.34.](https://github.com/assetgraph/assetgraph/commit/d501224dc9f5a4d9b48104da9387d5f7069785a4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [uglifyAst.objToAst: Sort object keys in an attempt to make the output deterministic.](https://github.com/assetgraph/assetgraph/commit/c481cdde1beb61e6a48e0de940a6c6fed55aa00c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.33
+
 - [Release 0.4.33.](https://github.com/assetgraph/assetgraph/commit/cfd37bd1acb0b770a001e63945acd4a15c7a2326) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.convertStylesheetsToInlineStyles: Only follow relations to stylesheets if the media attribute matches.](https://github.com/assetgraph/assetgraph/commit/ce98bf34e605f2c24a1735c833fd2493d179e167) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [resolvers.http: Added support for 'numRetries' setting in the 'requestOptions' object on the returned function. Will reattempt the request in case of a pre-HTTP-response error.](https://github.com/assetgraph/assetgraph/commit/812c77312b80e0a5e708da5d0ad691f35534127e) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2741,29 +2991,35 @@
 - [+7 more](https://github.com/assetgraph/assetgraph/compare/v0.4.32...v0.4.33)
 
 ### v0.4.32
+
 - [Release 0.4.32.](https://github.com/assetgraph/assetgraph/commit/44149a2277352702476970d964204ee107e75a9b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [More Windows path resolution fixes.](https://github.com/assetgraph/assetgraph/commit/c230ab755f09e0bfe7ae9f0d21f59c25cb5b39b9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.31
+
 - [Release 0.4.31.](https://github.com/assetgraph/assetgraph/commit/7d3f5852b8993fb1895d92495d0bb7a9d507584e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fix path resolution on Windows.](https://github.com/assetgraph/assetgraph/commit/408fe8c06e8a184f75a4c949b5cfbf8a8220c990) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.30
+
 - [Release 0.4.30.](https://github.com/assetgraph/assetgraph/commit/c3b022b0218c87220dca65f86e43e3cb4c926a61) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph.\_runTransform: Don't throw away the error object \(bug introduced in 6264935.](https://github.com/assetgraph/assetgraph/commit/3b7bc515378b04729e826f2b44db3dc3f85db9b8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleRequireJs: Issue the correct module names when augmenting the define statements.](https://github.com/assetgraph/assetgraph/commit/2223355480c6ddf6176c10c597cde097dde29a99) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph.\_runTransform: Warn if a transform calls the callback more than once and ignore the subsequent calls.](https://github.com/assetgraph/assetgraph/commit/6264935f763154d63639ff03a9b75b0c736844fd) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.29
+
 - [Release 0.4.29.](https://github.com/assetgraph/assetgraph/commit/684bcb043ce44ac95d9e0c2a79a9366a49a676c6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed Asset.rawSrc setter.](https://github.com/assetgraph/assetgraph/commit/e444faa9dc53b2072c50d442ea404d6e2ac21351) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update master](https://github.com/assetgraph/assetgraph/commit/774dd0159d218fbeb82fa90c7db09a8a756a39ae) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.28
+
 - [Release 0.4.28.](https://github.com/assetgraph/assetgraph/commit/d86837d8125de339913c9c7c3af094cddde1467e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.registerRequireJsConfig: Don't attempt to extract the config from not yet loaded non-JavaScript assets.](https://github.com/assetgraph/assetgraph/commit/047c598544094b1a5929006e08792ed59f64da94) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.27
+
 #### Pull requests
 
 - [#58](https://github.com/assetgraph/assetgraph/pull/58) \[minor\] Fix a RequireJS module definition ([Karl Guillotte](mailto:karl.guillotte.1@gmail.com))
@@ -2778,30 +3034,37 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v0.4.26...v0.4.27)
 
 ### v0.4.26
+
 - [Release 0.4.26.](https://github.com/assetgraph/assetgraph/commit/12740daf859a3b1180edbeff5748623c194019a0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.StaticUrlMapEntry, wildVardValues: Map undefined to  so \*\* that don't match anything get a sane value.](https://github.com/assetgraph/assetgraph/commit/b2cf6c891fe297b9416e3f56df69208fbaa2a6ac) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.25
+
 - [Release 0.4.25.](https://github.com/assetgraph/assetgraph/commit/384ee46255f0d836dc08358bc8b0ade523802bb1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.StaticUrlMapEntry: Fixed regexp generation for \/\*\*\/ in wildcard urls \(take 2\).](https://github.com/assetgraph/assetgraph/commit/07b4c80486068382c2e2baa780f6a20c4d7954ef) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.24
+
 - [Release 0.4.24.](https://github.com/assetgraph/assetgraph/commit/06394715574ac9be5928ee81db2492d4679725ae) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.StaticUrlMapEntry: Fixed regexp generation for \/\*\*\/ in wildcard urls.](https://github.com/assetgraph/assetgraph/commit/8be76d299cbbd519e681df98343b2813a548fe2f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.23
+
 - [Release 0.4.23.](https://github.com/assetgraph/assetgraph/commit/9f18659c69ae5f5fed673ba394aeb3c76a2626df) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html: Turn on QuerySelector support for jsdom documents.](https://github.com/assetgraph/assetgraph/commit/5fb295f36ba8486cf612ea54fd8d61d522b9d535) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.22
+
 - [Release 0.4.22.](https://github.com/assetgraph/assetgraph/commit/7fc712a268082f6f4befc13677b94e5e04bee556) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset, text and rawSrc setters: Don't break if the asset wasn't previously loaded and populated.](https://github.com/assetgraph/assetgraph/commit/80f316e06216345f54ef6d6749c813b09c8d09ac) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.21
+
 - [Release 0.4.21.](https://github.com/assetgraph/assetgraph/commit/80c0669a13fdfb4ad7db5d2ec27285417f77c8d2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Update jsdom-papandreou to 0.2.14-patch2.](https://github.com/assetgraph/assetgraph/commit/106743fecba1fd34f0de92290b712ae6bb0dc709) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.20
+
 - [Release 0.4.20.](https://github.com/assetgraph/assetgraph/commit/643888166ff86c36b894367eb4c061bd03ddd3c1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Relation.refreshHref: Whoops, turns out some relation types depend on a non-getter\/setter href property.](https://github.com/assetgraph/assetgraph/commit/220c5e8d660e2370027adbd61591bef166f8a96e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed relation.refreshHref for 'always inline' relations that don't have a href.](https://github.com/assetgraph/assetgraph/commit/2e685f7d6fe2f076e1dc222027c21c07681b00dc) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2810,10 +3073,12 @@
 - [+5 more](https://github.com/assetgraph/assetgraph/compare/v0.4.19...v0.4.20)
 
 ### v0.4.19
+
 - [Release 0.4.19.](https://github.com/assetgraph/assetgraph/commit/646747564871dbf848ca9d5dade996d86d63c04b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.registerRequireJsConfig: Prevent false positives in the code that identifies the AST for the require.js configuration.](https://github.com/assetgraph/assetgraph/commit/9ffbd1048786411f780b66a067cdb445ddef5e42) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.18
+
 - [Release 0.4.18.](https://github.com/assetgraph/assetgraph/commit/05a681636d06ccb7fe59ea5cefcdb0959ed2a865) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Asset.markDirty: Only invalidate this.\_rawSrc if this.text or this.parseTree exists.](https://github.com/assetgraph/assetgraph/commit/ba760c4bb37c4cb859990b2edb9bd39f0a52a356) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added support for assetGraph.addAsset\(\[...\]\) and assetGraph.addRelation\(\[...\]\).](https://github.com/assetgraph/assetgraph/commit/f86272705c831e0a59d08d913e8d3a2265e4c4cd) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2822,6 +3087,7 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.4.17...v0.4.18)
 
 ### v0.4.17
+
 - [Release 0.4.17.](https://github.com/assetgraph/assetgraph/commit/7cc365e97cf15aad35c97cfd684994d627521a2b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Experimental: Added require.config\({baseUrl: ...}\) support.](https://github.com/assetgraph/assetgraph/commit/483e40c40dab5fd141a356cef729c81c3d6f57c1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.registerRequireJsConfig: Fixed typo.](https://github.com/assetgraph/assetgraph/commit/73503d4d7796237b984e13c5c8f75be707fe08bc) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2830,50 +3096,61 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.4.16...v0.4.17)
 
 ### v0.4.16
+
 - [Release 0.4.16.](https://github.com/assetgraph/assetgraph/commit/eba94b2b6658fb6d8e3f184443c08d7e21b33b63) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed CssAlphaImageLoader.href setter and added test.](https://github.com/assetgraph/assetgraph/commit/54b8e20e9cd83ebe86196fe9487cfcf67f8218c7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.15
+
 - [Release 0.4.15.](https://github.com/assetgraph/assetgraph/commit/761b72c4259c59d6a4a0c89064656ca793ddd811) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update to jsdom-papandreou 0.2.14-patch1.](https://github.com/assetgraph/assetgraph/commit/0719446cbea1010613c8c72990624cb861132e9c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.14
+
 - [Release 0.4.14.](https://github.com/assetgraph/assetgraph/commit/6eb3fe3dc03d30663129706be170bab5160b7732) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.populate: Pass the error to options.onError in some more scenarios.](https://github.com/assetgraph/assetgraph/commit/ecb1341e12f75c2d7e048670da3eddaec483ba49) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.13
+
 - [Release 0.4.13.](https://github.com/assetgraph/assetgraph/commit/c0ffbd9277fc86d71fea0167c4c8c4a5063515da) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.CssUrlTokenRelation, href getter: Fixed stupid mistake causing an infinite loop.](https://github.com/assetgraph/assetgraph/commit/2b66fafaa34d71ca57c3e949415188d5878faa8a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update jsdom-papandreou to 0.2.13-patch3.](https://github.com/assetgraph/assetgraph/commit/2c7b0c8600b5280fdb20afbbd39ecc9e9aba47c7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.12
+
 - [Release 0.4.12.](https://github.com/assetgraph/assetgraph/commit/3b81d9b9472f8648d9c7cca368977bb2b9168935) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph.recomputeBaseAssets: Clean up the '\_baseAssetPath' path of all relations before starting the recomputation.](https://github.com/assetgraph/assetgraph/commit/15f064f7ab617f7adc28e46a9689f8d1c87108b6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Update bufferjs to 1.1.0, glob to 3.1.9, request to 2.9.153, and uglify-js to 1.2.6.](https://github.com/assetgraph/assetgraph/commit/67dbc3cba3f20b3388616c1f8657d4d6f60f5bf8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.11
+
 - [Release 0.4.11.](https://github.com/assetgraph/assetgraph/commit/6828eb6151006299a889f490cf1111eb1ed403ec) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Revert "Relation.baseAssetPath getter: Also recompute the baseAssetPath when this.\_baseAssetPath is null, not only when the property doesn't exist."](https://github.com/assetgraph/assetgraph/commit/ee9867787c07dfbe2e6210012bb5b32ae9db8160) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.10
+
 - [Release 0.4.10.](https://github.com/assetgraph/assetgraph/commit/22a9dbd6244f868dbbe9fc2e7c933bd4fa1f9c2d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update to jsdom-papandreou 0.2.13-patch2.](https://github.com/assetgraph/assetgraph/commit/27c22398296bf003bb8a05b4577330f62e6abbe6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.9
+
 - [Release 0.4.9.](https://github.com/assetgraph/assetgraph/commit/3b4a5ebec750618d14ef10cf22e021a4e2eaf878) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.moveAssets|moveAssetsInOrder: Also preserve the query string fragment identifier when the target url ends with a slash.](https://github.com/assetgraph/assetgraph/commit/976427f04397b62ea2ec20ac48c2a036c9708772) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [urlTools.fileUrlToFsPath: Strip query string and fragment identifier.](https://github.com/assetgraph/assetgraph/commit/5b191eacc071751b62ba5943a1f2cf93ce573e23) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.8
+
 - [Release 0.4.8.](https://github.com/assetgraph/assetgraph/commit/bad60023ebe7a3d8e7bea1ef9be82696139a0ecb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [CssImage, CssFontFaceSrc, CssAlphaImageLoader: Added support for multiple url\(\)\/src=... in a single property value.](https://github.com/assetgraph/assetgraph/commit/4eaf4164953e2a7a6fe6f8c0b074a592bfe68442) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.7
+
 - [Release 0.4.7.](https://github.com/assetgraph/assetgraph/commit/4defbed02b809e62dfdfb5856cb3eee297a5361b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Omit space between the equal sign and the version number.](https://github.com/assetgraph/assetgraph/commit/de4e104a91209b0c55e22cc7394fc23f5192323b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update cssom-papandreou to 0.2.3-patch2.](https://github.com/assetgraph/assetgraph/commit/e906189bc982a94cac4e37c4208c82d28263e7cd) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.6
+
 - [Release 0.4.6.](https://github.com/assetgraph/assetgraph/commit/0ad12cc1a663fd261f6d576c050330d63e1a5852) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Recompute base assets paths from scratch after running transforms.bundleRequireJs.](https://github.com/assetgraph/assetgraph/commit/bf7a558cf22fa2a4e072298b381166b434bcc1dc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.drawGraph: Include unresolved relations.](https://github.com/assetgraph/assetgraph/commit/a38ba8014c604b2607ddf1500f065cc66a4d4745) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2882,10 +3159,12 @@
 - [+8 more](https://github.com/assetgraph/assetgraph/compare/v0.4.5...v0.4.6)
 
 ### v0.4.5
+
 - [Release 0.4.5.](https://github.com/assetgraph/assetgraph/commit/638828cf9720caea38b3131fc7e95f90203b976c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Use jsdom-papandreou \(fork that includes this patch: https:\/\/github.com\/tmpvar\/jsdom\/pull\/414\).](https://github.com/assetgraph/assetgraph/commit/a01d0ce12767a4fc0626ce746c56345165758d53) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.4
+
 - [Release 0.4.4.](https://github.com/assetgraph/assetgraph/commit/4b79d7191f7fd9a3267990cbe80b26261f810897) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.pullGlobalsIntoVariables: Added experimental 'stringLiterals' mode where string literals and method names \(dot notation\) are hoisted into variables.](https://github.com/assetgraph/assetgraph/commit/0e4ba87c06e663287b9006b4347e5b1b8e2f8f20) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms: Back to throwing in the 'outer' transform function if an optional dependency couldn't be loaded.](https://github.com/assetgraph/assetgraph/commit/4ff9f1dc058b496ca883baa52b4689c85462f4c7) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2893,6 +3172,7 @@
 - [Fixed HtmlStyleAttribute test \(requires https:\/\/github.com\/tmpvar\/jsdom\/pull\/414 to pass\).](https://github.com/assetgraph/assetgraph/commit/39e5f0b72658ca2a245a4efcc87cc5006acddfed) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.3
+
 - [Release 0.4.3.](https://github.com/assetgraph/assetgraph/commit/e08a983e2b39f7eba929938a2cdb8a6e51ca9739) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.compileLessToCss: Catch exceptions thrown by the less compiler and report them.](https://github.com/assetgraph/assetgraph/commit/0f7521dda82eba5cc82bf477f8379f1ba855a48d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Don't throw in async transforms \(copy\/paste error\).](https://github.com/assetgraph/assetgraph/commit/5231093ccf10d704e32be2fd117c1381dca0f6e7) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2901,10 +3181,12 @@
 - [+3 more](https://github.com/assetgraph/assetgraph/compare/v0.4.2...v0.4.3)
 
 ### v0.4.2
+
 - [Release 0.4.2.](https://github.com/assetgraph/assetgraph/commit/41fadc3a1bd8e1f38e9c42374bed09251960197d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.compile\(LessToCss|StylusToCss|CoffeeScriptToJavaScript\): Don't require the optional dependency until the transform is invoked.](https://github.com/assetgraph/assetgraph/commit/c3b53a741504a5e44f09f239aefc0a2973188e53) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.4.1
+
 - [Release 0.4.1.](https://github.com/assetgraph/assetgraph/commit/39483030ec4763df25fa2bb741e48d0195641f69) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added AssetGraph.prototype.queue.](https://github.com/assetgraph/assetgraph/commit/761fce4654341413e42fc4a0c4b3e4ed03771b9f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Alias \(TransformQueue|AssetGraph\).prototype.if as if\_ for pre-ES5.](https://github.com/assetgraph/assetgraph/commit/ddf5a96bdacde763ab3c08dde22bd7e5a4a1d230) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2913,6 +3195,7 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.4.0...v0.4.1)
 
 ### v0.4.0
+
 - [Release 0.4.0.](https://github.com/assetgraph/assetgraph/commit/6831e39d08aaa7d562086d2dec3d459f4a05719f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Removed transforms.parallel](https://github.com/assetgraph/assetgraph/commit/7923c62c703e80683d48013507df766e2b76e1b7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [createCacheManifest example: Write stats to stderr at the end.](https://github.com/assetgraph/assetgraph/commit/2d7758e5509bb10be0e4d205fd6184fc5679e0e9) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2921,6 +3204,7 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v0.3.44...v0.4.0)
 
 ### v0.3.44
+
 - [Release 0.3.44.](https://github.com/assetgraph/assetgraph/commit/9aac1d05c2dfa79f0f3e61813b4f6d555c6b973a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleRequireJs: Don't rely on asset.clone preserving the original asset's url.](https://github.com/assetgraph/assetgraph/commit/69170c0eab1b02ec503c515c0bcf5bb01a1772e4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.JavaScriptAmdRequire.href setter: Don't prefix the module name with 'undefined' when there's no plugin prefix in the existing value.](https://github.com/assetgraph/assetgraph/commit/eb27536ebdf397f4c19702be98b0bcdfa9336de4) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2929,6 +3213,7 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v0.3.43...v0.3.44)
 
 ### v0.3.43
+
 - [Release 0.3.43.](https://github.com/assetgraph/assetgraph/commit/457aa857394b60ecea0bfd6ddabcfdf4027802fc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [StaticUrlMap & Image: Avoid overwriting asset.Base's registration of application\/octet-stream.](https://github.com/assetgraph/assetgraph/commit/285bcefca709ba30d668368c07b9cd1f78679b07) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [KnockoutJsTemplate.minify: Don't remove HTML comments as it's used by the templating logic.](https://github.com/assetgraph/assetgraph/commit/95e10bd3144f5f887aacc8f6ae59f0c48efdc148) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2937,10 +3222,12 @@
 - [+7 more](https://github.com/assetgraph/assetgraph/compare/v0.3.42...v0.3.43)
 
 ### v0.3.42
+
 - [Release 0.3.42.](https://github.com/assetgraph/assetgraph/commit/8bee6de4800e97ec5042ae51a92f8a5cc0cfa0e3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update cssom-papandreou to 0.2.2-patch2.](https://github.com/assetgraph/assetgraph/commit/6d609c925804f113e35535b6ce79a2ac3fc1285d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.41
+
 #### Pull requests
 
 - [#46](https://github.com/assetgraph/assetgraph/pull/46) Basic support for RequireJS less! plugin ([Bram Stein](mailto:b.l.stein@gmail.com))
@@ -2955,6 +3242,7 @@
 - [+6 more](https://github.com/assetgraph/assetgraph/compare/v0.3.40...v0.3.41)
 
 ### v0.3.40
+
 - [Release 0.3.40.](https://github.com/assetgraph/assetgraph/commit/df71b603c9457a06ceb56e39dbe4ca83faf425c6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [RequireJS\/AMD support: Added special support for a custom kotpl! plugin.](https://github.com/assetgraph/assetgraph/commit/ea3727a584f186562312f43e8b6ad9e0cec335c2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html.findOutgoingRelationsInParseTree: Always interpret a data-main property on a &lt;script&gt; to be a HtmlRequireJsMain relation.](https://github.com/assetgraph/assetgraph/commit/b4cad3f529d632862e238ad99ef6c05380c222e1) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2963,10 +3251,12 @@
 - [+21 more](https://github.com/assetgraph/assetgraph/compare/v0.3.39...v0.3.40)
 
 ### v0.3.39
+
 - [Release 0.3.39.](https://github.com/assetgraph/assetgraph/commit/35a5c48463f475377eb14bc8189023f068ae423e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Skip JavaScriptCommonJs relations that cannot be resolved \(but emit a warning\).](https://github.com/assetgraph/assetgraph/commit/c1200bed5c1f33ae9f888f75d09e5306e2b0df4d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.38
+
 - [Release 0.3.38.](https://github.com/assetgraph/assetgraph/commit/a135698c1373cbf02073197f15955fd740eccb69) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Html.findOutgoingRelationsInParseTree: Only model &lt;script type='...'&gt; tags as relations if the type attribute is either 'text\/javascript' or 'text\/coffeescript'. Fixes the broken test.](https://github.com/assetgraph/assetgraph/commit/60dd041694e3b3d14af3bf83fa69fe6bbab7a8ab) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added failing HtmlScript test that checks whether &lt;script&gt; tags with a type of something other than 'text\/javascript' or 'text\/coffeescript'.](https://github.com/assetgraph/assetgraph/commit/f85d7b5eeb42fcc1a38f61ca43939afba6f1a2e3) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -2975,32 +3265,38 @@
 - [+7 more](https://github.com/assetgraph/assetgraph/compare/v0.3.37...v0.3.38)
 
 ### v0.3.37
+
 - [Release 0.3.37.](https://github.com/assetgraph/assetgraph/commit/4bf0d06fc2f2456b7cfb2aff84c447a29ced53f5) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Stay at glob &lt; 3.0.0 until some minor bugs have been fixed.](https://github.com/assetgraph/assetgraph/commit/96d4eb986f9428a5206869fa34b81567762f02e7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json, prepublish hook: Run 'npm install' before the test suite.](https://github.com/assetgraph/assetgraph/commit/c1e1d9046159c3a458286d08297b7bb2ad6dbf21) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.36
+
 - [Release 0.3.36.](https://github.com/assetgraph/assetgraph/commit/4dd24b0ba2b2e639b3e4107dadb4c51f3d3591b3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [StaticUrlMap: Added support for {foo,bar} type wildcards and fixed another double-star wildcard bug.](https://github.com/assetgraph/assetgraph/commit/97e5ffc60521fc8a0ce32786257926976dd0f6f0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.JavaScriptOneGetStaticUrl: Added support for omitting the one.getStaticUrl\(...\) function call itself. It'll save some bytes, but render the relation unrecognizable.](https://github.com/assetgraph/assetgraph/commit/3f16ace27e3c0a1748419a782f38bee647a90273) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.36.](https://github.com/assetgraph/assetgraph/commit/7505b0ab2f962ff746ff452fb05ec476489dff8e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.35
+
 - [Release 0.3.35.](https://github.com/assetgraph/assetgraph/commit/00c2aa84081426caa6a642eb4c65a76476d5624b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html: Fixed typo in '.shtml'.](https://github.com/assetgraph/assetgraph/commit/80333f2982ba24589cfdd6e6feacd95529d5857e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.35.](https://github.com/assetgraph/assetgraph/commit/4b474d1711038b8cd608b3ac7b47c2e18c2e83cc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.34
+
 - [Release 0.3.34.](https://github.com/assetgraph/assetgraph/commit/d01b9c5f21df9265a4b4dcef425e0fd4b3c7441d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html: Added '.shtml' to 'alternativeExtensions'.](https://github.com/assetgraph/assetgraph/commit/dad4fc318e3ba81d69a6da96dff4695f49421436) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.33
+
 - [Release 0.3.33.](https://github.com/assetgraph/assetgraph/commit/7ef31485b4d75f7366f451a1e2a7f6431180472c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.bundleAssets: Don't bundle HtmlStyle relations with different media attributes.](https://github.com/assetgraph/assetgraph/commit/3df9e533d86fca520cbf5d6c7f5794237a0cf124) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Experimental: Dropped the urlIndex and allow multiple assets to share the same url.](https://github.com/assetgraph/assetgraph/commit/a70c39dcb89098f8af14173516c26d439e8553cc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.33.](https://github.com/assetgraph/assetgraph/commit/af4292d16bb42b5957c48e618488ba1f07a1894d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.32
+
 - [Release 0.3.32.](https://github.com/assetgraph/assetgraph/commit/0564dd241a6d86fe92cb734cc5190e2d87510e9e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Changed transforms.bundleAssets to transforms.bundleRelations.](https://github.com/assetgraph/assetgraph/commit/1525c0f191a4ec48295fa10e03c5220a765d71f7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html.findOutgoingRelationsInParseTree: Do a case insensitive match when deciding whether to skip a relation \(apparently &lt;a href='JavaScript:...'&gt; isn't uncommon.](https://github.com/assetgraph/assetgraph/commit/0cb11d793489fa395513c849cf2ceb4609dbd6b2) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3008,6 +3304,7 @@
 - [Now working on 0.3.32.](https://github.com/assetgraph/assetgraph/commit/3e229f10d6e0a7eca72ef5b21f5cfa257f02283b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.31
+
 - [Release 0.3.31.](https://github.com/assetgraph/assetgraph/commit/5b42b84f805e736d33a65045516b4945beedf58d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.StaticUrlMapEntry: Fixed wildCardValuesRegExp for hrefs using double-star wildcards.](https://github.com/assetgraph/assetgraph/commit/5e02825b73da9b2799a7b9b3e370b1d113b8841d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Relation: Made hrefType a getter\/setter.](https://github.com/assetgraph/assetgraph/commit/80e9860225525095fa5b51ea276141d396d947f9) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3015,6 +3312,7 @@
 - [Now working on 0.3.31.](https://github.com/assetgraph/assetgraph/commit/f2178092741d652737c77c64d6da86578cb2752f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.30
+
 - [Release 0.3.30.](https://github.com/assetgraph/assetgraph/commit/b2142b05014796af880e45d4aaec35da0610b248) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added .npmignore and excluded the test suite from the package.](https://github.com/assetgraph/assetgraph/commit/4bd369e8a7a1e6456d72d9dc4240ccaecaeb536c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Made graphviz, coffee-script, less, and stylus optional \(moved to 'devDependencies'\). Install them as needed.](https://github.com/assetgraph/assetgraph/commit/abf0e91522dabd64314e97c457c7f3ef7d21bbab) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3023,12 +3321,14 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v0.3.29...v0.3.30)
 
 ### v0.3.29
+
 - [Release 0.3.29.](https://github.com/assetgraph/assetgraph/commit/c365f5e5004c0301af3c2f323cad6110811bf246) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Experimental: Added 'hrefType' property to relations. Decides whether to try issuing a relative url \(relative, the default\), or to always issue an absolute url \(absolute\).](https://github.com/assetgraph/assetgraph/commit/7cf67a5202878721c99be09efa9476a851123665) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Don't depend on 'temp' \(not used\).](https://github.com/assetgraph/assetgraph/commit/11f632e56964a4c553a5fe526c0d58b814fc44fe) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.29.](https://github.com/assetgraph/assetgraph/commit/5c4f97a7adcce2b99282c0664abad18c5f179e06) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.28
+
 - [Release 0.3.28.](https://github.com/assetgraph/assetgraph/commit/44f10dde8940fa44270f1e639d7759568b02d2cf) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Css @media rule test: Don't use nested @media {} blocks, it seems to be illegal for some reason, and CSSOM 0.2.2 throws a parse error.](https://github.com/assetgraph/assetgraph/commit/badd9ca8771f1cb64a81b360024ce25eda3478ab) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.compile\*To\*: Don't use the same url for the compiled asset.](https://github.com/assetgraph/assetgraph/commit/5543f7b0a58e61e40f8b229de24d9fc77faa65fb) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3037,17 +3337,20 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.3.27...v0.3.28)
 
 ### v0.3.27
+
 - [Release 0.3.27.](https://github.com/assetgraph/assetgraph/commit/26b2a26b873e77fe50be665a000d346f6c61e6c6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.inlineCssImagesWithLegacyFallback: Fixed bug that caused non-CssImage relations to be inlined \(such as CssBehavior\).](https://github.com/assetgraph/assetgraph/commit/ea312647871fca24e4c5c28e1f56713026f82790) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.27.](https://github.com/assetgraph/assetgraph/commit/2cb608939d1fa46031e76319d74f18553a0f6069) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.26
+
 - [Release 0.3.26.](https://github.com/assetgraph/assetgraph/commit/f6a627122c0c7d0c9fd9b3830439d257cfb54708) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Run vows in the 'prepublish' hook to avoid releasing a new version if a test fails.](https://github.com/assetgraph/assetgraph/commit/a5e15f7449b7732b166887743cfa7087ee703254) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [query.queryAssetGraph: Fixed broken assetGraph.find\(Assets|Relations\)\(function\).](https://github.com/assetgraph/assetgraph/commit/e874d8bd086e7a47fa95ea8cb6aa73fbe684761c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.26.](https://github.com/assetgraph/assetgraph/commit/b34a230ad1bfc5ab2f88e9a270bf4ca891ecfc5d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.25
+
 - [Release 0.3.25.](https://github.com/assetgraph/assetgraph/commit/46dcff9607a984cdb2b9c361e6ed8eddf9241eb8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.populate: Report the including asset\(s\) when an asset cannot be loaded.](https://github.com/assetgraph/assetgraph/commit/75cbc11eeb5966120e1fc954f8a69e73e507119b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed some typos in inline docs.](https://github.com/assetgraph/assetgraph/commit/99209b6b0183793f74b9c239a4797a38b4ebc419) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3055,15 +3358,18 @@
 - [Now working on 0.3.25.](https://github.com/assetgraph/assetgraph/commit/6d1824cd76411b8d17a53292c86656e2546c8559) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.24
+
 - [Release 0.3.24.](https://github.com/assetgraph/assetgraph/commit/2abdd98266c5030b1e51e15ac987dd6ee3494671) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [resolvers.http: Prevent request from overwriting resolvers.http.headers.Cookie with an empty string.](https://github.com/assetgraph/assetgraph/commit/c72f22be05ed897a8c5fdedbbef6ebccb16ecdce) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.24.](https://github.com/assetgraph/assetgraph/commit/2b1a0d1263b70293eb04933e358281f43d8bae8c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.23
+
 - [Release 0.3.23.](https://github.com/assetgraph/assetgraph/commit/edae839582568a82fce3c65bf4934b9f31261803) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScript.findOutgoingRelationsInParseTree: Skip JavaScriptCommonJsRequire relations pointing at built-in modules.](https://github.com/assetgraph/assetgraph/commit/0d727b2813890171459e2dea7ae8fe61ca058994) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.22
+
 - [assets.Html.findOutgoingRelationsInParseTree: Look for space, start-of-string and end-of-string around tokens in the 'rel' attribute. Dashes are also counted as word boundaries, so that's not precise enough.](https://github.com/assetgraph/assetgraph/commit/dabdac64b51086c75d5f28503ca12add7d13016b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html: Interpret the 'rel' attribute of 'link' tags as a space-separated list.](https://github.com/assetgraph/assetgraph/commit/5dc104a46159e00c2cb6785c9a366de4427bd00f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added test for relations.HtmlShortcutIcon.](https://github.com/assetgraph/assetgraph/commit/985217c3f84c93181532de49d9b0710789939436) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3072,11 +3378,13 @@
 - [+3 more](https://github.com/assetgraph/assetgraph/compare/v0.3.21...v0.3.22)
 
 ### v0.3.21
+
 - [Release 0.3.21.](https://github.com/assetgraph/assetgraph/commit/5548439f1273e60c93cd6cea077d8c28ea75c6a4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.JavaScript.findOutgoingRelationsInParseTree: Reinstate depth-first traversal + added test.](https://github.com/assetgraph/assetgraph/commit/9922a39fd91cbb0e3607eb1db6748d9aca43fb04) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.20.](https://github.com/assetgraph/assetgraph/commit/84931a8058a7c1c59e7a5fb2ceb14d5e8bebc112) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.19
+
 - [Release 0.3.19.](https://github.com/assetgraph/assetgraph/commit/1099b4b7898a994ebb699638b8fb0b0a12b6559b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Revert "transforms.compressJavaScript: Turn off the 'make\_seqs' option for UglifyJS to prevent stack overflows in assets.JavaScript.findOutgoingRelationsInParseTree \(should be rewritten to not use recursion\)."](https://github.com/assetgraph/assetgraph/commit/39cad861af4b4bfbc0e9e338e960f6ed915a8e18) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.JavaScript.findOutgoingRelationsInParseTree: Avoid recursion. Fixes \#43.](https://github.com/assetgraph/assetgraph/commit/83bab1db4643a4640a86836562938d0a025f1dd6) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3085,6 +3393,7 @@
 - [+17 more](https://github.com/assetgraph/assetgraph/compare/v0.3.18...v0.3.19)
 
 ### v0.3.18
+
 - [Release 0.3.18.](https://github.com/assetgraph/assetgraph/commit/0b25bfeaad3ed62e01866abf963ca604d69afbef) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update node-glob to 2.1.0. Test suite now passes in node 0.6.2.](https://github.com/assetgraph/assetgraph/commit/d4c2617220f4d415b8bbe7e8382b9140c78cc60a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Node 0.6 compatibility: Check err.code as well as err.errno.](https://github.com/assetgraph/assetgraph/commit/0107f69db13804c151201dd2f81c94967c4afeb8) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3093,11 +3402,13 @@
 - [+4 more](https://github.com/assetgraph/assetgraph/compare/v0.3.17...v0.3.18)
 
 ### v0.3.17
+
 - [Release 0.3.17.](https://github.com/assetgraph/assetgraph/commit/c0b18ec94a661bac79b2280d00b0384d7de38266) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.compileLessToCss: If the Less asset has a file:\/\/ url, add its directory to the Less parser's search path so @import statements work.](https://github.com/assetgraph/assetgraph/commit/2e139893a2f981e17628faa1e989b0f12cbf5985) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.17.](https://github.com/assetgraph/assetgraph/commit/2307ff388d5e5d058b3c70c7ff22c82681e48eeb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.16
+
 - [Release 0.3.16.](https://github.com/assetgraph/assetgraph/commit/028d183400af0ad86f2dc6ad6d0db5c1e4abc4c7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Less: Use 'text\/less' as the default Content-Type \(and avoid overwriting assets.Text in the Content-Type registry\).](https://github.com/assetgraph/assetgraph/commit/0e74f55d8c9e89ab4ecf11f452913a402287248f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added support for Less assets and added a transform that compiles them to Css. Closes \#40.](https://github.com/assetgraph/assetgraph/commit/1ad0c179c9dd1d769e9989eaba58a6abdc3e90ed) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3106,17 +3417,20 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.3.15...v0.3.16)
 
 ### v0.3.15
+
 - [Release 0.3.15.](https://github.com/assetgraph/assetgraph/commit/49922a57a963aee2d987dc911e19914446c14426) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.inlineCssImagesWithLegacyFallback: Don't inline images pointed to using the underscore IE6 hack \(\_background-image: ...\).](https://github.com/assetgraph/assetgraph/commit/a8cfe3faeb0ca89f880209cccdc40b4e234aa03a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.15.](https://github.com/assetgraph/assetgraph/commit/a66c1f921c9e10b24fbdfeb05b7960b5cc820b9f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.14
+
 - [Release 0.3.14.](https://github.com/assetgraph/assetgraph/commit/574e1159c8ca11f7fe349137f11ed90b5b4fe109) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Update jsdom to 0.2.9.](https://github.com/assetgraph/assetgraph/commit/a644f0922d1e9d05855e3eec03b248170815735d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update jsdom to 0.2.8.](https://github.com/assetgraph/assetgraph/commit/8e8ec839dd4d726643c0d4afbf008a97eae8d64c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.14.](https://github.com/assetgraph/assetgraph/commit/25e6b92d8ba37784df061d041f794d0baea2eb29) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.13
+
 - [Release 0.3.13.](https://github.com/assetgraph/assetgraph/commit/146b4cca458912dfd97f29d4e86675f1e27cbfac) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [resolvers.http: Added hack that allows you to specify a fixed set of request headers through 'assetGraph.resolversByProtocol.http.headers'.](https://github.com/assetgraph/assetgraph/commit/2145bd1d214c7644cc7ee17ef58a72ee8af75026) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [README.rst: More transform docs.](https://github.com/assetgraph/assetgraph/commit/213228eb9c14963f3f04c2f8feac6ffbe648551c) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3125,6 +3439,7 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v0.3.12...v0.3.13)
 
 ### v0.3.12
+
 - [Release 0.3.12.](https://github.com/assetgraph/assetgraph/commit/900d0ece09bbb28760630051504acf57a43686cf) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html.findOutgoingRelationsInParseTree: Don't create relations when the href is empty or javascript: or mailto: or consists only of a fragment identifier.](https://github.com/assetgraph/assetgraph/commit/eab61f96c8da2768aaf2e423641246a7785316bc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Put a space between the equal sign and the version number in the 'dependencies' section.](https://github.com/assetgraph/assetgraph/commit/9ffb8ffe1edb9695fdcb48d5e82b54273d61b796) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3133,11 +3448,13 @@
 - [+9 more](https://github.com/assetgraph/assetgraph/compare/v0.3.11...v0.3.12)
 
 ### v0.3.11
+
 - [Release 0.3.11.](https://github.com/assetgraph/assetgraph/commit/890d0b22d8a2bf09164e060258b87e0f29426f82) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.addCacheManifest: When creating a new manifest, add a NETWORK section with '\*' in it.](https://github.com/assetgraph/assetgraph/commit/9ef3ab7bc08bee497737a0312638fa3350520805) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.11.](https://github.com/assetgraph/assetgraph/commit/ab9cebd7c64aba7a0418ff50267b4098af79ce1b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.10
+
 - [Release 0.3.10.](https://github.com/assetgraph/assetgraph/commit/bbf73ea4c11033d226471703f7969a928d0d1aa1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets\/index.js: Better error reporting.](https://github.com/assetgraph/assetgraph/commit/da721a1f40258999712465e0797a4a795cbe2c7a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [http and data resolvers: Better Content-Type parsing. Allow '+', '.'. Fixes parsing of eg. 'application\/atom+xml' and 'application\/vnd.openxmlformats-officedocument.wordprocessingml.template'.](https://github.com/assetgraph/assetgraph/commit/8acf2bed3af021da32b974aabf47eaa1c788adae) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3145,6 +3462,7 @@
 - [Now working on 0.3.10.](https://github.com/assetgraph/assetgraph/commit/115436750873a667393a08c3e3c0a9f996e5dd82) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.9
+
 - [Release 0.3.9.](https://github.com/assetgraph/assetgraph/commit/8e9a562b91d87b054a35fa7d8b12c66d5a0a1acb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.moveAssets\(InOrder\): Don't move the asset if 'newUrlFunction' returns something falsy.](https://github.com/assetgraph/assetgraph/commit/2915e0ba331b30d0473e2ae6e07df3124b6d6b44) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Support percent-encoded octets in data: urls and fall back to text\/plain; charset=us-ascii as per the spec.](https://github.com/assetgraph/assetgraph/commit/2ee6bf83de00fa935d786868ce953f73cbea02eb) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3153,6 +3471,7 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v0.3.8...v0.3.9)
 
 ### v0.3.8
+
 - [Release 0.3.8.](https://github.com/assetgraph/assetgraph/commit/ebea8f39e5d94c2fd56dcbfab68cdb902477cd55) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Changed glob dependency to ~2.0.7 \(2.0.7 disappeared from the npm repo?\).](https://github.com/assetgraph/assetgraph/commit/775770ca1ac9680a0344ea93cebcd21e898d7831) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added transforms.setHtmlImageDimensions.](https://github.com/assetgraph/assetgraph/commit/7ad811069d87fb333034e15b3ac0f32d9e9eca17) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3160,6 +3479,7 @@
 - [Now working on 0.3.8.](https://github.com/assetgraph/assetgraph/commit/efc7e91875f4fa0e93b6764509db62bc8d8ad363) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.7
+
 - [Release 0.3.7.](https://github.com/assetgraph/assetgraph/commit/bdb4ca180800a38ff140f4f414d6b287a54cc851) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Bugfix in HtmlConditionalComment.inline: Only every other element in the conditional comment was copied into the containing document.](https://github.com/assetgraph/assetgraph/commit/c131fe1eee2634d2c5d7e2a4f541db4c435978f2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Refined the test case for \#35 and fixed a bug in the 'sharedBundles' strategy.](https://github.com/assetgraph/assetgraph/commit/6525e09377eabd150bafca5e53e5deb94fe80997) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3168,6 +3488,7 @@
 - [+3 more](https://github.com/assetgraph/assetgraph/compare/v0.3.6...v0.3.7)
 
 ### v0.3.6
+
 - [Release 0.3.6.](https://github.com/assetgraph/assetgraph/commit/3b8f326ddd9179fc0fbe29c09664c7e0023934f7) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed non-IE conditional comment syntax in test.](https://github.com/assetgraph/assetgraph/commit/d246ae6277d83632f1d73d8b5e634cf3847f8016) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.inlineCssImagesWithLegacyFallback: The original Css asset could have more than one incoming relation, so don't manipulate it. Fixes interoperability with assetgraph-builder's cloneForEachLocale transform, among other things.](https://github.com/assetgraph/assetgraph/commit/1d16b9d80625e7a7e4dcee3b5e4ba4b05aa12dab) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3175,12 +3496,14 @@
 - [Now working on 0.3.6.](https://github.com/assetgraph/assetgraph/commit/6a402014cdb42d2df8599915f18045302694e3c4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.5
+
 - [Release 0.3.5.](https://github.com/assetgraph/assetgraph/commit/8e1db6663e093784d11a6446b556e61d3813358c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Update to jsdom 0.2.5.](https://github.com/assetgraph/assetgraph/commit/74381d8b8b24c0411807ed84e175c37f8cc183bf) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [README.rst: More transform docs.](https://github.com/assetgraph/assetgraph/commit/0a1e3b0528011bee093d7f3a240e13da5e2a1e54) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.3.5.](https://github.com/assetgraph/assetgraph/commit/5955950338013af571bff0c1266d5868bbc9043e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.4
+
 - [Release 0.3.4.](https://github.com/assetgraph/assetgraph/commit/58a963d4a91612926e1f257fe6253f45f7718cb9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html: Bugfixed non-IE conditional comment parsing.](https://github.com/assetgraph/assetgraph/commit/da6c242dd02ec55be973bc3821f6bd279c8b01fb) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed Relation.attach\(..., 'after', htmlConditionalComment\)](https://github.com/assetgraph/assetgraph/commit/ecdd2c96013076007ba8366c53faf20e4dba5fc4) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3189,6 +3512,7 @@
 - [+4 more](https://github.com/assetgraph/assetgraph/compare/v0.3.3...v0.3.4)
 
 ### v0.3.3
+
 - [Release 0.3.3.](https://github.com/assetgraph/assetgraph/commit/acb0524d6e56234f698ca06a5fe27b397c8b41b5) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.populate: Fixed stupid bug in the code that finds the external relations of an asset.](https://github.com/assetgraph/assetgraph/commit/1f1fb246af6221e8d01c7b9fbdb489818bded511) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.populate: Fixed error handling.](https://github.com/assetgraph/assetgraph/commit/39a923a83713a3cf83e76f52cea9f6e57568dd38) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3196,6 +3520,7 @@
 - [Now working on 0.3.3.](https://github.com/assetgraph/assetgraph/commit/187e21fc5a6d914baf21c4e6123fa958aaf88619) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.3.2
+
 - [Release 0.3.2.](https://github.com/assetgraph/assetgraph/commit/68f604b96726a82949746d7a70c6b5e003211e84) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed transforms.bundleAssets errors introduced in c438177e.](https://github.com/assetgraph/assetgraph/commit/b8c7906c83f64708988d5177a4c08e29ac0ee4b2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added some outgoingRelations tests.](https://github.com/assetgraph/assetgraph/commit/88d23fac60dbc88cc9ceedc42072855db2c1fd7b) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3204,6 +3529,7 @@
 - [+12 more](https://github.com/assetgraph/assetgraph/compare/v0.3.1...v0.3.2)
 
 ### v0.3.1
+
 - [Release 0.3.1.](https://github.com/assetgraph/assetgraph/commit/67c261bf759d4f31b05b9cf0f62e2442b95db73b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Better test coverage of what's supposed to happen to asset.outgoingRelations when the asset is removed from a graph.](https://github.com/assetgraph/assetgraph/commit/6e09fd98f685a8106c93b79c48d7f0be778b33de) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relations.Html\*: Fixed stupid copy\/paste error in 'attach' methods.](https://github.com/assetgraph/assetgraph/commit/4f7e34948e27a870cdaeb54b232fceb1a41588e8) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3212,6 +3538,7 @@
 - [+17 more](https://github.com/assetgraph/assetgraph/compare/v0.3.0...v0.3.1)
 
 ### v0.3.0
+
 - [Release 0.3.0.](https://github.com/assetgraph/assetgraph/commit/7f34ccbba90e4a3be71437391518aa107bcc2abd) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Moved parts of transform.populate into Relation.resolve.](https://github.com/assetgraph/assetgraph/commit/3812536dd834fe38c1b91216f8fdac779884dc22) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Relation: Cleanup + changed representation of 'no asset path' from \[\] to null.](https://github.com/assetgraph/assetgraph/commit/90b046111ad87f25d7ed1dc290ffa04d813e1ba3) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3220,6 +3547,7 @@
 - [+23 more](https://github.com/assetgraph/assetgraph/compare/v0.2.10...v0.3.0)
 
 ### v0.2.10
+
 - [Release 0.2.10.](https://github.com/assetgraph/assetgraph/commit/5ba9ecdf7d6a0fe52a87985e2cd8de34eaaad1ef) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html.encoding setter: If there's a &lt;head&gt;, make sure it contains a &lt;meta http-equiv='Content-Type'...&gt; tag specifying the new encoding.](https://github.com/assetgraph/assetgraph/commit/33e15713199a7b99594135d63c6c24e57cc098aa) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Asset.load: Fixed stupid this vs. that error causing the asset metadata to be mixed into the wrong object.](https://github.com/assetgraph/assetgraph/commit/8c937ce3009ef80b297ee73c3880183caf729c1e) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3228,6 +3556,7 @@
 - [+21 more](https://github.com/assetgraph/assetgraph/compare/v0.2.9...v0.2.10)
 
 ### v0.2.9
+
 - [Release 0.2.9.](https://github.com/assetgraph/assetgraph/commit/212f41731a4738ad2e2754b43b95cc8e1705bbd8) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Simplified AssetGraph.removeAsset and fixed a bug that prevented an asset with a relation to itself from being removed.](https://github.com/assetgraph/assetgraph/commit/c5bd6c1d8008459c87926b99cdce36203c5c6308) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.\*.originalRelations: Always provide relation.to as an object.](https://github.com/assetgraph/assetgraph/commit/b7577bdb5802df1b90023e5361193b4be842f2bd) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3235,16 +3564,19 @@
 - [Now working on 0.2.9.](https://github.com/assetgraph/assetgraph/commit/5f9ecc5b86db4c11a9bbaa7a1364c353e32d7d68) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.2.8
+
 - [Release 0.2.8.](https://github.com/assetgraph/assetgraph/commit/67d639029c088db812ec281dec714ab6d957de4d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Re-refixed CSSStyleSheet.toString\(\)... Sigh.](https://github.com/assetgraph/assetgraph/commit/b6aa0016c65dcd0c16ba95f82f0b9217f237b5ab) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.2.8.](https://github.com/assetgraph/assetgraph/commit/4a399b0aedc0879e38b4f27168a8464a8cff317b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.2.7
+
 - [Release 0.2.7.](https://github.com/assetgraph/assetgraph/commit/026a38a0cfd66aa095f2df58011504320aa8aead) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [CSSStyleSheet.toString\(\) hack: Prevent JavaScript error when there's no cssRule.style.](https://github.com/assetgraph/assetgraph/commit/96e1b06b2b759b587eb0d3d695b34709bd7f52f5) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.2.7.](https://github.com/assetgraph/assetgraph/commit/e068b29868f34680c5305732707013332eb4a796) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.2.6
+
 - [Release 0.2.6.](https://github.com/assetgraph/assetgraph/commit/819c4ff7c3a0afe77c8c9a035693dd04827e977c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html.outgoingRelations getter: Ignore &lt;a href=""&gt;.](https://github.com/assetgraph/assetgraph/commit/84964ee9d39a3c8433a5a821b8d601946b2a427a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [CSSStyleSheet.toString\(\): Splice together neighbor CSSRules with identical selectors. The inverse of f3c42e5.](https://github.com/assetgraph/assetgraph/commit/e8707df9ca952498a3685d772c8cc0be6b5942ac) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3253,6 +3585,7 @@
 - [+4 more](https://github.com/assetgraph/assetgraph/compare/v0.2.5...v0.2.6)
 
 ### v0.2.5
+
 - [Release 0.2.5.](https://github.com/assetgraph/assetgraph/commit/28a7a9bb8afb27e01219f37cf9943669381e9e4e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [More docs, README updates.](https://github.com/assetgraph/assetgraph/commit/e8a62e7145c571cd550216a1a9ee5758d6dca8c0) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [More docs.](https://github.com/assetgraph/assetgraph/commit/13011887c0c38bba4e9680e0031849c7a566cbc9) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3261,17 +3594,20 @@
 - [+7 more](https://github.com/assetgraph/assetgraph/compare/v0.2.4...v0.2.5)
 
 ### v0.2.4
+
 - [Release 0.2.4.](https://github.com/assetgraph/assetgraph/commit/1200ef76e058590a419cab5c1e9ce439b58688e6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed relations.JavaScriptOneInclude, more tests.](https://github.com/assetgraph/assetgraph/commit/793bd16df4f62b912a476c41233a530b77c8e11f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed relations.Html\(Style|Script\).attach.](https://github.com/assetgraph/assetgraph/commit/830bb2e9e9e676fd047f601de0f0ac0f8d3cfd2c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.2.4.](https://github.com/assetgraph/assetgraph/commit/811682bf70713a95e95dbef3340512f02cb4f5c6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.2.3
+
 - [Release 0.2.3.](https://github.com/assetgraph/assetgraph/commit/c9ef891bc21363ba1f8c03162d64e64ba5aedc35) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Simplified and fixed relations.JavaScriptOneInclude. Added test.](https://github.com/assetgraph/assetgraph/commit/1764ba756d8b738f0b5c8cb2a9e5ab94df37fb8d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.2.3.](https://github.com/assetgraph/assetgraph/commit/c63921cd14056646e3580c5866453975dae21a20) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.2.2
+
 - [Release 0.2.2.](https://github.com/assetgraph/assetgraph/commit/8ee4b293e906f0ec56a4787cb12cc51619fd3ae1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Fixed typos in error messages introduced in 692e6e1.](https://github.com/assetgraph/assetgraph/commit/aaf3eaf520c5e25df5b1a8975285da29eaa9015f) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.executeJavaScriptInOrder: Bugfix \(was async but never called the callback\).](https://github.com/assetgraph/assetgraph/commit/de1535def62c79afd236f7bcf44b9abb545028b1) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3280,12 +3616,14 @@
 - [+2 more](https://github.com/assetgraph/assetgraph/compare/v0.2.1...v0.2.2)
 
 ### v0.2.1
+
 - [Release 0.2.1.](https://github.com/assetgraph/assetgraph/commit/4e3b616b7541ea35ce4ea2832832b9ea480925fd) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.JavaScript.outgoingRelations getter: Ignore Ext.define\({uses: ...}\), avoids &lt;script&gt; ordering bugs due to cycles in the dependency graph.](https://github.com/assetgraph/assetgraph/commit/ea5546f20b63530cb028867ca1230283261b53bc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.2.1.](https://github.com/assetgraph/assetgraph/commit/9c37011ab8a6b8435d83639fec897b3b94940d9d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Added publicationConfig](https://github.com/assetgraph/assetgraph/commit/15b83e339cd0b8e89a3d9d32b5501efe7992409a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.2.0
+
 - [Release 0.2.0.](https://github.com/assetgraph/assetgraph/commit/b6855f5bb8a32a3a48d696976fa8e02a8f6aecc1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.populate: Fixed another race condition.](https://github.com/assetgraph/assetgraph/commit/7a3b4b8b632a0e088e04c6047b6dd346246c72f3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [More asserts.](https://github.com/assetgraph/assetgraph/commit/091582080787f16b47057d97a5bd572256a7a815) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3294,12 +3632,14 @@
 - [+61 more](https://github.com/assetgraph/assetgraph/compare/v0.1.5...v0.2.0)
 
 ### v0.1.5
+
 - [Release 0.1.5.](https://github.com/assetgraph/assetgraph/commit/5d358b29b0c8c0764a888cbfca53a504d541b561) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added support for detaching certain Ext.require relations.](https://github.com/assetgraph/assetgraph/commit/94756a646b13b1a6cd5df410d7b8e51167f20d01) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Use urlTools.resolveUrl\(assetGraph.root, ...\) when building urls instead of concatenating naively. Prevents occurrences of '..' in the url index and 'url' properties of assets when assetGraph.root contains '..'.](https://github.com/assetgraph/assetgraph/commit/86cd00e56548d1215616d95237474b8dce036505) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.1.5.](https://github.com/assetgraph/assetgraph/commit/9f16d6e561df7e458a16cfe0c94723e085d88ae1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.1.4
+
 - [Release 0.1.4](https://github.com/assetgraph/assetgraph/commit/70fb47812a1c23032b9bec91c95bff4aece0dad6) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph.resolveAssetConfig: Fixed test for root-relative urls \(also matched protocol-relative ones\).](https://github.com/assetgraph/assetgraph/commit/1e431abadb6b2a84aa99a930e64010a487475d75) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Base: Don't attempt to extract an extension from an url ending in a slash.](https://github.com/assetgraph/assetgraph/commit/633f54b2cc3730a2ab9a77722505620049c05e58) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3307,6 +3647,7 @@
 - [Now working on 0.1.4.](https://github.com/assetgraph/assetgraph/commit/e86b4966d48029e5d123b3c6abc565ea6b5273bc) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.1.3
+
 - [Release 0.1.3.](https://github.com/assetgraph/assetgraph/commit/57b4e61a563dff27988fa1fbf19a68388bcfa36c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Css\*.\_setRawUrlString: Also use non-greedy regular expressions when replacing existing url\(\) tokens.](https://github.com/assetgraph/assetgraph/commit/446eac05c8b7e91004476df7028c6e0d1197d909) ([Peter Müller](mailto:pm@one.com))
 - [assets.Css.getOriginalRelations: Made url\(...\) regexp non-greedy to prevent values with more end parentheses from being tokenized wrongly.](https://github.com/assetgraph/assetgraph/commit/70b521eead2c0f9188f82fe294cfcb4a355727b6) ([Peter Müller](mailto:pm@one.com))
@@ -3315,16 +3656,19 @@
 - [+4 more](https://github.com/assetgraph/assetgraph/compare/v0.1.2...v0.1.3)
 
 ### v0.1.2
+
 - [Release 0.1.2.](https://github.com/assetgraph/assetgraph/commit/2eb0e1fcdc4d50386e8c134da84beb3376e351f9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Removed bin folder \(see assetgraph-builder\) and transforms.spriteBackgroundImages \(see assetgraph-sprite\).](https://github.com/assetgraph/assetgraph/commit/5c0e58bd1409e515df1ceb66f6da705852464094) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.1.2.](https://github.com/assetgraph/assetgraph/commit/65ffafdf91a28062a35c762f3d91f03660e6deb2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.1.1
+
 - [Release 0.1.1.](https://github.com/assetgraph/assetgraph/commit/0df73b7572b961c9ae4d79fe76041de1e3f9f528) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Image: Removed canvas-related helper methods \(moved to assetgraph-sprite\).](https://github.com/assetgraph/assetgraph/commit/9374f5bdacebd5af947899cc3a7082386a548607) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.1.1.](https://github.com/assetgraph/assetgraph/commit/19ea75f4a56194cf5d11f1a73cae97bb983b3023) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.1.0
+
 - [Release 0.1.0.](https://github.com/assetgraph/assetgraph/commit/1617fb5679a98de8667c12498f78ae7c5fac1b88) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Removed transforms.spriteBackgroundImages \(moved to the assetgraph-sprite project\) and a bunch of transforms and binaries that don't have any business being in the core framework \(moved to the assetgraph-builder project\).](https://github.com/assetgraph/assetgraph/commit/ce2ecfbc06984252a40299e42a01a315f2805e18) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Changed abbreviation in test file name from all-caps to upper camel case.](https://github.com/assetgraph/assetgraph/commit/1ef1fb524a2204fe7c9a19710811f622cae891fc) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3333,6 +3677,7 @@
 - [+3 more](https://github.com/assetgraph/assetgraph/compare/v0.0.19...v0.1.0)
 
 ### v0.0.19
+
 - [Release 0.0.19.](https://github.com/assetgraph/assetgraph/commit/50181439b91b4d67b8b299578e80ce75073aff80) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [buildProduction & prepareForCDN: Don't follow HtmlAnchor relations.](https://github.com/assetgraph/assetgraph/commit/34468365af87e6c52ec0a363c310a12b6bd1242c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Moved dir\/ =&gt; dir\/index.html handling to resolvers.file.](https://github.com/assetgraph/assetgraph/commit/164b1f3c12557e9946b8dac0a1d9528b475b19b3) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3341,17 +3686,20 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.0.18...v0.0.19)
 
 ### v0.0.18
+
 - [Release 0.0.18.](https://github.com/assetgraph/assetgraph/commit/ee8688d069682b38603b4ab4157b6a93004f172a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Html.getOriginalRelations: Don't model &lt;a href='\#...'&gt; as relations.](https://github.com/assetgraph/assetgraph/commit/8defa209a2b80dd556e092204e7325e5180143ba) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.0.18.](https://github.com/assetgraph/assetgraph/commit/9009e6ca6fe2580bf3e74468959d5307aeb6a7bd) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.0.17
+
 - [Release 0.0.17.](https://github.com/assetgraph/assetgraph/commit/a9a3f0e2e0c48dbf46907d7ea1449df09099b391) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.addTypeToAssetConfig: Fixed the code that adds "index.html" to file: urls pointing at directories. Was broken for urls containing GET parameters or a fragment identifier.](https://github.com/assetgraph/assetgraph/commit/d21ae935c3c9b91d8b379ab8927f509bcc4f658a) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Pulled in jsdom's dependencies.](https://github.com/assetgraph/assetgraph/commit/890f0afce65c735676a49781372f0efe3f3942fa) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.0.17.](https://github.com/assetgraph/assetgraph/commit/ce770d2aafde66ad8d09988c44c2245c45090598) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.0.16
+
 - [Release 0.0.16.](https://github.com/assetgraph/assetgraph/commit/c6e26e63d094c7cf10af2a84c136e3110cb3bd68) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [resolvers.file: Strip CGI parameters and\/or fragment idenfier from url before attempting to read an asset from disc.](https://github.com/assetgraph/assetgraph/commit/4ee07c3170337cd890a4edff319e5667d5ca048d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [resolvers.http: Don't send fragment identifier to the server when fetching asset.](https://github.com/assetgraph/assetgraph/commit/e25e6a419c0a18d0ebf1dd2fe110fa6e7f9d94be) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3360,6 +3708,7 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.0.15...v0.0.16)
 
 ### v0.0.15
+
 - [Release 0.0.15.](https://github.com/assetgraph/assetgraph/commit/e419b0fbb20dbd9f3dcfe5b54d116af0e86c0324) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Wording in example.](https://github.com/assetgraph/assetgraph/commit/a0b8cc90521020cf5071fcf78fe2a8d52b4f4bbd) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added 'createBookmarklet' example.](https://github.com/assetgraph/assetgraph/commit/37444cfc69800dfa555fdd696d372d6f4c391701) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3368,6 +3717,7 @@
 - [+11 more](https://github.com/assetgraph/assetgraph/compare/v0.0.14...v0.0.15)
 
 ### v0.0.14
+
 - [Release 0.0.14.](https://github.com/assetgraph/assetgraph/commit/2329555c200f4da313a878930ff27ff7f03b74d4) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added example that detects dead links.](https://github.com/assetgraph/assetgraph/commit/11b0870e56674b4a90b3e941570f37ac0b87f64b) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Upgrade to glob 2.0.7.](https://github.com/assetgraph/assetgraph/commit/85d9ba8356b1c998e5dff28aae05fab7ce9caba1) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3376,6 +3726,7 @@
 - [+17 more](https://github.com/assetgraph/assetgraph/compare/v0.0.13...v0.0.14)
 
 ### v0.0.13
+
 - [Release 0.0.13.](https://github.com/assetgraph/assetgraph/commit/25c3dca766946d0f8bbf9f7480dc70edc7ea1644) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.Image.getCanvasImage: Fixed bugs in untested code committed in a5ad66a.](https://github.com/assetgraph/assetgraph/commit/e68d0b96e3edab9fa0f8931c5cc97c79049de9c2) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Use upper camel case instead of all-caps for abbreviations in class names.](https://github.com/assetgraph/assetgraph/commit/81acce083cdd55376b26b38ad38f8483d55511d1) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3384,6 +3735,7 @@
 - [+7 more](https://github.com/assetgraph/assetgraph/compare/v0.0.12...v0.0.13)
 
 ### v0.0.12
+
 - [Release 0.0.12.](https://github.com/assetgraph/assetgraph/commit/28f919dd0e8278e2a5e6b53256409da2264cac1c) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [package.json: Hardcode the version numbers of all dependencies.](https://github.com/assetgraph/assetgraph/commit/1989f2bb7ac3583d656fc624c926b172c1035f32) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.spriteBackgroundImage: Added reference to node-canvas issue about backporting drawImage\(\) to Cairo &lt;1.10.0.](https://github.com/assetgraph/assetgraph/commit/c8507a13401c68775aa56931e5c9cf23a8a2afeb) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3392,11 +3744,13 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.0.11...v0.0.12)
 
 ### v0.0.11
+
 - [On second thought, just add support for transforms.registerLabelsAsCustomProtocols\(undefined\).](https://github.com/assetgraph/assetgraph/commit/b0241cc9a46e62d2421c4448309380f0503b4592) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bin\/flattenOneInclude & bin\/refreshI18N: Fixed invocation of 'passError'.](https://github.com/assetgraph/assetgraph/commit/e00c2d716d7a5e93e55bad439116a9a4bddeadac) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.0.11.](https://github.com/assetgraph/assetgraph/commit/ef17473ed7a16f4a612bf62600726446b6ec048d) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.0.10
+
 - [Release 0.0.10.](https://github.com/assetgraph/assetgraph/commit/5d5d1c305e88e822cac2bfd73807e18247a61f82) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [buildProduction: Only queue transforms.registerLabelsAsCustomProtocols if at least one --label is specified on the command line.](https://github.com/assetgraph/assetgraph/commit/1f7f126fd27ac490dc88d3cea205000207f692c3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [buildDevelopment: Only queue transforms.registerLabelsAsCustomProtocols if at least one --label is specified on the command line.](https://github.com/assetgraph/assetgraph/commit/b795ee5d2bb681d5c3ec7015a6a5c4ff1b19987f) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3405,6 +3759,7 @@
 - [+38 more](https://github.com/assetgraph/assetgraph/compare/v0.0.9...v0.0.10)
 
 ### v0.0.9
+
 - [Release 0.0.9.](https://github.com/assetgraph/assetgraph/commit/ccf998e1978d863a06423b2eeb62734a77426e42) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Got rid of the JavaScriptLoader abomination and added an 'executeJavaScriptInOrder' transform in its place.](https://github.com/assetgraph/assetgraph/commit/ee081ab85b25b948b813f461ad7e7a72081a35c3) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph: Fixed a bug that caused getBaseAssetForRelation to always use a slow algorithm.](https://github.com/assetgraph/assetgraph/commit/ac1aa81ad3112b7ac6bf6bb626d10fa64ccf7ac2) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3413,11 +3768,13 @@
 - [+18 more](https://github.com/assetgraph/assetgraph/compare/v0.0.8...v0.0.9)
 
 ### v0.0.8
+
 - [Release 0.0.8.](https://github.com/assetgraph/assetgraph/commit/c4ffb5cda9224184ddee8c1389257766004c36e1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.spriteBackgroundImages: Emit a warning \(and don't create sprites\) if node-canvas isn't compiled with a recent enough version of Cairo \(drawImage\(\) requires &gt;=1.10.0\).](https://github.com/assetgraph/assetgraph/commit/3d8dd4dddbd67d73d89380e36754de0fa554fbee) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Now working on 0.0.8.](https://github.com/assetgraph/assetgraph/commit/ff528577b22c9748425eeda8ce927a3fe35680a1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 
 ### v0.0.7
+
 - [Release 0.0.7.](https://github.com/assetgraph/assetgraph/commit/88d18da9b0cf28b64c75a254793fd85319837b24) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Renamed query.undefined to query.isUndefined and query.defined to query.isDefined.](https://github.com/assetgraph/assetgraph/commit/9708e641e847929af587313082092eb872569305) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Expose the assets, relations, transforms, query, and traversal modules directly on the exported AssetGraph constructor.](https://github.com/assetgraph/assetgraph/commit/c8ac66c9e47e5e9ac98ef687bd34eb4e1528af2e) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3426,6 +3783,7 @@
 - [+16 more](https://github.com/assetgraph/assetgraph/compare/v0.0.6...v0.0.7)
 
 ### v0.0.6
+
 - [Release 0.0.6.](https://github.com/assetgraph/assetgraph/commit/8c8197d158af440323fc833db53693ae3208f6f1) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [bin\/\*: Dropped --multi-word command line options so that optimist.camelCase\(\) isn't needed.](https://github.com/assetgraph/assetgraph/commit/355496ac90f05a96d0d0ba0681646589cfcb2457) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph.removeAsset: Always remove incoming relations and optionally detach them.](https://github.com/assetgraph/assetgraph/commit/5fc61b49d5441868e6554a7920b2ec4721e1d00b) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3434,6 +3792,7 @@
 - [+76 more](https://github.com/assetgraph/assetgraph/compare/v0.0.4...v0.0.6)
 
 ### v0.0.4
+
 - [Release 0.0.4.](https://github.com/assetgraph/assetgraph/commit/35ec672fe4c2eced4aae995b620d519cac52395e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [assets.CSS.getOriginalRelations: Skip behavior properties that have \# as the first char in the url so stuff like behavior\(\#default\#VML\) won't be treated as a relation.](https://github.com/assetgraph/assetgraph/commit/aa0e474d1ec6b210f89a4e382fafbeb9c3d74e68) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Added hack to remove one.include statements without populating the corresponding relations.](https://github.com/assetgraph/assetgraph/commit/1920258fa0a9d84460b590e638d9983590a2fa58) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3442,6 +3801,7 @@
 - [+28 more](https://github.com/assetgraph/assetgraph/compare/v0.0.3...v0.0.4)
 
 ### v0.0.3
+
 - [Release 0.0.3.](https://github.com/assetgraph/assetgraph/commit/e8d2cecd14e4a375a03d7e5c4c5c03b36caa08d9) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [transforms.flattenStaticIncludes: Rolled back to the pre-789691cb version \(bugs were introduced\).](https://github.com/assetgraph/assetgraph/commit/22cbaee167fcb9de2ab61d8e858292807593378e) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [JavaScriptLoader: Removed transforms.stats from the stack \(leftover debugging code\).](https://github.com/assetgraph/assetgraph/commit/7a9ed983a0b28cb183a3934aacd4bb819b0c19bb) ([Andreas Lind Petersen](mailto:andreas@one.com))
@@ -3450,10 +3810,11 @@
 - [+1 more](https://github.com/assetgraph/assetgraph/compare/v0.0.2...v0.0.3)
 
 ### v0.0.2
+
 - [package.json: Bumped version to 0.0.2](https://github.com/assetgraph/assetgraph/commit/da4732eb15c9863e7272c05c9c428a41c69c0573) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Copied in bleeding-edge CSSOM for @import support.](https://github.com/assetgraph/assetgraph/commit/80c0cfc7788164d264656ea32cefe98206affb01) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [relation.\_inline fixes.](https://github.com/assetgraph/assetgraph/commit/a7d4a754ffe86600d95530189dcb6855118a3871) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [AssetGraph: Use seq instead of step.](https://github.com/assetgraph/assetgraph/commit/e156f7809b48465626aa0524814f65d1b22beabe) ([Andreas Lind Petersen](mailto:andreas@one.com))
 - [Implemented AssetGraph.cloneAsset.](https://github.com/assetgraph/assetgraph/commit/5116b95520cc270e188e4f079daff35d8cf01d08) ([Andreas Lind Petersen](mailto:andreas@one.com))
-- [+490 more](https://github.com/assetgraph/assetgraph/compare/da4732eb15c9863e7272c05c9c428a41c69c0573%5E...v0.0.2)
-
+- [+490 more](https://github.com/assetgraph/assetgraph/compare/5116b95520cc270e188e4f079daff35d8cf01d08...v0.0.2)
+Done in 5.93s.

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "magicpen-prism": "5.0.0",
     "mocha": "^9.1.0",
     "nyc": "^15.0.0",
-    "offline-github-changelog": "^2.0.0",
+    "offline-github-changelog": "^2.4.0",
     "open": "^8.0.2",
     "prettier": "~2.6.0",
     "proxyquire": "^2.0.1",


### PR DESCRIPTION
I noticed the CHANGELOG file hadn't been regenerated with any versions since 6.0.

Maybe a more automated process for this would be nice...