### PR TITLE
[review] Add support for Safari mask-icon.

### DIFF
--- a/lib/relations/Html/HtmlShortcutIcon.js
+++ b/lib/relations/Html/HtmlShortcutIcon.js
@@ -8,7 +8,7 @@ class HtmlShortcutIcon extends HtmlRelation {
     if (
       node.nodeType === node.ELEMENT_NODE &&
       node.matches(
-        'link[rel~=icon][href], link[rel~=apple-touch-icon][href], link[rel~=apple-touch-icon-precomposed][href]'
+        'link[rel~=icon][href], link[rel~=mask-icon][href], link[rel~=apple-touch-icon][href], link[rel~=apple-touch-icon-precomposed][href]'
       )
     ) {
       return {

--- a/test/relations/Html/HtmlShortcutIcon.js
+++ b/test/relations/Html/HtmlShortcutIcon.js
@@ -12,8 +12,8 @@ describe('relations/HtmlShortcutIcon', function () {
     });
     await assetGraph.loadAssets('index.html').populate();
 
-    expect(assetGraph, 'to contain assets', 2);
-    expect(assetGraph, 'to contain relations', 'HtmlShortcutIcon', 7);
+    expect(assetGraph, 'to contain assets', 3);
+    expect(assetGraph, 'to contain relations', 'HtmlShortcutIcon', 8);
 
     const htmlAsset = assetGraph.findAssets({ type: 'Html' })[0];
     const pngAsset = assetGraph.findAssets({ type: 'Png' })[0];
@@ -38,7 +38,7 @@ describe('relations/HtmlShortcutIcon', function () {
       firstExistingHtmlShortcutIconRelation
     );
 
-    expect(assetGraph, 'to contain relations', 'HtmlShortcutIcon', 9);
+    expect(assetGraph, 'to contain relations', 'HtmlShortcutIcon', 10);
 
     const matches = assetGraph
       .findAssets({ type: 'Html' })[0]

--- a/testdata/relations/Html/HtmlShortcutIcon/foo.svg
+++ b/testdata/relations/Html/HtmlShortcutIcon/foo.svg
@@ -1,0 +1,3 @@
+<svg version="1.1" width="32" height="32" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="16" cy="16" r="16" fill="#000000"/>
+</svg>

--- a/testdata/relations/Html/HtmlShortcutIcon/index.html
+++ b/testdata/relations/Html/HtmlShortcutIcon/index.html
@@ -10,6 +10,7 @@
     <link rel="apple-touch-icon-precomposed" href="foo.png">
     <link rel="apple-touch-icon-invalid" href="foo.png"> <!-- Shouldn't be recognized as a relation -->
     <link rel="AN apple-touch-icon and then some" href="foo.png">
+    <link rel="mask-icon" href="foo.svg" color="#ff0000">
 </head>
 <body>
 </body>


### PR DESCRIPTION
Safari has support for SVG favicons through the `mask-icon` relation type. The SVG file is treated as a single-color mask, and automatically adapts to light & dark mode. You can read more about it in the [Apple mask-icon documentation](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/pinnedTabs/pinnedTabs.html).

Assetgraph doesn't currently support this type of relation so processing a site using `mask-icon` results in a broken icon in Safari. This pull request adds support for the `mask-icon` relationship so that the SVG file is correctly included in the assetgraph output.