### PR TITLE
Fix Windows compatibility for relation auto-registration

### DIFF
--- a/lib/AssetGraph.js
+++ b/lib/AssetGraph.js
@@ -982,9 +982,10 @@ for (const fileName of fs.readdirSync(
 }
 
 // Register relations
-for (const fileName of glob.sync(
-  pathModule.resolve(__dirname, 'relations', '*', '*.js')
-)) {
+for (const fileName of glob.sync('relations/*/*.js', {
+  cwd: __dirname,
+  absolute: true,
+})) {
   const dirName = pathModule.dirname(fileName);
   const assetType = pathModule.basename(dirName);
 

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "main": "lib/AssetGraph.js",
   "scripts": {
-    "lint": "eslint . && prettier --check '**/*.{js,json,md}'",
+    "lint": "eslint . && prettier --check \"**/*.{js,json,md}\"",
     "test": "mocha",
     "test:ci": "npm run coverage",
     "docs": "jsdoc -c jsdoc.json",


### PR DESCRIPTION
## Problem

The current glob pattern in `AssetGraph.js` for auto-registering relations fails on Windows systems.

## Root Cause

The issue is in `lib/AssetGraph.js` line 986:

```javascript
for (const fileName of glob.sync(
  pathModule.resolve(__dirname, 'relations', '*', '*.js')  // This fails on Windows
)) {
```

The `pathModule.resolve(__dirname, 'relations', '*', '*.js')` approach doesn't work reliably with glob patterns on Windows because it creates an absolute path with Windows path separators that the glob library doesn't handle correctly.

## Solution

Replace the absolute path glob pattern with a relative pattern using the `cwd` and `absolute` options:

```javascript
for (const fileName of glob.sync('relations/*/*.js', {
  cwd: __dirname,
  absolute: true,
})) {
  // fileName is already an absolute path
  const dirName = pathModule.dirname(fileName);
  // ... rest of the logic
}
```

## Minimal Reproduction

**On Linux (works):**

```bash
node -e "const glob=require('glob'); const path=require('path'); console.log('Files found:', glob.sync(path.resolve(__dirname, 'lib', 'relations', '*', '*.js')).length)"
# Output: Files found: 91
```

**On Windows (fails):**

```bash
node -e "const glob=require('glob'); const path=require('path'); console.log('Files found:', glob.sync(path.resolve(__dirname, 'lib', 'relations', '*', '*.js')).length)"
# Output: Files found: 0
```

**Fixed approach (works on both):**

```bash
node -e "const glob=require('glob'); const path=require('path'); console.log('Files found:', glob.sync('lib/relations/*/*.js', {cwd: __dirname}).length)"
# Output: Files found: 91
```

The problem is that `path.resolve()` on Windows creates paths like `C:\...\lib\relations\*\*.js` which contain literal asterisks in the path string, rather than glob patterns that the glob library can interpret.

#### Addendum: npm scripts cross-platform quoting

The current lint script uses single quotes around the Prettier glob, which works on POSIX shells but fails on Windows because npm run uses cmd.exe by default and cmd.exe does not treat single quotes as quoting. As a result, Prettier receives the quotes literally and the glob is not expanded.
